### PR TITLE
Add Docker Build CI + Labeler

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,17 @@
+connectors:
+  - changed-files:
+      - any-glob-to-any-file: "connectors/**"
+
+worker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "cmd/ingestion-worker/**"
+          - "runner/**"
+          - "pipeline/**"
+
+control-plane:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "cmd/ingestion-control/**"
+          - "server/**"
+          - "internal/modules/**"

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,62 @@
+name: "CI: Build and Push"
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: filament-control
+            dockerfile: cmd/ingestion-control/Dockerfile
+          - image: filament-worker
+            dockerfile: cmd/ingestion-worker/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: |
+            cmd/ingestion-control/go.sum
+            cmd/ingestion-worker/go.sum
+
+      - name: Build binary
+        env:
+          GOWORK: off
+          CGO_ENABLED: "0"
+          GOOS: linux
+        run: go build -C $(dirname ${{ matrix.dockerfile }}) -trimpath -ldflags="-s -w" -o "$GITHUB_WORKSPACE/bin/${{ matrix.image }}" .
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -20,9 +20,9 @@ jobs:
           - image: filament-worker
             dockerfile: cmd/ingestion-worker/Dockerfile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache-dependency-path: |
@@ -36,16 +36,16 @@ jobs:
           GOOS: linux
         run: go build -C $(dirname ${{ matrix.dockerfile }}) -trimpath -ldflags="-s -w" -o "$GITHUB_WORKSPACE/bin/${{ matrix.image }}" .
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
@@ -53,7 +53,7 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,18 @@
+name: "CI: Labeler"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: ".github/labeler.yml"
+          sync-labels: true

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/labeler.yml"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: ".github/labeler.yml"
+          configuration-path: ".github/labeler.yaml"
           sync-labels: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .cache/
 
 # Build outputs
+/bin/
+/cmd/ingestion-control/ingestion-control
+/cmd/ingestion-worker/ingestion-worker
 /cmd/ingestiond/ingestiond
 /examples/my-pipeline/my-pipeline
 

--- a/cmd/ingestion-control/Dockerfile
+++ b/cmd/ingestion-control/Dockerfile
@@ -1,24 +1,7 @@
 # syntax=docker/dockerfile:1
+FROM gcr.io/distroless/static:nonroot
 
-# Build context is the repo root:
-#   docker build -f cmd/ingestion-control/Dockerfile -t filament-control .
-
-ARG GO_VERSION=1.26.4
-
-FROM golang:${GO_VERSION}-bookworm AS build
-
-WORKDIR /src
-COPY . .
-
-ENV GOWORK=off CGO_ENABLED=0
-
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    cd cmd/ingestion-control && go build -trimpath -buildvcs=false -ldflags="-s -w" -o /out/app .
-
-FROM gcr.io/distroless/static:nonroot AS runtime
-
-COPY --from=build /out/app /app
+COPY bin/filament-control /app
 
 EXPOSE 8080
 USER nonroot:nonroot

--- a/cmd/ingestion-worker/Dockerfile
+++ b/cmd/ingestion-worker/Dockerfile
@@ -1,24 +1,7 @@
 # syntax=docker/dockerfile:1
+FROM gcr.io/distroless/static:nonroot
 
-# Build context is the repo root:
-#   docker build -f cmd/ingestion-worker/Dockerfile -t filament-worker .
-
-ARG GO_VERSION=1.26.4
-
-FROM golang:${GO_VERSION}-bookworm AS build
-
-WORKDIR /src
-COPY . .
-
-ENV GOWORK=off CGO_ENABLED=0
-
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    cd cmd/ingestion-worker && go build -trimpath -buildvcs=false -ldflags="-s -w" -o /out/app .
-
-FROM gcr.io/distroless/static:nonroot AS runtime
-
-COPY --from=build /out/app /app
+COPY bin/filament-worker /app
 
 USER nonroot:nonroot
 

--- a/cmd/ingestion-worker/main.go
+++ b/cmd/ingestion-worker/main.go
@@ -34,6 +34,10 @@ func main() {
 }
 
 func run(ctx context.Context) error {
+	// Default logger too, so library logs (e.g. iceberg-go) come out as JSON.
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
 	runID := ingestion.RunID(os.Getenv("RUN_ID"))
 	if runID == "" {
 		return errors.New("RUN_ID is required")
@@ -82,7 +86,7 @@ func run(ctx context.Context) error {
 	runner.RunOne(ctx, runner.Deps{
 		Bus:       bus,
 		DataStore: store,
-		Log:       slogLogger{l: slog.New(slog.NewJSONHandler(os.Stdout, nil))},
+		Log:       slogLogger{l: logger},
 		// Temporary bootstrap path: ConfigRef values are resolved from process
 		// env vars as JSON connector configs. Replace this with the fetched
 		// control-plane secret/config store before production k8s dispatch.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,9 @@
+# build both linux binaries into bin/
+binaries:
+    GOWORK=off CGO_ENABLED=0 GOOS=linux go build -C cmd/ingestion-control -trimpath -ldflags="-s -w" -o ../../bin/filament-control .
+    GOWORK=off CGO_ENABLED=0 GOOS=linux go build -C cmd/ingestion-worker -trimpath -ldflags="-s -w" -o ../../bin/filament-worker .
+
+# build both docker images
+images: binaries
+    docker build -f cmd/ingestion-control/Dockerfile -t galaxy-io/filament:latest .
+    docker build -f cmd/ingestion-worker/Dockerfile -t galaxy-io/filament-worker:latest .


### PR DESCRIPTION
## Build & CI
Go compiles on the host/runner where the build cache lives, Dockerfiles only package.

### Build
- **justfile** — `just binaries` cross-compiles both linux binaries into `bin/`; `just images` builds both docker images from them. Local flow: `just images && kind load ...`
- **Dockerfiles** are now runtime-only: distroless + `COPY bin/<binary>`. No Go toolchain in the image build, no `COPY . .` cache-busting. Plain `docker build` now requires `just binaries` first.
- `.gitignore` covers `bin/` and in-place `go build` artifacts.

### CI
- **build-and-push.yaml** — matrix over `filament-control` / `filament-worker`, mapped explicitly to their Dockerfiles. Shared Go module/build cache across both jobs (keyed on both go.sums). Runs on every push to `main` as a build check; **pushes to ghcr.io only on `v*` tags** (pre-release: nothing ships until we tag). Tags: semver on release tags, `sha-*` + `latest` on main (computed, unpushed for now).
- **labeler** — path-based PR labels (`connectors`, `worker`, `control-plane`), `sync-labels` on synchronize.
- All actions pinned to commit SHAs (tag re-pointing is how the tj-actions supply-chain attack shipped).

### Worker
- `slog.SetDefault` in worker main so library logs (iceberg-go) emit structured JSON instead of plaintext.