### PR TITLE
Atterpac/mysql cdc

### DIFF
--- a/checkpoint/checkpoint.go
+++ b/checkpoint/checkpoint.go
@@ -21,6 +21,11 @@ const (
 	ModeKeyset = "keyset"
 	ModeBitmap = "bitmap"
 	ModeCtid   = "ctid"
+	// ModeStream is a change-stream position cursor: a single monotonic location in
+	// the source's replication log (Postgres WAL LSN, MySQL binlog file:pos) plus a
+	// per-run sequence guard. Unlike the shard-based cursors above it has no layout;
+	// resume simply restarts the stream at the recorded position.
+	ModeStream = "stream"
 )
 
 // KeysetShard is one independently-resumable slice of a resource's primary-key space.
@@ -131,6 +136,47 @@ func MergeShardDelta(base ingestion.Checkpoint, delta ingestion.Checkpoint) inge
 	}
 	ks.Shards[part].Key = key
 	return ks.ToCheckpoint(base.Resource())
+}
+
+// NewStreamDelta is the per-batch checkpoint of a change-stream read: the stream
+// position (lsn) of the batch's last record and its per-run sequence. It is both
+// the delta and the full checkpoint — a stream cursor has no layout to merge into.
+func NewStreamDelta(resource, lsn string, seq uint64) *ingestion.CheckpointData {
+	return &ingestion.CheckpointData{ResourceName: resource, Cursor: map[string]any{
+		"mode": ModeStream,
+		"lsn":  lsn,
+		"seq":  int64(seq),
+	}}
+}
+
+// ParseStream decodes a stream cursor. Reports false when cp is nil or a different
+// cursor shape. Tolerates a missing mode when an lsn is present (the batcher's
+// legacy shape carried lsn/seq only).
+func ParseStream(cp ingestion.Checkpoint) (lsn string, seq uint64, ok bool) {
+	if cp == nil {
+		return "", 0, false
+	}
+	raw := cp.Raw()
+	mode, hasMode := raw["mode"].(string)
+	lsn, _ = raw["lsn"].(string)
+	if lsn == "" || (hasMode && mode != ModeStream) {
+		return "", 0, false
+	}
+	return lsn, uint64(anyToInt(raw["seq"])), true
+}
+
+// MergeStream applies a stream delta onto base, keeping the newer position. The
+// per-run seq guards against an out-of-order fold (concurrent writers can publish
+// batch facts out of order); the higher seq wins, a tie keeps the delta.
+func MergeStream(base ingestion.Checkpoint, delta ingestion.Checkpoint) ingestion.Checkpoint {
+	dLSN, dSeq, ok := ParseStream(delta)
+	if !ok {
+		return base
+	}
+	if _, bSeq, ok := ParseStream(base); ok && bSeq > dSeq {
+		return base
+	}
+	return NewStreamDelta(delta.Resource(), dLSN, dSeq)
 }
 
 // coarseDeltaTag marks an ack/want completion delta — shared by bitmap and ctid, which

--- a/connectors/mysql/register.go
+++ b/connectors/mysql/register.go
@@ -1,0 +1,18 @@
+// Package mysql wires the mysql source and sink onto the default registry.
+// Enable both with a single blank import:
+//
+//	import _ "github.com/galaxy-io/filament/connectors/mysql"
+package mysql
+
+import (
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/registry"
+
+	sink "github.com/galaxy-io/filament/connectors/mysql/sink"
+	source "github.com/galaxy-io/filament/connectors/mysql/source"
+)
+
+func init() {
+	registry.RegisterSource("mysql", func() ingestion.Source { return source.New() })
+	registry.RegisterSink("mysql", func() ingestion.Sink { return sink.New() })
+}

--- a/connectors/mysql/source/cdc.go
+++ b/connectors/mysql/source/cdc.go
@@ -1,0 +1,521 @@
+package mysql
+
+// Change-data-capture via the binlog replication protocol. ExtractChanges connects
+// as a replica (go-mysql BinlogSyncer), decodes ROW-format events for the requested
+// tables, and emits insert/update/delete records encoded in the same JSON shape as
+// the snapshot reader, so sinks cannot tell the two apart.
+//
+// A run has catch-up semantics: it captures the server's current binlog position as
+// a watermark, streams from the last checkpointed position up to that watermark, and
+// returns. Re-requesting the run continues from the persisted cursor, so continuous
+// CDC is a re-request loop (the same mechanism as snapshot resume). The cursor is a
+// stream checkpoint (checkpoint.ModeStream): a GTID set on a gtid_mode=ON server
+// (the default — see cdc_gtid.go), else "file:pos". Every record carries it in
+// Meta.LSN and a Drained sentinel persists the final watermark even for a run that
+// saw no changes — without it, an idle first run would leave no cursor and the next
+// run would re-capture a later position, silently skipping the gap between them.
+//
+// Requirements on the server: ROW binlog format (the 8.0+ default), binlog retention
+// covering the resume window, and REPLICATION SLAVE/CLIENT privileges. Column names
+// are not in the binlog (binlog_row_metadata=MINIMAL default), so each table's
+// column list is read from information_schema and invalidated on any DDL event; a
+// column-count mismatch mid-stream fails the run rather than mis-mapping values.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/checkpoint"
+)
+
+// defaultServerID identifies this client in the replica topology; it must differ
+// from the server's and any real replica's server_id. Override with "server_id".
+const defaultServerID = 62347
+
+var _ ingestion.ChangeSource = (*Source)(nil)
+
+// ExtractChanges streams binlog row events from the checkpointed position to the
+// position the server reports at call time, pushing one record per changed row.
+// The cursor kind is chosen automatically: GTID when the server runs with
+// gtid_mode=ON (survives replica promotion — the executed-transaction set is
+// global to the topology, binlog file offsets are not), file:pos otherwise.
+// Existing file:pos checkpoints keep the file:pos path even on a GTID server,
+// so an in-flight stream never jumps cursors mid-run; a new run id migrates.
+func (s *Source) ExtractChanges(ctx context.Context, sink ingestion.RecordSink, opts ingestion.ChangeExtractOpts) error {
+	if s.db == nil {
+		return fmt.Errorf("mysql source: extract changes before configure")
+	}
+	if useGTID, err := s.chooseGTID(ctx, opts.Checkpoints); err != nil {
+		return err
+	} else if useGTID {
+		watermark, err := s.gtidExecuted(ctx)
+		if err != nil {
+			return err
+		}
+		return s.extractChangesGTID(ctx, sink, opts, watermark)
+	}
+
+	watermark, err := s.masterPosition(ctx)
+	if err != nil {
+		return err
+	}
+	start, ok := startPosition(opts.Checkpoints)
+	if !ok {
+		start = watermark // first run: begin at the current tail
+	}
+
+	run := newCDCRun(sink, opts.Resources, opts.Limit)
+
+	if posCmp(start, watermark) >= 0 {
+		return run.pushStreamMarksLSN(posString(watermark))
+	}
+
+	syncer := replication.NewBinlogSyncer(s.binlogConfig())
+	defer syncer.Close()
+	streamer, err := syncer.StartSync(start)
+	if err != nil {
+		return fmt.Errorf("mysql cdc: start sync at %s: %w", posString(start), err)
+	}
+
+	pos := start
+
+	for {
+		ev, err := streamer.GetEvent(ctx)
+		if err != nil {
+			return fmt.Errorf("mysql cdc: read event at %s: %w", posString(pos), err)
+		}
+		if rot, ok := ev.Event.(*replication.RotateEvent); ok {
+			pos = gomysql.Position{Name: string(rot.NextLogName), Pos: uint32(rot.Position)}
+			continue
+		}
+		if ev.Header.LogPos > 0 {
+			pos.Pos = ev.Header.LogPos
+		}
+
+		switch e := ev.Event.(type) {
+		case *replication.QueryEvent:
+			// DDL (or any statement event): drop the schema cache so the next row
+			// event re-reads column lists that may have changed.
+			run.clearSchema()
+		case *replication.RowsEvent:
+			limited, err := run.pushRowsEvent(ctx, s, ev.Header.EventType, e, posString(pos))
+			if err != nil {
+				return err
+			}
+			if limited {
+				return nil // truncated: no watermark sentinel, resume re-reads from the cursor
+			}
+		}
+
+		if posCmp(pos, watermark) >= 0 {
+			return run.pushStreamMarksLSN(posString(pos))
+		}
+	}
+}
+
+// chooseGTID decides the cursor kind for this run: GTID when the server supports
+// it AND no resource carries a legacy file:pos cursor (continuity beats upgrade —
+// jumping cursor kinds mid-stream would need a file:pos → GTID translation the
+// binlog does not offer).
+func (s *Source) chooseGTID(ctx context.Context, cps map[string]ingestion.Checkpoint) (bool, error) {
+	for _, cp := range cps {
+		if lsn, _, ok := checkpoint.ParseStream(cp); ok && !strings.HasPrefix(lsn, gtidCursorPrefix) {
+			return false, nil
+		}
+	}
+	return s.gtidMode(ctx)
+}
+
+type cdcRun struct {
+	sink      ingestion.RecordSink
+	resources []string
+	tracked   map[string]bool
+	tables    map[string][]column // schema cache, invalidated on DDL
+	seq       uint64
+	emitted   int
+	limit     int
+}
+
+func newCDCRun(sink ingestion.RecordSink, resources []string, limit int) *cdcRun {
+	tracked := make(map[string]bool, len(resources))
+	for _, r := range resources {
+		tracked[r] = true
+	}
+	return &cdcRun{
+		sink:      sink,
+		resources: resources,
+		tracked:   tracked,
+		tables:    map[string][]column{},
+		limit:     limit,
+	}
+}
+
+func (r *cdcRun) clearSchema() {
+	clear(r.tables)
+}
+
+func (r *cdcRun) pushRowsEvent(ctx context.Context, s *Source, typ replication.EventType, e *replication.RowsEvent, lsn string) (bool, error) {
+	db, table := string(e.Table.Schema), string(e.Table.Table)
+	if db != s.database || !r.tracked[table] {
+		return false, nil
+	}
+	cols, err := s.cachedColumns(ctx, r.tables, table, len(e.Table.ColumnType))
+	if err != nil {
+		return false, err
+	}
+	n, err := s.pushRowsEventLSN(r.sink, typ, table, cols, e.Rows, lsn, &r.seq)
+	if err != nil {
+		return false, err
+	}
+	r.emitted += n
+	return r.limit > 0 && r.emitted >= r.limit, nil
+}
+
+// pushStreamMarksLSN emits one Drained sentinel per resource carrying the final
+// stream position, so the cursor persists even when a resource saw no changes
+// this run.
+func (r *cdcRun) pushStreamMarksLSN(lsn string) error {
+	for _, resource := range r.resources {
+		rec := ingestion.Record{Resource: resource, Drained: true}
+		rec.Meta.LSN = lsn
+		rec.Meta.Seq = r.seq
+		if err := r.sink.Push(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// pushRowsEventLSN decodes one ROW event into records stamped with the given
+// stream cursor. Updates arrive as (before, after) pairs: an unchanged-key update
+// emits OpUpdate with the after image; a key-changing update emits
+// OpDelete(before) + OpInsert(after) so the sink's merge keeps exactly one row.
+func (s *Source) pushRowsEventLSN(sink ingestion.RecordSink, typ replication.EventType, table string, cols []column, rows [][]any, lsn string, seq *uint64) (int, error) {
+	push := func(op ingestion.Operation, row []any) error {
+		data, err := encodeRowJSON(cols, row)
+		if err != nil {
+			return fmt.Errorf("mysql cdc: encode %s row: %w", table, err)
+		}
+		*seq++
+		rec := ingestion.Record{
+			Resource: table,
+			ID:       rowID(cols, row),
+			Op:       op,
+			Data:     data,
+		}
+		rec.Meta.LSN = lsn
+		rec.Meta.Seq = *seq
+		return sink.Push(rec)
+	}
+
+	n := 0
+	switch {
+	case isWriteRows(typ):
+		for _, row := range rows {
+			if err := push(ingestion.OpInsert, row); err != nil {
+				return n, err
+			}
+			n++
+		}
+	case isDeleteRows(typ):
+		for _, row := range rows {
+			if err := push(ingestion.OpDelete, row); err != nil {
+				return n, err
+			}
+			n++
+		}
+	case isUpdateRows(typ):
+		for i := 0; i+1 < len(rows); i += 2 {
+			before, after := rows[i], rows[i+1]
+			if rowID(cols, before) == rowID(cols, after) {
+				if err := push(ingestion.OpUpdate, after); err != nil {
+					return n, err
+				}
+				n++
+				continue
+			}
+			if err := push(ingestion.OpDelete, before); err != nil {
+				return n, err
+			}
+			if err := push(ingestion.OpInsert, after); err != nil {
+				return n + 1, err
+			}
+			n += 2
+		}
+	}
+	return n, nil
+}
+
+func isWriteRows(t replication.EventType) bool {
+	return t == replication.WRITE_ROWS_EVENTv0 || t == replication.WRITE_ROWS_EVENTv1 || t == replication.WRITE_ROWS_EVENTv2
+}
+
+func isDeleteRows(t replication.EventType) bool {
+	return t == replication.DELETE_ROWS_EVENTv0 || t == replication.DELETE_ROWS_EVENTv1 || t == replication.DELETE_ROWS_EVENTv2
+}
+
+func isUpdateRows(t replication.EventType) bool {
+	return t == replication.UPDATE_ROWS_EVENTv0 || t == replication.UPDATE_ROWS_EVENTv1 || t == replication.UPDATE_ROWS_EVENTv2
+}
+
+// cachedColumns returns table's ordinal column list, reading through to
+// information_schema on a cache miss. The binlog carries column count but not names
+// (binlog_row_metadata defaults to MINIMAL), so a count mismatch means the catalog
+// and the event disagree — DDL landed between them — and mapping by position would
+// silently put values in wrong columns; fail instead.
+func (s *Source) cachedColumns(ctx context.Context, cache map[string][]column, table string, want int) ([]column, error) {
+	cols, ok := cache[table]
+	if !ok {
+		var err error
+		cols, _, err = s.tableMeta(ctx, table)
+		if err != nil {
+			return nil, fmt.Errorf("mysql cdc: columns %q: %w", table, err)
+		}
+		cache[table] = cols
+	}
+	if len(cols) != want {
+		return nil, fmt.Errorf("mysql cdc: %q has %d columns in the catalog but %d in the binlog event (concurrent DDL?); re-snapshot the table", table, len(cols), want)
+	}
+	return cols, nil
+}
+
+// rowID renders the primary-key tuple as the record id, columns joined with unit
+// separator 0x1F — the same convention as the snapshot reader's CONCAT_WS(CHAR(31)).
+// A keyless table falls back to the whole row (such tables cannot be merged anyway;
+// policy validation rejects them for CDC ingestion).
+func rowID(cols []column, row []any) string {
+	var parts []string
+	for i, c := range cols {
+		if c.pkOrder > 0 && i < len(row) {
+			parts = append(parts, valueText(row[i]))
+		}
+	}
+	if len(parts) == 0 {
+		for i := range row {
+			parts = append(parts, valueText(row[i]))
+		}
+	}
+	return strings.Join(parts, "\x1f")
+}
+
+// valueText renders a binlog value as plain text (for record ids).
+func valueText(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case []byte:
+		return string(t)
+	case string:
+		return t
+	case fmt.Stringer:
+		return t.String()
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+// encodeRowJSON renders one decoded binlog row as a JSON object in column order,
+// matching the snapshot reader's JSON_OBJECT output: binary columns as base64
+// (TO_BASE64 convention, reversed by the typed sink's FROM_BASE64), JSON columns
+// embedded raw, everything else as JSON scalars.
+func encodeRowJSON(cols []column, row []any) ([]byte, error) {
+	if len(row) < len(cols) {
+		return nil, fmt.Errorf("row has %d values for %d columns", len(row), len(cols))
+	}
+	buf := make([]byte, 0, 64*len(cols))
+	buf = append(buf, '{')
+	for i, c := range cols {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		key, err := json.Marshal(c.name)
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, key...)
+		buf = append(buf, ':')
+		buf, err = appendJSONValue(buf, row[i], c)
+		if err != nil {
+			return nil, fmt.Errorf("column %q: %w", c.name, err)
+		}
+	}
+	return append(buf, '}'), nil
+}
+
+func appendJSONValue(buf []byte, v any, c column) ([]byte, error) {
+	if v == nil {
+		return append(buf, "null"...), nil
+	}
+	switch t := v.(type) {
+	case int8, int16, int32, int64, int, uint8, uint16, uint32, uint64, uint:
+		return append(buf, fmt.Sprint(t)...), nil
+	case float32:
+		return strconv.AppendFloat(buf, float64(t), 'g', -1, 32), nil
+	case float64:
+		return strconv.AppendFloat(buf, t, 'g', -1, 64), nil
+	case bool:
+		return strconv.AppendBool(buf, t), nil
+	}
+
+	raw := valueBytes(v)
+	switch {
+	case strings.EqualFold(c.dataType, "json"):
+		if json.Valid(raw) {
+			return append(buf, raw...), nil
+		}
+		return nil, fmt.Errorf("invalid JSON payload")
+	case isBinaryType(c.dataType):
+		buf = append(buf, '"')
+		buf = base64.StdEncoding.AppendEncode(buf, raw)
+		return append(buf, '"'), nil
+	default:
+		quoted, err := json.Marshal(string(raw))
+		if err != nil {
+			return nil, err
+		}
+		return append(buf, quoted...), nil
+	}
+}
+
+// valueBytes normalizes a binlog value's textual forms ([]byte, string, or a
+// Stringer such as a decimal) to bytes.
+func valueBytes(v any) []byte {
+	switch t := v.(type) {
+	case []byte:
+		return t
+	case string:
+		return []byte(t)
+	case fmt.Stringer:
+		return []byte(t.String())
+	default:
+		return []byte(fmt.Sprint(t))
+	}
+}
+
+// ── binlog position plumbing ─────────────────────────────────────────────────
+
+// masterPosition reads the server's current binlog write position. MySQL 8.2
+// renamed the statement; try the new spelling first.
+func (s *Source) masterPosition(ctx context.Context) (gomysql.Position, error) {
+	for _, stmt := range []string{"SHOW BINARY LOG STATUS", "SHOW MASTER STATUS"} {
+		rows, err := s.db.QueryContext(ctx, stmt)
+		if err != nil {
+			continue
+		}
+		pos, err := scanPosition(rows)
+		rows.Close()
+		if err != nil {
+			return gomysql.Position{}, err
+		}
+		return pos, nil
+	}
+	return gomysql.Position{}, fmt.Errorf("mysql cdc: cannot read binlog position (is log_bin enabled and REPLICATION CLIENT granted?)")
+}
+
+// scanPosition pulls (file, position) out of a SHOW … STATUS result, tolerating the
+// varying trailing columns across server versions.
+func scanPosition(rows interface {
+	Columns() ([]string, error)
+	Next() bool
+	Scan(...any) error
+	Err() error
+}) (gomysql.Position, error) {
+	colNames, err := rows.Columns()
+	if err != nil {
+		return gomysql.Position{}, err
+	}
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return gomysql.Position{}, err
+		}
+		return gomysql.Position{}, fmt.Errorf("mysql cdc: binlog status returned no rows (log_bin disabled?)")
+	}
+	var file string
+	var pos uint32
+	dest := make([]any, len(colNames))
+	var discard any
+	for i := range dest {
+		dest[i] = &discard
+	}
+	dest[0], dest[1] = &file, &pos
+	if err := rows.Scan(dest...); err != nil {
+		return gomysql.Position{}, err
+	}
+	return gomysql.Position{Name: file, Pos: pos}, nil
+}
+
+// startPosition picks the oldest checkpointed position across the run's resources —
+// the safe restart point; re-delivered events are absorbed by the idempotent merge.
+func startPosition(cps map[string]ingestion.Checkpoint) (gomysql.Position, bool) {
+	var out gomysql.Position
+	found := false
+	for _, cp := range cps {
+		lsn, _, ok := checkpoint.ParseStream(cp)
+		if !ok {
+			continue
+		}
+		pos, err := parsePos(lsn)
+		if err != nil {
+			continue
+		}
+		if !found || posCmp(pos, out) < 0 {
+			out = pos
+			found = true
+		}
+	}
+	return out, found
+}
+
+func posString(p gomysql.Position) string {
+	return p.Name + ":" + strconv.FormatUint(uint64(p.Pos), 10)
+}
+
+func parsePos(s string) (gomysql.Position, error) {
+	name, posStr, ok := strings.Cut(s, ":")
+	if !ok {
+		return gomysql.Position{}, fmt.Errorf("bad binlog position %q", s)
+	}
+	n, err := strconv.ParseUint(posStr, 10, 32)
+	if err != nil {
+		return gomysql.Position{}, fmt.Errorf("bad binlog position %q: %w", s, err)
+	}
+	return gomysql.Position{Name: name, Pos: uint32(n)}, nil
+}
+
+// posCmp orders binlog positions: by file (the numeric suffix increases across
+// rotations, and the names are zero-padded so lexical order matches), then offset.
+func posCmp(a, b gomysql.Position) int {
+	if a.Name != b.Name {
+		return strings.Compare(a.Name, b.Name)
+	}
+	switch {
+	case a.Pos < b.Pos:
+		return -1
+	case a.Pos > b.Pos:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// binlogConfig builds the replication client config from the connection settings
+// captured at Configure.
+func (s *Source) binlogConfig() replication.BinlogSyncerConfig {
+	return replication.BinlogSyncerConfig{
+		ServerID:   s.serverID,
+		Flavor:     "mysql",
+		Host:       s.binlogHost,
+		Port:       s.binlogPort,
+		User:       s.binlogUser,
+		Password:   s.binlogPass,
+		UseDecimal: true, // decimals as exact decimal values, not lossy float64
+	}
+}

--- a/connectors/mysql/source/cdc_gtid.go
+++ b/connectors/mysql/source/cdc_gtid.go
@@ -1,0 +1,172 @@
+package mysql
+
+// GTID-based CDC streaming — the default whenever the server runs with
+// gtid_mode=ON (cdc.go's file:pos path remains the fallback for servers
+// without it). A GTID cursor survives replica promotion: the set of executed
+// transactions is global to the topology, while binlog file names and offsets
+// are local to one server.
+//
+// GTID granularity is the transaction, not the event, and a transaction's
+// GTID event arrives BEFORE its row events. Records therefore carry the
+// cursor as of the last COMMITTED transaction (the in-flight GTID folds into
+// the running set only at commit): a run that dies mid-transaction resumes by
+// replaying that whole transaction, which the idempotent merge absorbs —
+// checkpointing the in-flight GTID early would instead skip its undelivered
+// tail on resume.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/checkpoint"
+)
+
+// gtidCursorPrefix discriminates a GTID stream cursor from a file:pos one in
+// the shared ModeStream checkpoint payload.
+const gtidCursorPrefix = "gtid:"
+
+// gtidMode reports whether the server runs with gtid_mode=ON.
+func (s *Source) gtidMode(ctx context.Context) (bool, error) {
+	var mode string
+	if err := s.db.QueryRowContext(ctx, "SELECT @@gtid_mode").Scan(&mode); err != nil {
+		return false, fmt.Errorf("mysql cdc: read gtid_mode: %w", err)
+	}
+	return strings.EqualFold(mode, "ON"), nil
+}
+
+// gtidExecuted reads the server's executed-transaction set — the GTID watermark.
+func (s *Source) gtidExecuted(ctx context.Context) (gomysql.GTIDSet, error) {
+	var raw string
+	if err := s.db.QueryRowContext(ctx, "SELECT @@global.gtid_executed").Scan(&raw); err != nil {
+		return nil, fmt.Errorf("mysql cdc: read gtid_executed: %w", err)
+	}
+	set, err := gomysql.ParseMysqlGTIDSet(strings.ReplaceAll(raw, "\n", ""))
+	if err != nil {
+		return nil, fmt.Errorf("mysql cdc: parse gtid_executed %q: %w", raw, err)
+	}
+	return set, nil
+}
+
+// extractChangesGTID streams row events from the checkpointed GTID set up to the
+// watermark captured at run start.
+func (s *Source) extractChangesGTID(ctx context.Context, sink ingestion.RecordSink, opts ingestion.ChangeExtractOpts, watermark gomysql.GTIDSet) error {
+	start, ok, err := startGTID(opts.Checkpoints)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		start = watermark.Clone() // first run: begin at the current tail
+	}
+
+	run := newCDCRun(sink, opts.Resources, opts.Limit)
+
+	if start.Contain(watermark) {
+		return run.pushStreamMarksLSN(gtidCursor(start))
+	}
+
+	syncer := replication.NewBinlogSyncer(s.binlogConfig())
+	defer syncer.Close()
+	streamer, err := syncer.StartSyncGTID(start)
+	if err != nil {
+		return fmt.Errorf("mysql cdc: start gtid sync at %q: %w", start.String(), err)
+	}
+
+	committed := start.Clone() // transactions fully delivered — the record cursor
+	var inflight string        // GTID of the transaction whose rows are streaming
+
+	fold := func() error {
+		if inflight == "" {
+			return nil
+		}
+		if err := committed.Update(inflight); err != nil {
+			return fmt.Errorf("mysql cdc: fold gtid %q: %w", inflight, err)
+		}
+		inflight = ""
+		return nil
+	}
+
+	for {
+		ev, err := streamer.GetEvent(ctx)
+		if err != nil {
+			return fmt.Errorf("mysql cdc: read event at %q: %w", committed.String(), err)
+		}
+
+		switch e := ev.Event.(type) {
+		case *replication.GTIDEvent:
+			// Header of the next transaction: the previous one (if any) is fully
+			// delivered — fold it before tracking the new in-flight GTID.
+			if err := fold(); err != nil {
+				return err
+			}
+			sid, err := uuid.FromBytes(e.SID)
+			if err != nil {
+				return fmt.Errorf("mysql cdc: gtid sid: %w", err)
+			}
+			inflight = fmt.Sprintf("%s:%d", sid, e.GNO)
+		case *replication.XIDEvent:
+			if err := fold(); err != nil { // transaction commit
+				return err
+			}
+		case *replication.QueryEvent:
+			// A statement event is its own transaction (DDL, or COMMIT of a
+			// non-transactional change): fold and drop the schema cache.
+			if err := fold(); err != nil {
+				return err
+			}
+			run.clearSchema()
+		case *replication.RowsEvent:
+			// Records carry the committed-set cursor: resuming from it replays the
+			// current (uncommitted-at-cursor-time) transaction in full.
+			limited, err := run.pushRowsEvent(ctx, s, ev.Header.EventType, e, gtidCursor(committed))
+			if err != nil {
+				return err
+			}
+			if limited {
+				return nil // truncated: resume replays from the committed cursor
+			}
+		}
+
+		if committed.Contain(watermark) {
+			return run.pushStreamMarksLSN(gtidCursor(committed))
+		}
+	}
+}
+
+// gtidCursor renders a GTID set as a ModeStream cursor value.
+func gtidCursor(set gomysql.GTIDSet) string { return gtidCursorPrefix + set.String() }
+
+// startGTID picks the resume set across the run's resources: the cursor contained
+// by all the others (per-resource cursors form a monotone chain, so a minimum
+// exists; re-delivering from an older set is safe, skipping is not). Incomparable
+// sets mean the checkpoints came from different streams — fail rather than guess.
+func startGTID(cps map[string]ingestion.Checkpoint) (gomysql.GTIDSet, bool, error) {
+	var min gomysql.GTIDSet
+	for _, cp := range cps {
+		lsn, _, ok := checkpoint.ParseStream(cp)
+		if !ok || !strings.HasPrefix(lsn, gtidCursorPrefix) {
+			continue
+		}
+		set, err := gomysql.ParseMysqlGTIDSet(strings.TrimPrefix(lsn, gtidCursorPrefix))
+		if err != nil {
+			return nil, false, fmt.Errorf("mysql cdc: parse gtid cursor %q: %w", lsn, err)
+		}
+		switch {
+		case min == nil:
+			min = set
+		case min.Contain(set):
+			min = set
+		case set.Contain(min):
+			// keep min
+		default:
+			return nil, false, fmt.Errorf("mysql cdc: incomparable gtid cursors %q and %q (mixed streams?)", min.String(), set.String())
+		}
+	}
+	return min, min != nil, nil
+}

--- a/connectors/mysql/source/cdc_gtid.go
+++ b/connectors/mysql/source/cdc_gtid.go
@@ -115,12 +115,16 @@ func (s *Source) extractChangesGTID(ctx context.Context, sink ingestion.RecordSi
 				return err
 			}
 		case *replication.QueryEvent:
-			// A statement event is its own transaction (DDL, or COMMIT of a
-			// non-transactional change): fold and drop the schema cache.
-			if err := fold(); err != nil {
-				return err
+		    // reject events for transactions 
+			switch q := strings.ToUpper(strings.TrimSpace(string(e.Query))); {
+			case q == "BEGIN", q == "COMMIT", q == "ROLLBACK", strings.HasPrefix(q, "SAVEPOINT "), strings.HasPrefix(q, "ROLLBACK TO "):
+				// not a commit boundary
+			default:
+				if err := fold(); err != nil {
+					return err
+				}
+				run.clearSchema()
 			}
-			run.clearSchema()
 		case *replication.RowsEvent:
 			// Records carry the committed-set cursor: resuming from it replays the
 			// current (uncommitted-at-cursor-time) transaction in full.

--- a/internal/modules/engine/engine.go
+++ b/internal/modules/engine/engine.go
@@ -65,8 +65,13 @@ func (m *Module) onRunRequested(ctx context.Context, msg eventbus.Message) error
 		return fmt.Errorf("engine: load run %q: %w", ev.Run, err)
 	}
 	// Idempotency: only a freshly-requested run is ours to start. A redelivered
-	// trigger for a run already running or finished is acked and ignored.
-	if state.Status != ingestion.RunRequested && state.Status != ingestion.RunPartial {
+	// trigger for a run already running or finished is acked and ignored — except
+	// a completed CDC run, which is a catch-up cycle by construction: re-requesting
+	// it continues the change stream from its persisted cursor, so each request
+	// drains the source up to a fresh watermark and completes again.
+	cdcCycle := state.Request.IngestionType.OrDefault() == ingestion.IngestionCDC &&
+		state.Status == ingestion.RunCompleted
+	if state.Status != ingestion.RunRequested && state.Status != ingestion.RunPartial && !cdcCycle {
 		return nil
 	}
 	m.runOne(ctx, specFromState(state))

--- a/internal/modules/tracker/tracker.go
+++ b/internal/modules/tracker/tracker.go
@@ -222,6 +222,9 @@ func (m *Module) foldCursor(ctx context.Context, ev ingestion.Event) (ingestion.
 	if part, ack, want, hasWant, ok := checkpoint.CoarseDelta(ev.Fields.Checkpoint); ok {
 		return m.foldBitmap(ctx, ev, part, ack, want, hasWant)
 	}
+	if _, _, ok := checkpoint.ParseStream(ev.Fields.Checkpoint); ok {
+		return m.foldStream(ctx, ev)
+	}
 	key := ckKey{ev.Run, ev.Resource}
 
 	m.mu.Lock()
@@ -231,6 +234,33 @@ func (m *Module) foldCursor(ctx context.Context, ev ingestion.Event) (ingestion.
 		m.cp[key] = base
 	}
 	merged := checkpoint.MergeShardDelta(base, ev.Fields.Checkpoint)
+	if merged == nil {
+		m.mu.Unlock()
+		return nil, false
+	}
+	m.cp[key] = merged
+	m.since[key]++
+	persist := m.since[key] >= m.cadence(ctx, ev.Run)
+	if persist {
+		m.since[key] = 0
+	}
+	m.mu.Unlock()
+	return merged, persist
+}
+
+// foldStream folds a change-stream position delta: the newer position (guarded by the
+// per-run seq, since concurrent writers can publish batch facts out of order) replaces
+// the resource's cursor wholesale — a stream cursor has no shard layout to merge into.
+func (m *Module) foldStream(ctx context.Context, ev ingestion.Event) (ingestion.Checkpoint, bool) {
+	key := ckKey{ev.Run, ev.Resource}
+
+	m.mu.Lock()
+	base, ok := m.cp[key]
+	if !ok {
+		base = m.loadCheckpoint(ctx, ev.Run, ev.Resource) // recover position after a restart
+		m.cp[key] = base
+	}
+	merged := checkpoint.MergeStream(base, ev.Fields.Checkpoint)
 	if merged == nil {
 		m.mu.Unlock()
 		return nil, false

--- a/pipeline/batcher.go
+++ b/pipeline/batcher.go
@@ -80,6 +80,16 @@ func (p *Pipeline) batcher(ctx context.Context, shard int) {
 				if !flush(key) {
 					return
 				}
+				// A stream (CDC) drain carries the final position instead of a row
+				// count: persist it even when the run wrote nothing, so the next run
+				// resumes from here rather than re-capturing a later position and
+				// skipping the gap.
+				if rec.Meta.LSN != "" {
+					if !sendStreamMark(ctx, p, key, rec.Meta) {
+						return
+					}
+					continue
+				}
 				if !sendDrained(ctx, p, key, seen[key]) {
 					return
 				}
@@ -129,19 +139,35 @@ type partKey struct {
 	part     int
 }
 
-// shardCursor builds the per-shard checkpoint delta from a flushed batch. A bitmap
-// (Coarse) read has no key cursor, so the delta is an ack of this batch's row count, which
-// the tracker sums toward the shard's expected total. A keyset read carries the last
+// sendStreamMark queues a stream-position marker (no records) so the writer publishes
+// the final CDC position without a sink write. Returns false if the pipeline is
+// shutting down.
+func sendStreamMark(ctx context.Context, p *Pipeline, key partKey, meta ingestion.RecordMeta) bool {
+	b := ingestion.Batch{
+		Tenant:   p.tenant,
+		Run:      p.run,
+		Resource: key.resource,
+		Part:     key.part,
+		Drained:  true,
+		Cursor:   checkpoint.NewStreamDelta(key.resource, meta.LSN, meta.Seq),
+	}
+	select {
+	case p.batchCh <- b:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// shardCursor builds the per-shard checkpoint delta from a flushed batch. A change
+// stream (Meta.LSN) carries the last record's stream position. A bitmap (Coarse) read
+// has no key cursor, so the delta is an ack of this batch's row count, which the
+// tracker sums toward the shard's expected total. A keyset read carries the last
 // record's key. A plain ctid read carries neither → nil.
 func shardCursor(resource string, part int, recs []ingestion.Record) *ingestion.CheckpointData {
 	last := recs[len(recs)-1]
 	if last.Meta.LSN != "" {
-		cp := ingestion.NewCheckpoint(resource)
-		cp.Cursor["lsn"] = last.Meta.LSN
-		if last.Meta.Seq > 0 {
-			cp.Cursor["seq"] = int64(last.Meta.Seq)
-		}
-		return cp
+		return checkpoint.NewStreamDelta(resource, last.Meta.LSN, last.Meta.Seq)
 	}
 	if last.Coarse {
 		return checkpoint.NewCoarseAck(resource, part, len(recs))


### PR DESCRIPTION
This pull request introduces GTID-based Change Data Capture (CDC) streaming to the MySQL connector, providing a more robust and topology-aware way to track changes. The new logic uses GTID (Global Transaction Identifier) sets for streaming and checkpointing, improving failover handling and consistency compared to the previous file:position-based method. The implementation includes detection of GTID mode, reading the current GTID set, streaming changes from a checkpoint, and safe resumption logic.

The most important changes include:

**GTID-Based CDC Implementation:**
* Added a new GTID-based CDC streaming mechanism in `cdc_gtid.go`, which is used when the MySQL server runs with `gtid_mode=ON`. This approach uses GTID sets for tracking and resuming change streams, making checkpointing resilient to replica promotion and topology changes.
* Implemented logic to stream events starting from a checkpointed GTID set up to a captured watermark, ensuring that resumption after failures is safe and idempotent.
* Added handling for folding in-flight GTIDs only upon transaction commit, preventing loss of uncommitted changes on resumption.

**Checkpoint and Resume Logic:**
* Introduced functions to encode/decode GTID-based cursors and to determine the minimal common checkpoint across resources, ensuring safe and monotonic recovery.

**Server Capability Detection: