### PR TITLE
default resource planner

### DIFF
--- a/internal/modules/engine/engine.go
+++ b/internal/modules/engine/engine.go
@@ -120,14 +120,12 @@ func (m *Module) runOne(ctx context.Context, spec filament.RunSpec) {
 		return
 	}
 	defer func() { _ = src.Teardown(ctx) }()
-	if planner, ok := src.(filament.ResourcePlanner); ok {
-		resources, err := planner.PlanResources(ctx, spec.Resources, spec.Selectors)
-		if err != nil {
-			em.fail(fmt.Errorf("plan resources: %w", err))
-			return
-		}
-		spec.Resources = resources
+	plannedResources, err := runner.PlanResources(ctx, src, spec.Resources, spec.Selectors)
+	if err != nil {
+		em.fail(fmt.Errorf("plan resources: %w", err))
+		return
 	}
+	spec.Resources = plannedResources
 
 	snk, err := m.sinks.Resolve(spec.Sink.Provider)
 	if err != nil {

--- a/runner/resources.go
+++ b/runner/resources.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/galaxy-io/filament"
+)
+
+// PlanResources resolves a run's requested resources to concrete source
+// resources. An empty request means "all" for discoverable sources. Sources
+// with private selector semantics can override this through ResourcePlanner.
+func PlanResources(ctx context.Context, src filament.Source, resources, selectors []string) ([]string, error) {
+	if planner, ok := src.(filament.ResourcePlanner); ok {
+		planned, err := planner.PlanResources(ctx, resources, selectors)
+		if err != nil {
+			return nil, err
+		}
+		if len(planned) == 0 {
+			return nil, fmt.Errorf("source %q planned no resources", src.Spec().Name)
+		}
+		return planned, nil
+	}
+	if len(resources) > 0 {
+		return resources, nil
+	}
+	discoverable, ok := src.(filament.Discoverable)
+	if !ok {
+		return resources, nil
+	}
+	discovered, err := discoverable.Discover(ctx, filament.DiscoverOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("discover all resources: %w", err)
+	}
+	planned := make([]string, 0, len(discovered.Resources))
+	for _, resource := range discovered.Resources {
+		if resource.Selectable {
+			planned = append(planned, resource.Name)
+		}
+	}
+	if len(planned) == 0 {
+		return nil, fmt.Errorf("source %q discovered no selectable resources", src.Spec().Name)
+	}
+	return planned, nil
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -69,14 +69,12 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 		return
 	}
 	defer func() { _ = src.Teardown(ctx) }()
-	if planner, ok := src.(filament.ResourcePlanner); ok {
-		resources, err := planner.PlanResources(ctx, spec.Resources, spec.Selectors)
-		if err != nil {
-			em.fail(fmt.Errorf("plan resources: %w", err))
-			return
-		}
-		spec.Resources = resources
+	plannedResources, err := PlanResources(ctx, src, spec.Resources, spec.Selectors)
+	if err != nil {
+		em.fail(fmt.Errorf("plan resources: %w", err))
+		return
 	}
+	spec.Resources = plannedResources
 
 	snk, err := deps.Sinks.Resolve(spec.Sink.Provider)
 	if err != nil {


### PR DESCRIPTION
Adds a default resource planner to expand empty resources to all discoverable on all connectors 

## Slop
This pull request refactors how resource planning is handled for source modules, centralizing the logic into a new helper function. The main goal is to reduce code duplication and make resource resolution more consistent across the codebase.

Resource planning refactor:

* Introduced a new `PlanResources` function in `runner/resources.go` that encapsulates the logic for resolving and validating resources for a run, including handling `ResourcePlanner` and `Discoverable` sources.
* Updated `engine.go` and `runner.go` to use the new `PlanResources` function, removing duplicate resource planning logic from both files. [[1]](diffhunk://#diff-bf37d62445111004f369d36d070a1907bfd5a85cd8591e0d303cdab5cd49221fL123-R128) [[2]](diffhunk://#diff-20e6696d056b9497806d8852a99dad01af18dab2c3378ebf73dee3ccbea93f45L72-R77)

Error handling improvements:

* The new `PlanResources` function adds stricter error handling, returning errors if no resources are planned or discovered, which helps prevent silent failures during execution.