### PR TITLE
Atterpac/http additions

### DIFF
--- a/connectors/http/catalog.go
+++ b/connectors/http/catalog.go
@@ -12,16 +12,22 @@ var notionManifest []byte
 //go:embed manifests/linear.yaml
 var linearManifest []byte
 
+//go:embed manifests/github.yaml
+var githubManifest []byte
+
 // NewNotion returns a Source backed by the embedded Notion manifest.
 func NewNotion() *Source {
-	return NewManifestWithMetadata("notion", "Notion", "All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.", "https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg", notionManifest, filament.ConfigSchema{Fields: []filament.ConfigField{
-		{Name: "api_key", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, Help: "Notion integration secret"},
-	}})
+	return NewManifestWithMetadata("notion", "Notion", "All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.", "https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg", notionManifest, manifestOwnedConfig())
 }
 
 // NewLinear returns a Source backed by the embedded Linear manifest.
 func NewLinear() *Source {
-	return NewManifestWithMetadata("linear", "Linear", "Modern issue tracking and project management tool built for high-performance teams.", "https://cdn.getgalaxy.io/sources/source-icon-linear-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-linear-light.svg", linearManifest, filament.ConfigSchema{Fields: []filament.ConfigField{
-		{Name: "api_key", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, Help: "Linear API key"},
-	}})
+	return NewManifestWithMetadata("linear", "Linear", "Modern issue tracking and project management tool built for high-performance teams.", "https://cdn.getgalaxy.io/sources/source-icon-linear-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-linear-light.svg", linearManifest, manifestOwnedConfig())
 }
+
+// NewGitHub returns a Source backed by the embedded GitHub REST API manifest.
+func NewGitHub() *Source {
+	return NewManifestWithMetadata("github", "GitHub", "Code hosting platform for version control, collaboration, and software development workflows.", "https://cdn.getgalaxy.io/sources/source-icon-github-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-github-light.svg", githubManifest, manifestOwnedConfig())
+}
+
+func manifestOwnedConfig() filament.ConfigSchema { return filament.ConfigSchema{} }

--- a/connectors/http/catalog.go
+++ b/connectors/http/catalog.go
@@ -15,6 +15,9 @@ var linearManifest []byte
 //go:embed manifests/github.yaml
 var githubManifest []byte
 
+//go:embed manifests/slack.yaml
+var slackManifest []byte
+
 // NewNotion returns a Source backed by the embedded Notion manifest.
 func NewNotion() *Source {
 	return NewManifestWithMetadata("notion", "Notion", "All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.", "https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg", notionManifest, manifestOwnedConfig())
@@ -28,6 +31,11 @@ func NewLinear() *Source {
 // NewGitHub returns a Source backed by the embedded GitHub REST API manifest.
 func NewGitHub() *Source {
 	return NewManifestWithMetadata("github", "GitHub", "Code hosting platform for version control, collaboration, and software development workflows.", "https://cdn.getgalaxy.io/sources/source-icon-github-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-github-light.svg", githubManifest, manifestOwnedConfig())
+}
+
+// NewSlack returns a Source backed by the embedded Slack Web API manifest.
+func NewSlack() *Source {
+	return NewManifestWithMetadata("slack", "Slack", "Messaging and collaboration platform designed for teams to communicate and work together efficiently.", "https://cdn.getgalaxy.io/sources/source-icon-slack-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-slack-light.svg", slackManifest, manifestOwnedConfig())
 }
 
 func manifestOwnedConfig() filament.ConfigSchema { return filament.ConfigSchema{} }

--- a/connectors/http/catalog.go
+++ b/connectors/http/catalog.go
@@ -12,6 +12,9 @@ var notionManifest []byte
 //go:embed manifests/linear.yaml
 var linearManifest []byte
 
+//go:embed manifests/attio.yaml
+var attioManifest []byte
+
 //go:embed manifests/github.yaml
 var githubManifest []byte
 
@@ -26,6 +29,11 @@ func NewNotion() *Source {
 // NewLinear returns a Source backed by the embedded Linear manifest.
 func NewLinear() *Source {
 	return NewManifestWithMetadata("linear", "Linear", "Modern issue tracking and project management tool built for high-performance teams.", "https://cdn.getgalaxy.io/sources/source-icon-linear-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-linear-light.svg", linearManifest, manifestOwnedConfig())
+}
+
+// NewAttio returns a Source backed by the embedded Attio REST API manifest.
+func NewAttio() *Source {
+	return NewManifestWithMetadata("attio", "Attio", "CRM platform designed for modern teams to centralize customer data, pipelines, and workflows.", "https://cdn.getgalaxy.io/sources/source-icon-attio-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-attio-light.svg", attioManifest, manifestOwnedConfig())
 }
 
 // NewGitHub returns a Source backed by the embedded GitHub REST API manifest.

--- a/connectors/http/manifests/attio.yaml
+++ b/connectors/http/manifests/attio.yaml
@@ -1,0 +1,543 @@
+version: 1
+name: attio
+config:
+  api_key:
+    type: secret
+    required: true
+    help: Attio workspace API key
+defaults:
+  method: GET
+field_sets:
+  record:
+    workspace_id: { path: id.workspace_id, type: uuid }
+    object_id: { path: id.object_id, type: uuid }
+    record_id: { path: id.record_id, type: uuid }
+    created_at: timestamptz
+    web_url: string?
+    values: json?
+    raw: { path: $, type: json, mode: remainder }
+connection:
+  base_url: https://api.attio.com
+  auth:
+    bearer: config.api_key
+  headers:
+    Accept: application/json
+resources:
+  - name: objects
+    path: /v2/objects
+    primary_key: [object_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      object_id: { path: id.object_id, type: uuid }
+      api_slug: string
+      singular_noun: string?
+      plural_noun: string?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      object: api_slug
+    response:
+      records: $.data
+      pagination: none
+  - name: records
+    path: /v2/objects/{object}/records/query
+    params:
+      object: parent.object
+    method: POST
+    for_each: objects
+    primary_key: [record_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      object_id: { path: id.object_id, type: uuid }
+      record_id: { path: id.record_id, type: uuid }
+      object: { path: parent.object, type: string }
+      created_at: timestamptz
+      web_url: string?
+      values: json?
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      object: id.object_id
+      record_id: id.record_id
+    body:
+      encoding: json
+      template:
+        limit: 500
+        offset: 0
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: body.offset
+          limit: body.limit
+          page_size: 500
+  - name: lists
+    path: /v2/lists
+    primary_key: [list_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      list_id: { path: id.list_id, type: uuid }
+      api_slug: string?
+      name: string
+      parent_object: json?
+      workspace_access: string?
+      workspace_member_access: json?
+      created_by_actor: json?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      list: api_slug
+    response:
+      records: $.data
+      pagination: none
+  - name: entries
+    path: /v2/lists/{list}/entries/query
+    params:
+      list: parent.list
+    method: POST
+    for_each: lists
+    primary_key: [entry_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      list_id: { path: id.list_id, type: uuid }
+      entry_id: { path: id.entry_id, type: uuid }
+      list: { path: parent.list, type: string }
+      parent_record_id: uuid?
+      parent_object: string?
+      created_at: timestamptz
+      entry_values: json?
+      raw: { path: $, type: json, mode: remainder }
+    body:
+      encoding: json
+      template:
+        limit: 500
+        offset: 0
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: body.offset
+          limit: body.limit
+          page_size: 500
+  - name: object_attributes
+    path: /v2/objects/{object}/attributes
+    params:
+      object: parent.object
+    for_each: objects
+    primary_key: [attribute_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      object_id: { path: id.object_id, type: uuid }
+      attribute_id: { path: id.attribute_id, type: uuid }
+      object: { path: parent.object, type: string }
+      title: string
+      description: string?
+      api_slug: string
+      type: string
+      is_system_attribute: bool
+      is_writable: bool
+      is_required: bool
+      is_unique: bool
+      is_multiselect: bool
+      is_default_value_enabled: bool
+      is_archived: bool
+      default_value: json?
+      relationship: json?
+      config: json?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: query.offset
+          limit: query.limit
+          page_size: 500
+  - name: list_attributes
+    path: /v2/lists/{list}/attributes
+    params:
+      list: parent.list
+    for_each: lists
+    primary_key: [attribute_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      list_id: { path: id.object_id, type: uuid }
+      attribute_id: { path: id.attribute_id, type: uuid }
+      list: { path: parent.list, type: string }
+      title: string
+      description: string?
+      api_slug: string
+      type: string
+      is_system_attribute: bool
+      is_writable: bool
+      is_required: bool
+      is_unique: bool
+      is_multiselect: bool
+      is_default_value_enabled: bool
+      is_archived: bool
+      default_value: json?
+      relationship: json?
+      config: json?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: query.offset
+          limit: query.limit
+          page_size: 500
+  - name: object_views
+    path: /v2/objects/{object}/views
+    params:
+      object: parent.object
+    for_each: objects
+    primary_key: [view_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      object_id: { path: id.object_id, type: uuid }
+      view_id: { path: id.view_id, type: uuid }
+      object: { path: parent.object, type: string }
+      title: string
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    query:
+      limit: "500"
+    response:
+      records: $.data
+      pagination:
+        cursor:
+          response: pagination.next_cursor
+          request: query.cursor
+          null_terminates: true
+  - name: list_views
+    path: /v2/lists/{list}/views
+    params:
+      list: parent.list
+    for_each: lists
+    primary_key: [view_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      list_id: { path: id.list_id, type: uuid }
+      view_id: { path: id.view_id, type: uuid }
+      list: { path: parent.list, type: string }
+      title: string
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    query:
+      limit: "500"
+    response:
+      records: $.data
+      pagination:
+        cursor:
+          response: pagination.next_cursor
+          request: query.cursor
+          null_terminates: true
+  - name: record_entries
+    path: /v2/objects/{object}/records/{record}/entries
+    params:
+      object: parent.object
+      record: parent.record_id
+    for_each: records
+    primary_key: [entry_id]
+    fields:
+      object: { path: parent.object, type: string }
+      record_id: { path: parent.record_id, type: uuid }
+      list_id: uuid
+      list_api_slug: string
+      entry_id: uuid
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: query.offset
+          limit: query.limit
+          page_size: 500
+  - name: files
+    path: /v2/files
+    for_each: records
+    query:
+      object: "{{ parent.object }}"
+      record_id: "{{ parent.record_id }}"
+      limit: "200"
+    primary_key: [file_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      file_id: { path: id.file_id, type: uuid }
+      object_id: uuid?
+      object_slug: string?
+      record_id: uuid?
+      file_type: string?
+      storage_provider: string?
+      name: string?
+      content_type: string?
+      content_size: int64?
+      parent_folder_id: uuid?
+      created_by_actor: json?
+      created_at: timestamptz?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        cursor:
+          response: pagination.next_cursor
+          request: query.cursor
+          null_terminates: true
+  - name: workspace_members
+    path: /v2/workspace_members
+    primary_key: [workspace_member_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      workspace_member_id: { path: id.workspace_member_id, type: uuid }
+      first_name: string
+      last_name: string
+      avatar_url: string?
+      email_address: string
+      access_level: string
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination: none
+  - name: notes
+    path: /v2/notes
+    query:
+      limit: "500"
+    primary_key: [note_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      note_id: { path: id.note_id, type: uuid }
+      parent_object: string
+      parent_record_id: uuid
+      title: string
+      meeting_id: uuid?
+      content_plaintext: string
+      content_markdown: string
+      tags: json
+      created_by_actor: json?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: query.offset
+          limit: query.limit
+          page_size: 500
+  - name: tasks
+    path: /v2/tasks
+    query:
+      limit: "500"
+    primary_key: [task_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      task_id: { path: id.task_id, type: uuid }
+      content_plaintext: string
+      deadline_at: timestamptz?
+      is_completed: bool
+      completed_at: timestamptz?
+      linked_records: json
+      assignees: json
+      created_by_actor: json?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: query.offset
+          limit: query.limit
+          page_size: 500
+  - name: threads
+    path: /v2/threads
+    query:
+      limit: "500"
+    primary_key: [thread_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      thread_id: { path: id.thread_id, type: uuid }
+      comments: json
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: query.offset
+          limit: query.limit
+          page_size: 500
+  - name: meetings
+    path: /v2/meetings
+    query:
+      limit: "500"
+    primary_key: [meeting_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      meeting_id: { path: id.meeting_id, type: uuid }
+      title: string
+      description: string?
+      is_all_day: bool
+      start: json
+      end: json
+      participants: json
+      linked_records: json
+      created_by_actor: json?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      meeting_id: id.meeting_id
+    response:
+      records: $.data
+      pagination:
+        cursor:
+          response: pagination.next_cursor
+          request: query.cursor
+          null_terminates: true
+  - name: call_recordings
+    path: /v2/meetings/{meeting}/call_recordings
+    params:
+      meeting: parent.meeting_id
+    for_each: meetings
+    query:
+      limit: "500"
+    primary_key: [call_recording_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      meeting_id: { path: id.meeting_id, type: uuid }
+      call_recording_id: { path: id.call_recording_id, type: uuid }
+      status: string
+      web_url: string
+      created_by_actor: json?
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      meeting_id: id.meeting_id
+      call_recording_id: id.call_recording_id
+    response:
+      records: $.data
+      pagination:
+        cursor:
+          response: pagination.next_cursor
+          request: query.cursor
+          null_terminates: true
+  - name: transcripts
+    path: /v2/meetings/{meeting}/call_recordings/{recording}/transcript
+    params:
+      meeting: parent.meeting_id
+      recording: parent.call_recording_id
+    for_each: call_recordings
+    primary_key: [call_recording_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      meeting_id: { path: id.meeting_id, type: uuid }
+      call_recording_id: { path: id.call_recording_id, type: uuid }
+      transcript: json
+      raw_transcript: string
+      web_url: string
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      cardinality: one
+      pagination: none
+  - name: webhooks
+    path: /v2/webhooks
+    query:
+      limit: "500"
+    primary_key: [webhook_id]
+    fields:
+      workspace_id: { path: id.workspace_id, type: uuid }
+      webhook_id: { path: id.webhook_id, type: uuid }
+      target_url: string
+      subscriptions: json
+      status: string
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.data
+      pagination:
+        offset:
+          offset: query.offset
+          limit: query.limit
+          page_size: 500
+  - name: people
+    path: /v2/objects/people/records/query
+    method: POST
+    primary_key: [record_id]
+    use_fields: [record]
+    body:
+      encoding: json
+      template: { limit: 500, offset: 0 }
+    response:
+      records: $.data
+      pagination: { offset: { offset: body.offset, limit: body.limit, page_size: 500 } }
+  - name: companies
+    path: /v2/objects/companies/records/query
+    method: POST
+    primary_key: [record_id]
+    use_fields: [record]
+    body:
+      encoding: json
+      template: { limit: 500, offset: 0 }
+    response:
+      records: $.data
+      pagination: { offset: { offset: body.offset, limit: body.limit, page_size: 500 } }
+  - name: deals
+    path: /v2/objects/deals/records/query
+    method: POST
+    primary_key: [record_id]
+    use_fields: [record]
+    body:
+      encoding: json
+      template: { limit: 500, offset: 0 }
+    response:
+      records: $.data
+      pagination: { offset: { offset: body.offset, limit: body.limit, page_size: 500 } }
+  - name: users
+    path: /v2/objects/users/records/query
+    method: POST
+    primary_key: [record_id]
+    use_fields: [record]
+    body:
+      encoding: json
+      template: { limit: 500, offset: 0 }
+    response:
+      records: $.data
+      pagination: { offset: { offset: body.offset, limit: body.limit, page_size: 500 } }
+  - name: workspaces
+    path: /v2/objects/workspaces/records/query
+    method: POST
+    primary_key: [record_id]
+    use_fields: [record]
+    body:
+      encoding: json
+      template: { limit: 500, offset: 0 }
+    response:
+      records: $.data
+      pagination: { offset: { offset: body.offset, limit: body.limit, page_size: 500 } }
+discovery:
+  mode: static
+  include:
+    - objects
+    - records
+    - object_attributes
+    - object_views
+    - record_entries
+    - files
+    - lists
+    - entries
+    - list_attributes
+    - list_views
+    - workspace_members
+    - notes
+    - tasks
+    - threads
+    - meetings
+    - call_recordings
+    - transcripts
+    - webhooks
+    - people
+    - companies
+    - deals
+    - users
+    - workspaces

--- a/connectors/http/manifests/github.yaml
+++ b/connectors/http/manifests/github.yaml
@@ -1,0 +1,130 @@
+version: 1
+name: github
+config:
+  token:
+    type: secret
+    required: true
+    help: GitHub personal access token or GitHub App installation token
+  organization:
+    type: string
+    required: true
+    help: GitHub organization login
+defaults:
+  method: GET
+  query:
+    per_page: "100"
+  response:
+    records: $
+    pagination:
+      link: next
+field_sets:
+  issue_lifecycle:
+    created_at: timestamptz
+    updated_at: timestamptz
+    closed_at: timestamptz?
+connection:
+  base_url: https://api.github.com
+  auth:
+    bearer: config.token
+  headers:
+    Accept: application/vnd.github+json
+    X-GitHub-Api-Version: "2022-11-28"
+resources:
+  - name: repositories
+    path: /orgs/{organization}/repos
+    params:
+      organization: config.organization
+    query:
+      type: all
+      sort: full_name
+      direction: asc
+    primary_key: [id]
+    fields:
+      id: int64
+      node_id: string
+      name: string
+      full_name: string
+      private: bool
+      fork: bool
+      archived: bool
+      disabled: bool
+      visibility: string?
+      description: string?
+      language: string?
+      default_branch: string?
+      html_url: string
+      created_at: timestamptz?
+      updated_at: timestamptz?
+      pushed_at: timestamptz?
+      topics: json?
+      owner: json?
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      repository: name
+  - name: issues
+    path: /repos/{organization}/{repository}/issues
+    params:
+      organization: config.organization
+      repository: parent.repository
+    query:
+      state: all
+      direction: asc
+      sort: created
+    primary_key: [id]
+    use_fields: [issue_lifecycle]
+    fields:
+      id: int64
+      node_id: string
+      repository: { path: parent.repository, type: string }
+      number: int64
+      title: string
+      body: string?
+      state: string
+      state_reason: string?
+      locked: bool
+      comments: int64
+      html_url: string
+      user: json?
+      assignee: json?
+      assignees: json?
+      labels: json?
+      milestone: json?
+      pull_request: json?
+      raw: { path: $, type: json, mode: remainder }
+    for_each: repositories
+  - name: pull_requests
+    path: /repos/{organization}/{repository}/pulls
+    params:
+      organization: config.organization
+      repository: parent.repository
+    query:
+      state: all
+      direction: asc
+      sort: created
+    primary_key: [id]
+    use_fields: [issue_lifecycle]
+    fields:
+      id: int64
+      node_id: string
+      repository: { path: parent.repository, type: string }
+      number: int64
+      title: string
+      body: string?
+      state: string
+      draft: bool?
+      locked: bool
+      html_url: string
+      user: json?
+      assignee: json?
+      assignees: json?
+      requested_reviewers: json?
+      requested_teams: json?
+      labels: json?
+      milestone: json?
+      head: json?
+      base: json?
+      merged_at: timestamptz?
+      raw: { path: $, type: json, mode: remainder }
+    for_each: repositories
+discovery:
+  mode: static

--- a/connectors/http/manifests/slack.yaml
+++ b/connectors/http/manifests/slack.yaml
@@ -1,0 +1,332 @@
+version: 1
+name: slack
+config:
+  token:
+    type: secret
+    required: true
+    help: Slack bot or user OAuth token
+  conversation_types:
+    type: string
+    default: public_channel
+    help: Comma-separated Slack conversation types (public_channel, private_channel, mpim, im)
+defaults:
+  method: GET
+  response:
+    error:
+      path: error
+      when_present: true
+      message_path: error
+connection:
+  base_url: https://slack.com/api
+  auth:
+    bearer: config.token
+  headers:
+    Accept: application/json
+resources:
+  - name: team
+    path: /team.info
+    primary_key: [id]
+    fields:
+      id: string
+      name: string
+      domain: string?
+      email_domain: string?
+      icon: json?
+      enterprise_id: string?
+      enterprise_name: string?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.team
+      cardinality: one
+      pagination: none
+
+  - name: users
+    path: /users.list
+    query:
+      limit: "200"
+    primary_key: [id]
+    fields:
+      id: string
+      team_id: string?
+      name: string?
+      real_name: string?
+      deleted: bool?
+      color: string?
+      tz: string?
+      tz_label: string?
+      tz_offset: int64?
+      is_admin: bool?
+      is_owner: bool?
+      is_primary_owner: bool?
+      is_restricted: bool?
+      is_ultra_restricted: bool?
+      is_bot: bool?
+      updated: int64?
+      profile: json?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.members
+      pagination:
+        cursor:
+          response: response_metadata.next_cursor
+          request: query.cursor
+
+  - name: user_groups
+    path: /usergroups.list
+    query:
+      include_users: "true"
+      include_count: "true"
+      include_disabled: "true"
+    primary_key: [id]
+    fields:
+      id: string
+      team_id: string?
+      name: string
+      handle: string?
+      description: string?
+      date_create: int64?
+      date_update: int64?
+      date_delete: int64?
+      auto_type: string?
+      created_by: string?
+      updated_by: string?
+      deleted_by: string?
+      prefs: json?
+      users: json?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.usergroups
+      pagination: none
+
+  - name: conversations
+    # Membership-aware inventory: conversations.history rejects channels a bot
+    # can discover but has not joined with not_in_channel.
+    path: /users.conversations
+    query:
+      types: "{{ config.conversation_types }}"
+      exclude_archived: "false"
+      limit: "200"
+    primary_key: [id]
+    fields:
+      id: string
+      name: string?
+      created: int64?
+      creator: string?
+      updated: int64?
+      topic: json?
+      purpose: json?
+      num_members: int64?
+      is_channel: bool?
+      is_group: bool?
+      is_im: bool?
+      is_mpim: bool?
+      is_private: bool?
+      is_archived: bool?
+      is_general: bool?
+      is_shared: bool?
+      is_org_shared: bool?
+      is_ext_shared: bool?
+      is_member: bool?
+      user: string?
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      channel_id: id
+    response:
+      records: $.channels
+      pagination:
+        cursor:
+          response: response_metadata.next_cursor
+          request: query.cursor
+
+  - name: messages
+    path: /conversations.history
+    query:
+      channel: "{{ parent.channel_id }}"
+      limit: "200"
+    for_each: conversations
+    primary_key: [channel_id, ts]
+    fields:
+      channel_id: { path: parent.channel_id, type: string }
+      ts: string
+      thread_ts: string?
+      type: string?
+      subtype: string?
+      user: string?
+      bot_id: string?
+      app_id: string?
+      text: string?
+      client_msg_id: string?
+      team: string?
+      reply_count: int64?
+      reply_users_count: int64?
+      latest_reply: string?
+      subscribed: bool?
+      hidden: bool?
+      blocks: json?
+      attachments: json?
+      files: json?
+      reactions: json?
+      metadata: json?
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      thread_ts: ts
+    response:
+      records: $.messages
+      pagination:
+        cursor:
+          response: response_metadata.next_cursor
+          request: query.cursor
+    incremental:
+      cursor_field: ts
+      start_param: oldest
+      inject_into: query
+      checkpoint_key: messages_since
+      comparator: numeric
+
+  - name: thread_replies
+    path: /conversations.replies
+    query:
+      channel: "{{ parent.channel_id }}"
+      ts: "{{ parent.thread_ts }}"
+      limit: "200"
+    for_each: messages
+    primary_key: [channel_id, thread_ts, ts]
+    fields:
+      channel_id: { path: parent.channel_id, type: string }
+      thread_ts: { path: parent.thread_ts, type: string }
+      ts: string
+      type: string?
+      subtype: string?
+      user: string?
+      bot_id: string?
+      app_id: string?
+      text: string?
+      client_msg_id: string?
+      reply_count: int64?
+      blocks: json?
+      attachments: json?
+      files: json?
+      reactions: json?
+      metadata: json?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.messages
+      pagination:
+        cursor:
+          response: response_metadata.next_cursor
+          request: query.cursor
+
+  - name: files
+    path: /files.list
+    primary_key: [id]
+    fields:
+      id: string
+      created: int64?
+      timestamp: int64?
+      name: string?
+      title: string?
+      mimetype: string?
+      filetype: string?
+      pretty_type: string?
+      user: string?
+      size: int64?
+      mode: string?
+      editable: bool?
+      is_external: bool?
+      external_type: string?
+      is_public: bool?
+      public_url_shared: bool?
+      url_private: string?
+      url_private_download: string?
+      permalink: string?
+      permalink_public: string?
+      channels: json?
+      groups: json?
+      ims: json?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.files
+      pagination:
+        page:
+          number: page
+          size: count
+          page_size: 100
+          total_pages: paging.pages
+
+  - name: bookmarks
+    path: /bookmarks.list
+    query:
+      channel_id: "{{ parent.channel_id }}"
+    for_each: conversations
+    primary_key: [id]
+    fields:
+      id: string
+      channel_id: { path: parent.channel_id, type: string }
+      title: string?
+      link: string?
+      emoji: string?
+      icon_url: string?
+      type: string?
+      entity_id: string?
+      date_created: int64?
+      date_updated: int64?
+      rank: string?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.bookmarks
+      pagination: none
+
+  - name: pins
+    path: /pins.list
+    query:
+      channel: "{{ parent.channel_id }}"
+    for_each: conversations
+    primary_key: [channel_id, created]
+    fields:
+      channel_id: { path: parent.channel_id, type: string }
+      type: string
+      created: int64
+      created_by: string?
+      message: json?
+      file: json?
+      comment: json?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.items
+      pagination: none
+
+  - name: reactions
+    path: /reactions.list
+    query:
+      limit: "200"
+      full: "true"
+    primary_key: [type, channel, message_ts, file_id]
+    fields:
+      type: string
+      channel: string?
+      message_ts: { path: message.ts, type: string, nullable: true }
+      file_id: { path: file.id, type: string, nullable: true }
+      message: json?
+      file: json?
+      comment: json?
+      raw: { path: $, type: json, mode: remainder }
+    response:
+      records: $.items
+      pagination:
+        cursor:
+          response: response_metadata.next_cursor
+          request: query.cursor
+
+discovery:
+  mode: static
+  include:
+    - team
+    - users
+    - user_groups
+    - conversations
+    - messages
+    - thread_replies
+    - files
+    - bookmarks
+    - pins
+    - reactions

--- a/connectors/http/register.go
+++ b/connectors/http/register.go
@@ -6,7 +6,7 @@ import (
 )
 
 // init registers the manifest-driven HTTP source plus the bundled SaaS catalog
-// (Notion, Linear). Enable with:
+// (Notion, Linear, GitHub). Enable with:
 //
 //	import _ "github.com/galaxy-io/filament/connectors/http"
 //
@@ -16,4 +16,5 @@ func init() {
 	registry.RegisterSource("httpapi", func() filament.Source { return New() })
 	registry.RegisterSource("notion", func() filament.Source { return NewNotion() })
 	registry.RegisterSource("linear", func() filament.Source { return NewLinear() })
+	registry.RegisterSource("github", func() filament.Source { return NewGitHub() })
 }

--- a/connectors/http/register.go
+++ b/connectors/http/register.go
@@ -6,7 +6,7 @@ import (
 )
 
 // init registers the manifest-driven HTTP source plus the bundled SaaS catalog
-// (Notion, Linear, GitHub, Slack). Enable with:
+// (Notion, Linear, Attio, GitHub, Slack). Enable with:
 //
 //	import _ "github.com/galaxy-io/filament/connectors/http"
 //
@@ -16,6 +16,7 @@ func init() {
 	registry.RegisterSource("httpapi", func() filament.Source { return New() })
 	registry.RegisterSource("notion", func() filament.Source { return NewNotion() })
 	registry.RegisterSource("linear", func() filament.Source { return NewLinear() })
+	registry.RegisterSource("attio", func() filament.Source { return NewAttio() })
 	registry.RegisterSource("github", func() filament.Source { return NewGitHub() })
 	registry.RegisterSource("slack", func() filament.Source { return NewSlack() })
 }

--- a/connectors/http/register.go
+++ b/connectors/http/register.go
@@ -6,7 +6,7 @@ import (
 )
 
 // init registers the manifest-driven HTTP source plus the bundled SaaS catalog
-// (Notion, Linear, GitHub). Enable with:
+// (Notion, Linear, GitHub, Slack). Enable with:
 //
 //	import _ "github.com/galaxy-io/filament/connectors/http"
 //
@@ -17,4 +17,5 @@ func init() {
 	registry.RegisterSource("notion", func() filament.Source { return NewNotion() })
 	registry.RegisterSource("linear", func() filament.Source { return NewLinear() })
 	registry.RegisterSource("github", func() filament.Source { return NewGitHub() })
+	registry.RegisterSource("slack", func() filament.Source { return NewSlack() })
 }

--- a/connectors/http/register.go
+++ b/connectors/http/register.go
@@ -5,7 +5,7 @@ import (
 	"github.com/galaxy-io/filament/registry"
 )
 
-// init registers the manifest-driven HTTP source plus the bundled SaaS catalog
+// init registers the bundled manifest-driven SaaS catalog
 // (Notion, Linear, Attio, GitHub, Slack). Enable with:
 //
 //	import _ "github.com/galaxy-io/filament/connectors/http"
@@ -13,7 +13,6 @@ import (
 // New SaaS connectors are a catalog/<name>.yaml manifest + one line here — no
 // new module, no new dependency.
 func init() {
-	registry.RegisterSource("httpapi", func() filament.Source { return New() })
 	registry.RegisterSource("notion", func() filament.Source { return NewNotion() })
 	registry.RegisterSource("linear", func() filament.Source { return NewLinear() })
 	registry.RegisterSource("attio", func() filament.Source { return NewAttio() })

--- a/connectors/http/source_test.go
+++ b/connectors/http/source_test.go
@@ -184,6 +184,25 @@ func TestSourcePlanResourcesExpandsSelectedNotionDatabase(t *testing.T) {
 	}
 }
 
+func TestSourcePlanResourcesKeepsSingleStaticResource(t *testing.T) {
+	ctx := context.Background()
+	src := NewAttio()
+	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
+		"api_key": "test-token",
+	})); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	defer src.Teardown(ctx)
+
+	got, err := src.PlanResources(ctx, []string{"objects"}, []string{"objects"})
+	if err != nil {
+		t.Fatalf("plan resources: %v", err)
+	}
+	if len(got) != 1 || got[0] != "objects" {
+		t.Fatalf("resources = %v, want [objects]", got)
+	}
+}
+
 func TestToIngestionRecordWrapsHTTPAPIPayload(t *testing.T) {
 	rec := toIngestionRecord(pipeline.Record{
 		Resource: "databases",
@@ -351,6 +370,338 @@ func TestNewNotionSpecHidesManifestPath(t *testing.T) {
 		t.Fatalf("configure embedded notion manifest: %v", err)
 	}
 	defer src.Teardown(ctx)
+	discovered, err := src.Discover(ctx, filament.DiscoverOpts{})
+	if err != nil {
+		t.Fatalf("discover static Notion resources: %v", err)
+	}
+	want := []string{"users", "databases", "pages", "blocks"}
+	if len(discovered.Resources) != len(want) {
+		t.Fatalf("resources = %#v, want %v", discovered.Resources, want)
+	}
+	for i, name := range want {
+		if discovered.Resources[i].Name != name || discovered.Resources[i].Selector != name {
+			t.Fatalf("resource[%d] = %#v, want stable %q selector", i, discovered.Resources[i], name)
+		}
+	}
+}
+
+func TestEmbeddedCatalogMetadata(t *testing.T) {
+	tests := []struct {
+		name, description, darkLogo, lightLogo string
+		source                                 *Source
+	}{
+		{
+			name: "github", source: NewGitHub(),
+			description: "Code hosting platform for version control, collaboration, and software development workflows.",
+			darkLogo:    "https://cdn.getgalaxy.io/sources/source-icon-github-dark.svg",
+			lightLogo:   "https://cdn.getgalaxy.io/sources/source-icon-github-light.svg",
+		},
+		{
+			name: "slack", source: NewSlack(),
+			description: "Messaging and collaboration platform designed for teams to communicate and work together efficiently.",
+			darkLogo:    "https://cdn.getgalaxy.io/sources/source-icon-slack-dark.svg",
+			lightLogo:   "https://cdn.getgalaxy.io/sources/source-icon-slack-light.svg",
+		},
+		{
+			name: "attio", source: NewAttio(),
+			description: "CRM platform designed for modern teams to centralize customer data, pipelines, and workflows.",
+			darkLogo:    "https://cdn.getgalaxy.io/sources/source-icon-attio-dark.svg",
+			lightLogo:   "https://cdn.getgalaxy.io/sources/source-icon-attio-light.svg",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := test.source.Spec()
+			if spec.Description != test.description ||
+				spec.DarkLogoURL != test.darkLogo ||
+				spec.LightLogoURL != test.lightLogo {
+				t.Fatalf("metadata = %#v", spec)
+			}
+		})
+	}
+}
+
+func TestNewAttioSpecAndEmbeddedManifest(t *testing.T) {
+	ctx := context.Background()
+	src := NewAttio()
+	spec := src.Spec()
+	if spec.Name != "attio" || spec.DisplayName != "Attio" {
+		t.Fatalf("spec identity = %q/%q, want attio/Attio", spec.Name, spec.DisplayName)
+	}
+	if len(spec.Config.Fields) != 1 {
+		t.Fatalf("config fields = %#v, want api_key", spec.Config.Fields)
+	}
+	field := spec.Config.Fields[0]
+	if field.Name != "api_key" || field.Type != filament.FieldSecret || !field.Required {
+		t.Fatalf("api_key field = %#v, want required secret", field)
+	}
+	if err := src.Validate(filament.NewConfig(map[string]any{})); err == nil {
+		t.Fatal("validate without API key succeeded")
+	}
+	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
+		"api_key": "test-api-key",
+	})); err != nil {
+		t.Fatalf("configure embedded Attio manifest: %v", err)
+	}
+	defer src.Teardown(ctx)
+
+	discovered, err := src.Discover(ctx, filament.DiscoverOpts{})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	want := []string{
+		"objects", "records", "object_attributes", "object_views", "record_entries", "files",
+		"lists", "entries", "list_attributes", "list_views", "workspace_members", "notes",
+		"tasks", "threads", "meetings", "call_recordings", "transcripts", "webhooks",
+		"people", "companies", "deals", "users", "workspaces",
+	}
+	if len(discovered.Resources) != len(want) {
+		t.Fatalf("resources = %#v, want %v", discovered.Resources, want)
+	}
+	for i, name := range want {
+		if discovered.Resources[i].Name != name {
+			t.Fatalf("resource[%d] = %q, want %q", i, discovered.Resources[i].Name, name)
+		}
+	}
+}
+
+func TestAttioUsesAPIKeyAsBearerToken(t *testing.T) {
+	ctx := context.Background()
+	var authorization string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/objects":
+			fmt.Fprint(w, `{"data":[{"id":{"workspace_id":"14beef7a-99f7-4534-a87e-70b564330a4c","object_id":"97052eb9-e65e-443f-a297-f2d9a4a7f795"},"api_slug":"people","singular_noun":"Person","plural_noun":"People","created_at":"2022-11-21T13:22:49Z"}]}`)
+		case "/v2/lists":
+			fmt.Fprint(w, `{"data":[{"id":{"workspace_id":"14beef7a-99f7-4534-a87e-70b564330a4c","list_id":"33ebdbe9-e529-47c9-b894-0ba25e9c15c0"},"api_slug":"sales","name":"Sales","parent_object":["companies"],"workspace_access":null,"workspace_member_access":[],"created_by_actor":null,"created_at":"2022-11-21T13:22:49Z"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	manifestData := []byte(strings.Replace(string(attioManifest), "https://api.attio.com", api.URL, 1))
+	src := NewManifest("attio", "Attio", manifestData, filament.ConfigSchema{})
+	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "attio-key"})); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	defer src.Teardown(ctx)
+
+	var sink collectSink
+	if err := src.Extract(ctx, &sink, filament.ExtractOpts{Resources: []string{"objects", "lists"}}); err != nil {
+		t.Fatalf("extract Attio catalog: %v", err)
+	}
+	if authorization != "Bearer attio-key" {
+		t.Fatalf("Authorization = %q, want Bearer attio-key", authorization)
+	}
+	if len(sink.records) != 2 {
+		t.Fatalf("records = %#v, want one Attio object and list", sink.records)
+	}
+}
+
+func TestSlackEmbeddedManifestAndMessageFanOut(t *testing.T) {
+	ctx := context.Background()
+	var authorization string
+	var historyChannels []string
+	var replyScopes []string
+	var conversationTypes string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users.conversations":
+			conversationTypes = r.URL.Query().Get("types")
+			fmt.Fprint(w, `{"ok":true,"channels":[{"id":"C123","name":"general","is_channel":true}],"response_metadata":{"next_cursor":""}}`)
+		case "/conversations.history":
+			historyChannels = append(historyChannels, r.URL.Query().Get("channel"))
+			if r.URL.Query().Get("cursor") == "" {
+				fmt.Fprint(w, `{"ok":true,"messages":[{"type":"message","user":"U123","text":"hello","ts":"1710000000.000001"}],"response_metadata":{"next_cursor":"next-page"}}`)
+				return
+			}
+			fmt.Fprint(w, `{"ok":true,"messages":[{"type":"message","user":"U456","text":"world","ts":"1710000001.000002"}],"response_metadata":{"next_cursor":""}}`)
+		case "/conversations.replies":
+			replyScopes = append(replyScopes, r.URL.Query().Get("channel")+"|"+r.URL.Query().Get("ts"))
+			fmt.Fprintf(w, `{"ok":true,"messages":[{"type":"message","user":"U789","text":"reply","ts":"%s"}],"response_metadata":{"next_cursor":""}}`, r.URL.Query().Get("ts"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	manifestData := []byte(strings.Replace(string(slackManifest), "https://slack.com/api", api.URL, 1))
+	src := NewManifest("slack", "Slack", manifestData, filament.ConfigSchema{})
+	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"token": "xoxb-test"})); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	defer src.Teardown(ctx)
+
+	discovered, err := src.Discover(ctx, filament.DiscoverOpts{})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	wantResources := []string{"team", "users", "user_groups", "conversations", "messages", "thread_replies", "files", "bookmarks", "pins", "reactions"}
+	if len(discovered.Resources) != len(wantResources) {
+		t.Fatalf("resources = %#v, want %v", discovered.Resources, wantResources)
+	}
+	for i, name := range wantResources {
+		if discovered.Resources[i].Name != name || discovered.Resources[i].Selector != name {
+			t.Fatalf("resource[%d] = %#v, want %q", i, discovered.Resources[i], name)
+		}
+	}
+
+	var sink collectSink
+	if err := src.Extract(ctx, &sink, filament.ExtractOpts{Resources: []string{"thread_replies"}, Parallelism: 1}); err != nil {
+		t.Fatalf("extract thread replies: %v", err)
+	}
+	if authorization != "Bearer xoxb-test" {
+		t.Fatalf("Authorization = %q, want Bearer xoxb-test", authorization)
+	}
+	if conversationTypes != "public_channel" {
+		t.Fatalf("conversation types = %q, want least-privilege public_channel default", conversationTypes)
+	}
+	if len(historyChannels) != 2 || historyChannels[0] != "C123" || historyChannels[1] != "C123" {
+		t.Fatalf("history channels = %v, want C123 for both pages", historyChannels)
+	}
+	gotReplyScopes := make(map[string]bool, len(replyScopes))
+	for _, scope := range replyScopes {
+		gotReplyScopes[scope] = true
+	}
+	if len(replyScopes) != 2 ||
+		!gotReplyScopes["C123|1710000000.000001"] ||
+		!gotReplyScopes["C123|1710000001.000002"] {
+		t.Fatalf("reply scopes = %v, want inherited channel and message timestamps", replyScopes)
+	}
+	if len(sink.records) != 2 {
+		t.Fatalf("records = %#v, want two thread replies only", sink.records)
+	}
+	for _, rec := range sink.records {
+		if rec.Resource != "thread_replies" {
+			t.Fatalf("resource = %q, want thread_replies (dependencies must not emit)", rec.Resource)
+		}
+		var data map[string]any
+		if err := json.Unmarshal(rec.Data, &data); err != nil {
+			t.Fatalf("decode message: %v", err)
+		}
+		if data["channel_id"] != "C123" {
+			t.Fatalf("channel_id = %#v, want inherited C123", data["channel_id"])
+		}
+	}
+}
+
+func TestNewGitHubSpecAndEmbeddedManifest(t *testing.T) {
+	ctx := context.Background()
+	src := NewGitHub()
+	spec := src.Spec()
+	if spec.Name != "github" || spec.DisplayName != "GitHub" {
+		t.Fatalf("spec identity = %q/%q, want github/GitHub", spec.Name, spec.DisplayName)
+	}
+	if len(spec.Config.Fields) != 2 {
+		t.Fatalf("config fields = %#v, want token and organization", spec.Config.Fields)
+	}
+	fields := map[string]filament.ConfigField{}
+	for _, field := range spec.Config.Fields {
+		fields[field.Name] = field
+	}
+	if fields["token"].Type != filament.FieldSecret || !fields["token"].Required {
+		t.Fatalf("token field = %#v, want required secret", fields["token"])
+	}
+	if fields["organization"].Type != filament.FieldString || !fields["organization"].Required {
+		t.Fatalf("organization field = %#v, want required string", fields["organization"])
+	}
+	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
+		"token":        "github-token",
+		"organization": "galaxy-io",
+	})); err != nil {
+		t.Fatalf("configure embedded GitHub manifest: %v", err)
+	}
+	defer src.Teardown(ctx)
+
+	discovered, err := src.Discover(ctx, filament.DiscoverOpts{})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	want := []string{"repositories", "issues", "pull_requests"}
+	if len(discovered.Resources) != len(want) {
+		t.Fatalf("resources = %#v, want %v", discovered.Resources, want)
+	}
+	for i := range want {
+		if discovered.Resources[i].Name != want[i] {
+			t.Fatalf("resource[%d] = %q, want %q", i, discovered.Resources[i].Name, want[i])
+		}
+	}
+}
+
+func TestStaticDiscoveryChildSelectionScansButDoesNotEmitParents(t *testing.T) {
+	ctx := context.Background()
+	var parentRequests, childRequests int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/parents":
+			parentRequests++
+			fmt.Fprint(w, `[{"id":"parent-1"}]`)
+		case "/parents/parent-1/children":
+			childRequests++
+			fmt.Fprint(w, `[{"id":"child-1","name":"Child"}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	path := filepath.Join(t.TempDir(), "static.yaml")
+	data := fmt.Sprintf(`version: 1
+name: static
+connection:
+  base_url: %s
+resources:
+  - name: parents
+    path: /parents
+    primary_key: [id]
+    fields:
+      id: string
+    capture:
+      id: id
+    response:
+      records: $
+      pagination: none
+  - name: children
+    path: /parents/{parent}/children
+    params:
+      parent: parent.id
+    for_each: parents
+    primary_key: [id]
+    fields:
+      id: string
+      name: string
+    response:
+      records: $
+      pagination: none
+discovery:
+  mode: static
+  include: [parents, children]
+`, api.URL)
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	src := New()
+	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"manifest_path": path})); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	defer src.Teardown(ctx)
+
+	var sink collectSink
+	if err := src.Extract(ctx, &sink, filament.ExtractOpts{Resources: []string{"children"}}); err != nil {
+		t.Fatalf("extract children: %v", err)
+	}
+	if parentRequests != 1 || childRequests != 1 {
+		t.Fatalf("requests parent=%d child=%d, want 1 each", parentRequests, childRequests)
+	}
+	if len(sink.records) != 1 || sink.records[0].Resource != "children" {
+		t.Fatalf("emitted records = %#v, want only selected child", sink.records)
+	}
 }
 
 func TestSourceLinearHTTPAPIManifestExtractIssuesWithGraphQLPagination(t *testing.T) {


### PR DESCRIPTION
Adds Github, Attio, Slack manifests

## Slop
This pull request adds support for several new SaaS connectors (Attio, GitHub, and Slack) to the HTTP manifest-driven catalog, alongside improvements to the code structure for easier extensibility. It introduces new manifest files for GitHub and Slack, updates the registration logic, and adds tests to ensure correct resource planning for static resources.

**New SaaS Connectors:**
- Added support for Attio, GitHub, and Slack as new manifest-driven connectors, including their registration and manifest embedding in `catalog.go` and `register.go`. [[1]](diffhunk://#diff-0573f9fbd6382b3c25419a3d217b99bbecaa8676642e912461a09b3c4a9c9c91R15-R49) [[2]](diffhunk://#diff-5e6d0c2617f54b7a7ece6b74111f76d48f9721ee17d49d811a8c1d3e882f7515L8-R20)
- Implemented new manifest files for GitHub (`manifests/github.yaml`) and Slack (`manifests/slack.yaml`) with comprehensive resource definitions for each platform. [[1]](diffhunk://#diff-bff74589261866953549335bc1c102421b32448e780cefb1c9795e8aeedcee12R1-R130) [[2]](diffhunk://#diff-b9b8ad7eec1a1a42dfdfc14ae4ef869bddeff08f6441e4eda42a22a57c58475fR1-R332)

**Testing Improvements:**
- Added a test to verify that static resources are correctly retained in the resource planning logic for Attio.

**Code Structure Improvements:**
- Refactored connector initialization to use a shared `manifestOwnedConfig` function for config schemas, simplifying the addition of new connectors.

These changes make it much easier to add new SaaS integrations and ensure that the connectors behave correctly when planning resources.