### PR TITLE
setConfigPath to reconstruct secrets

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -221,9 +222,25 @@ func resolveSecretRefs(ctx context.Context, secrets filament.Secrets, ref *filam
 		if err != nil {
 			return fmt.Errorf("resolve %s secret %q for field %q: %w", role, name, field, err)
 		}
-		ref.Config[field] = string(secret.Value)
+		setConfigPath(ref.Config, field, string(secret.Value))
 	}
 	return nil
+}
+
+// setConfigPath assigns value at a dotted field path, rebuilding objects that
+// were removed when their only submitted values were secrets.
+func setConfigPath(cfg map[string]any, path string, value any) {
+	parts := strings.Split(path, ".")
+	current := cfg
+	for _, part := range parts[:len(parts)-1] {
+		nested, ok := current[part].(map[string]any)
+		if !ok {
+			nested = make(map[string]any)
+			current[part] = nested
+		}
+		current = nested
+	}
+	current[parts[len(parts)-1]] = value
 }
 
 func resolveRefConfig(ctx context.Context, secrets filament.Secrets, ref *filament.Ref, tenant filament.TenantID, role string) error {


### PR DESCRIPTION
This pull request improves how secret values are injected into nested configuration fields. The main change is the introduction of the `setConfigPath` helper function, which ensures that secrets referenced by dotted field paths are correctly assigned within nested maps, even if intermediate maps need to be created.

Configuration handling improvements:

* Added the `setConfigPath` function to assign values to nested configuration fields based on dotted paths, rebuilding intermediate objects as needed. (`runner/runner.go`)
* Updated the secret resolution logic to use `setConfigPath`, ensuring that secrets are properly injected into nested config structures instead of only at the top level. (`runner/runner.go`)

Dependency update:

* Added the `strings` package to support splitting dotted field paths. (`runner/runner.go`)