### PR TITLE
Add Granola AI connector

### DIFF
--- a/connectors/http/catalog.go
+++ b/connectors/http/catalog.go
@@ -21,6 +21,9 @@ var githubManifest []byte
 //go:embed manifests/slack.yaml
 var slackManifest []byte
 
+//go:embed manifests/granola.yaml
+var granolaManifest []byte
+
 // NewNotion returns a Source backed by the embedded Notion manifest.
 func NewNotion() *Source {
 	return NewManifestWithMetadata("notion", "Notion", "All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.", "https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg", notionManifest, manifestOwnedConfig())
@@ -44,6 +47,11 @@ func NewGitHub() *Source {
 // NewSlack returns a Source backed by the embedded Slack Web API manifest.
 func NewSlack() *Source {
 	return NewManifestWithMetadata("slack", "Slack", "Messaging and collaboration platform designed for teams to communicate and work together efficiently.", "https://cdn.getgalaxy.io/sources/source-icon-slack-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-slack-light.svg", slackManifest, manifestOwnedConfig())
+}
+
+// NewGranola returns a Source backed by the embedded Granola API manifest.
+func NewGranola() *Source {
+	return NewManifestWithMetadata("granola", "Granola", "AI notepad for back-to-back meetings that captures, enhances, and acts on meeting insights.", "https://cdn.getgalaxy.io/sources/source-icon-granola-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-granola-light.svg", granolaManifest, manifestOwnedConfig())
 }
 
 func manifestOwnedConfig() filament.ConfigSchema { return filament.ConfigSchema{} }

--- a/connectors/http/manifests/granola.yaml
+++ b/connectors/http/manifests/granola.yaml
@@ -1,0 +1,158 @@
+version: 1
+name: granola
+config:
+  api_key:
+    type: secret
+    required: true
+    help: Granola API key
+defaults:
+  method: GET
+  query:
+    page_size: "10"
+  response:
+    records: $
+    pagination:
+      cursor:
+        response: cursor
+        request: query.cursor
+        more: hasMore
+        null_terminates: true
+    error:
+      path: error
+      when_present: true
+      message_path: message
+connection:
+  base_url: https://public-api.granola.ai
+  auth:
+    bearer: config.api_key
+  headers:
+    Accept: application/json
+resources:
+  - name: notes
+    path: /v1/notes
+    incremental:
+      cursor_field: updated_at
+      start_param: updated_after
+      inject_into: query
+      checkpoint_key: notes_since
+      comparator: time
+    primary_key: [id]
+    fields:
+      id: string
+      object: string
+      title: string?
+      owner: json
+      created_at: timestamptz
+      updated_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+    capture:
+      note_id: id
+  - name: note_detail
+    path: /v1/notes/{note_id}
+    params:
+      note_id: parent.note_id
+    query:
+      include: transcript
+    for_each: notes
+    primary_key: [id]
+    fields:
+      id: string
+      object: string
+      title: string?
+      web_url: string
+      calendar_event: json?
+      attendees: json
+      folder_membership: json
+      summary_text: string
+      summary_markdown: string?
+      transcript: json?
+      raw: { path: $, type: json, mode: remainder }
+  - name: folders
+    path: /v1/folders
+    primary_key: [id]
+    fields:
+      id: string
+      object: string
+      name: string
+      parent_folder_id: string?
+      raw: { path: $, type: json, mode: remainder }
+  - name: webhook_endpoints
+    path: /v1/webhook-endpoints
+    method: GET
+    primary_key: [id]
+    fields:
+      id: string
+      object: string
+      url: string
+      url_redacted: bool
+      events: json
+      folder_ids: json
+      scopes: json
+      created_by: json?
+      enabled: bool
+      created_at: timestamptz
+      raw: { path: $, type: json, mode: remainder }
+  - name: create_webhook_endpoint
+    path: /v1/webhook-endpoints
+    method: POST
+    params:
+      url: config.url
+      scopes: config.scopes
+      events: config.events
+    body:
+      encoding: json
+      template:
+        url: "{{ config.url }}"
+        scopes: "{{ config.scopes }}"
+        events: "{{ config.events }}"
+        folder_ids: "{{ config.folder_ids }}"
+    response:
+      records: $
+      cardinality: one
+    fields:
+      id: string
+      object: string
+      url: string
+      events: json
+      scopes: json
+      created_at: timestamptz
+      signing_secret: string?
+      raw: { path: $, type: json, mode: remainder }
+  - name: delete_webhook_endpoint
+    path: /v1/webhook-endpoints/{webhook_endpoint_id}
+    method: DELETE
+    params:
+      webhook_endpoint_id: config.endpoint_id
+    response:
+      records: $
+      cardinality: one
+    fields:
+      id: string
+      object: string
+      deleted: bool
+      signing_secret: string?
+  - name: audit_events
+    path: /v1/audit
+    incremental:
+      cursor_field: occurred_at
+      start_param: occurred_after
+      inject_into: query
+      checkpoint_key: audit_since
+      comparator: time
+    primary_key: [id]
+    fields:
+      id: string
+      object: string
+      action: string
+      occurred_at: timestamptz
+      actor: json
+      data: json
+      context: json
+      raw: { path: $, type: json, mode: remainder }
+discovery:
+  mode: static
+  include:
+    - notes
+    - folders
+    - webhook_endpoints
+    - audit_events

--- a/connectors/http/register.go
+++ b/connectors/http/register.go
@@ -6,7 +6,7 @@ import (
 )
 
 // init registers the bundled manifest-driven SaaS catalog
-// (Notion, Linear, Attio, GitHub, Slack). Enable with:
+// (Notion, Linear, Attio, GitHub, Slack, Granola). Enable with:
 //
 //	import _ "github.com/galaxy-io/filament/connectors/http"
 //
@@ -18,4 +18,5 @@ func init() {
 	registry.RegisterSource("attio", func() filament.Source { return NewAttio() })
 	registry.RegisterSource("github", func() filament.Source { return NewGitHub() })
 	registry.RegisterSource("slack", func() filament.Source { return NewSlack() })
+	registry.RegisterSource("granola", func() filament.Source { return NewGranola() })
 }

--- a/docs/pages/connectors/sources/granola.mdx
+++ b/docs/pages/connectors/sources/granola.mdx
@@ -1,0 +1,77 @@
+---
+title: "Granola"
+description: "Read meeting notes, transcripts, and folders from Granola AI notepad."
+icon: "https://cdn.getgalaxy.io/sources/source-icon-granola-dark.svg"
+---
+
+Granola is a manifest-driven source — `connectors/http/manifests/granola.yaml`
+declares its resources, auth, and pagination against the shared grammar in
+`connectors/http/manifest/`; no Granola-specific Go code exists. See
+[HTTP](/pages/connectors/sources/http) for how the manifest mechanism works.
+
+## Auth
+
+A Granola API key (bearer auth with `grn_` prefix). API keys support two access
+scopes:
+
+| Scope | Access |
+|---|---|
+| `personal` | Notes you own, notes directly shared with you, notes in private folders shared with you |
+| `public` | Notes visible to everyone in the workspace, notes in the Team space |
+
+Workspace admins on Business/Enterprise plans can also create workspace API keys
+that access public workspace notes plus notes in spaces granted Granola API
+access.
+
+## Resources
+
+Five resources, statically discovered:
+
+| Resource | Path | Description |
+|---|---|---|
+| `notes` | `/v1/notes` | List of meeting notes with updated_at cursor for incremental sync |
+| `note_detail` | `/v1/notes/{note_id}` | Full note details with transcript, attendees, folder membership |
+| `folders` | `/v1/folders` | Folder hierarchy (top-level and parent_folder_id hierarchy) |
+| `webhook_endpoints` | `/v1/webhook-endpoints` | List your registered webhook endpoints |
+| `audit_events` | `/v1/audit` | Audit events for workspace activity |
+
+### Incremental sync
+
+The `notes` resource supports incremental extraction via `updated_at` (datetime
+comparator). Each run fetches notes updated since the last checkpoint, making it
+efficient for repeated syncs.
+
+### Note detail extraction
+
+`note_detail` fans out from `notes`, fetching the complete note including
+transcript (with speaker diarization) when `include=transcript` is passed. This
+is useful for extracting meeting transcription for downstream AI processing.
+
+### Webhook management
+
+Granola's webhook endpoints (available on Business/Enterprise plans) can be
+listed, created, and deleted through the connector:
+
+| Resource | Path | Description |
+|---|---|---|
+| `create_webhook_endpoint` | `/v1/webhook-endpoints` | Register a webhook endpoint (returns signing secret) |
+| `delete_webhook_endpoint` | `/v1/webhook-endpoints/{id}` | Remove a webhook endpoint by ID |
+
+Webhook deliveries are signed with HMAC-SHA256 (Standard Webhooks format), and
+the signing secret is returned on creation. Store it securely — it cannot be
+retrieved later.
+
+## Events
+
+When webhook endpoints are configured, Granola delivers events for note changes:
+
+| Event | Triggered when |
+|---|---|
+| `note.generated` | First AI summary generated for a note |
+| `note.regenerated` | AI summary regenerated |
+| `note.edited` | Note summary edited |
+| `note.access_granted` | Note shared with you |
+
+## Modes
+
+`ModeFull` and `ModeIncremental` (see [HTTP](/pages/connectors/sources/http)).


### PR DESCRIPTION
- connector/http/manifests/granola.yaml: Granola AI notepad API connector
- connector/http/catalog.go: Add NewGranola() factory
- connector/http/register.go: Register granola connector
- docs/pages/connectors/sources/granola.mdx: Connector documentation

Granola connector supports:
- notes endpoint (with incremental sync on updated_at)
- note_detail endpoint (full note with transcript)
- folders endpoint (hierarchical folder structure)
- webhook management endpoints (create/list/delete)
- audit_events endpoint (workspace activity log)
- Bearer token authentication (API key)