### PR TITLE
Atterpac/validate checks

### DIFF
--- a/connectors/clickhouse/sink/clickhouse.go
+++ b/connectors/clickhouse/sink/clickhouse.go
@@ -74,8 +74,9 @@ type table struct {
 func New() *Sink { return &Sink{} }
 
 var (
-	_ filament.Sink        = (*Sink)(nil)
-	_ filament.Schematized = (*Sink)(nil)
+	_ filament.Sink            = (*Sink)(nil)
+	_ filament.LiveValidatable = (*Sink)(nil)
+	_ filament.Schematized     = (*Sink)(nil)
 )
 
 // Spec describes the sink's configuration and supported write policies.
@@ -113,6 +114,25 @@ func (s *Sink) Spec() filament.SinkSpec {
 
 // Name identifies this sink implementation.
 func (s *Sink) Name() string { return "clickhouse" }
+
+// TestConnection pings ClickHouse through a short-lived connection without
+// creating the configured destination database.
+func (s *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
+	opts, err := connectionOptions(cfg)
+	if err != nil {
+		return fmt.Errorf("clickhouse sink: connection config: %w", err)
+	}
+	opts.Auth.Database = defaultDatabase
+	conn, err := ch.Open(opts)
+	if err != nil {
+		return fmt.Errorf("clickhouse sink: open: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if err := conn.Ping(ctx); err != nil {
+		return fmt.Errorf("clickhouse sink: ping over %s to %s: %w", opts.Protocol, opts.Addr[0], err)
+	}
+	return nil
+}
 
 // Open connects to ClickHouse and prepares per-run state.
 func (s *Sink) Open(ctx context.Context, run filament.RunSpec) error {

--- a/connectors/http/connector.go
+++ b/connectors/http/connector.go
@@ -18,6 +18,8 @@ import (
 	"github.com/galaxy-io/filament/connectors/http/manifest"
 	"github.com/galaxy-io/filament/connectors/http/obs"
 	"github.com/galaxy-io/filament/connectors/http/request"
+	"github.com/galaxy-io/filament/connectors/http/response"
+	"github.com/galaxy-io/filament/connectors/http/template"
 )
 
 // Capture is one parent record's flattened, captured field map keyed by the
@@ -176,6 +178,39 @@ func (c *Connector) Configure(ctx context.Context) error {
 	// auth strategies grow startup probes (oauth2 token preflight, etc.) they
 	// will need ctx to honour caller deadlines.
 	_ = ctx
+	return nil
+}
+
+// TestConnection performs one authenticated request against the first
+// top-level, non-streaming resource in the manifest. It deliberately stops
+// after the first response: validation should prove that the credentials are
+// accepted without walking pagination or extracting user data.
+func (c *Connector) TestConnection(ctx context.Context) error {
+	if c.manifest == nil || c.builder == nil || c.client == nil {
+		return fmt.Errorf("connector is not configured")
+	}
+	var probe *manifest.Resource
+	for i := range c.manifest.Resources {
+		candidate := &c.manifest.Resources[i]
+		if candidate.Parent == nil && candidate.Mode != "stream" {
+			probe = candidate
+			break
+		}
+	}
+	if probe == nil {
+		return fmt.Errorf("manifest has no top-level request suitable for connection validation")
+	}
+
+	build := func(ctx context.Context) (*http.Request, error) {
+		return c.builder.Build(ctx, *probe, template.Scope{Config: c.creds})
+	}
+	_, body, err := c.doRequest(ctx, build, probe.Name)
+	if err != nil {
+		return fmt.Errorf("connection probe: %w", err)
+	}
+	if err := response.New(probe.Response).CheckError(body); err != nil {
+		return fmt.Errorf("connection probe: %w", err)
+	}
 	return nil
 }
 

--- a/connectors/http/manifests/linear.yaml
+++ b/connectors/http/manifests/linear.yaml
@@ -11,6 +11,12 @@ connection:
     header:
       name: Authorization
       value: config.api_key
+defaults:
+  response:
+    error:
+      path: errors
+      when_present: true
+      message_path: errors.0.message
 resources:
   - name: teams
     path: /graphql

--- a/connectors/http/source.go
+++ b/connectors/http/source.go
@@ -44,6 +44,7 @@ type Source struct {
 var (
 	_ filament.Source          = (*Source)(nil)
 	_ filament.Discoverable    = (*Source)(nil)
+	_ filament.LiveValidatable = (*Source)(nil)
 	_ filament.Resumable       = (*Source)(nil)
 	_ filament.ResumePlanner   = (*Source)(nil)
 	_ filament.ResourcePlanner = (*Source)(nil)
@@ -155,21 +156,10 @@ func (s *Source) Configure(ctx context.Context, cfg filament.Config) error {
 	if err := s.Validate(cfg); err != nil {
 		return err
 	}
-	c := &Connector{}
-	if len(s.manifestData) > 0 {
-		c.SetManifestData(s.manifestData)
-	} else {
-		c.SetManifestPath(cfg.String("manifest_path"))
+	c, err := s.connectorForConfig(cfg)
+	if err != nil {
+		return err
 	}
-	var configSpecs map[string]manifest.ConfigSpec
-	if len(s.manifestData) > 0 {
-		if parsed, err := manifest.Parse(s.manifestData); err == nil {
-			configSpecs = parsed.Config
-		}
-	} else if parsed, err := manifest.Load(cfg.String("manifest_path")); err == nil {
-		configSpecs = parsed.Config
-	}
-	c.SetCredentials(credentialsFromConfig(cfg, configSpecs))
 	if err := c.Validate(); err != nil {
 		return fmt.Errorf("httpapi source: validate connector: %w", err)
 	}
@@ -178,6 +168,51 @@ func (s *Source) Configure(ctx context.Context, cfg filament.Config) error {
 	}
 	s.connector = c
 	return nil
+}
+
+// TestConnection builds the manifest connector and performs a single,
+// authenticated API request without extracting or persisting any records.
+func (s *Source) TestConnection(ctx context.Context, cfg filament.Config) error {
+	if err := s.Validate(cfg); err != nil {
+		return err
+	}
+	c, err := s.connectorForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	if err := c.Configure(ctx); err != nil {
+		return fmt.Errorf("%s source: configure connection probe: %w", s.name, err)
+	}
+	defer func() { _ = c.Teardown(ctx) }()
+	if err := c.TestConnection(ctx); err != nil {
+		return fmt.Errorf("%s source: %w", s.name, err)
+	}
+	return nil
+}
+
+func (s *Source) connectorForConfig(cfg filament.Config) (*Connector, error) {
+	c := &Connector{}
+	if len(s.manifestData) > 0 {
+		c.SetManifestData(s.manifestData)
+	} else {
+		c.SetManifestPath(cfg.String("manifest_path"))
+	}
+	var configSpecs map[string]manifest.ConfigSpec
+	if len(s.manifestData) > 0 {
+		parsed, err := manifest.Parse(s.manifestData)
+		if err != nil {
+			return nil, fmt.Errorf("%s source: parse manifest: %w", s.name, err)
+		}
+		configSpecs = parsed.Config
+	} else {
+		parsed, err := manifest.Load(cfg.String("manifest_path"))
+		if err != nil {
+			return nil, fmt.Errorf("%s source: load manifest: %w", s.name, err)
+		}
+		configSpecs = parsed.Config
+	}
+	c.SetCredentials(credentialsFromConfig(cfg, configSpecs))
+	return c, nil
 }
 
 // Discover enumerates selectable resources, falling back to the manifest's

--- a/connectors/http/source_test.go
+++ b/connectors/http/source_test.go
@@ -67,6 +67,58 @@ func TestSourceExtractFromSeedsPaginationCursor(t *testing.T) {
 	}
 }
 
+func TestSourceTestConnectionMakesOneAuthenticatedRequest(t *testing.T) {
+	var calls int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method != http.MethodGet || r.URL.Path != "/probe" {
+			t.Errorf("request = %s %s, want GET /probe", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("Authorization") != "Bearer good-token" {
+			fmt.Fprint(w, `{"error":"invalid token"}`)
+			return
+		}
+		fmt.Fprint(w, `{"items":[]}`)
+	}))
+	defer api.Close()
+
+	data := []byte(fmt.Sprintf(`
+version: 1
+name: probe
+config:
+  token: {type: secret, required: true}
+connection:
+  base_url: %s
+  auth:
+    bearer: config.token
+resources:
+  - name: probe
+    path: /probe
+    response:
+      records: $.items
+      error:
+        path: error
+        when_present: true
+`, api.URL))
+	src := NewManifest("probe", "Probe", data, filament.ConfigSchema{})
+	if err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
+		"token": "good-token",
+	})); err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("requests = %d, want exactly 1", calls)
+	}
+
+	err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
+		"token": "bad-token",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "invalid token") {
+		t.Fatalf("bad credentials error = %v, want wrapped API error", err)
+	}
+}
+
 func TestSourcePlanResumeExpandsManifestResources(t *testing.T) {
 	ctx := context.Background()
 	api := httptest.NewServer(http.NotFoundHandler())

--- a/connectors/iceberg/iceberg.go
+++ b/connectors/iceberg/iceberg.go
@@ -87,9 +87,10 @@ func New() *Sink {
 }
 
 var (
-	_ filament.Sink          = (*Sink)(nil)
-	_ filament.Transactional = (*Sink)(nil)
-	_ filament.Schematized   = (*Sink)(nil)
+	_ filament.Sink            = (*Sink)(nil)
+	_ filament.LiveValidatable = (*Sink)(nil)
+	_ filament.Transactional   = (*Sink)(nil)
+	_ filament.Schematized     = (*Sink)(nil)
 )
 
 // Spec reports the sink's capabilities and configuration surface.
@@ -133,6 +134,24 @@ func (s *Sink) Spec() filament.SinkSpec {
 
 // Name identifies this sink implementation.
 func (s *Sink) Name() string { return "iceberg" }
+
+// TestConnection loads the configured catalog and performs a read-only
+// namespace listing. This exercises catalog authentication without creating
+// a namespace or table.
+func (s *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
+	setup, err := buildCatalogSetup(cfg)
+	if err != nil {
+		return fmt.Errorf("iceberg sink: %w", err)
+	}
+	cat, err := catalog.Load(ctx, "iceberg-validation", setup.Properties)
+	if err != nil {
+		return fmt.Errorf("iceberg sink: open catalog: %w", err)
+	}
+	if _, err := cat.ListNamespaces(ctx, nil); err != nil {
+		return fmt.Errorf("iceberg sink: list namespaces: %w", err)
+	}
+	return nil
+}
 
 // Open connects to the catalog and prepares per-resource tables for the run.
 func (s *Sink) Open(ctx context.Context, run filament.RunSpec) error {

--- a/connectors/mysql/sink/mysql.go
+++ b/connectors/mysql/sink/mysql.go
@@ -55,8 +55,9 @@ func (t *Sink) resumableFor(resource string) bool {
 func New() *Sink { return &Sink{} }
 
 var (
-	_ filament.Sink        = (*Sink)(nil)
-	_ filament.Schematized = (*Sink)(nil)
+	_ filament.Sink            = (*Sink)(nil)
+	_ filament.LiveValidatable = (*Sink)(nil)
+	_ filament.Schematized     = (*Sink)(nil)
 )
 
 // Spec describes the sink's config fields and write capabilities.
@@ -91,6 +92,30 @@ func (t *Sink) Spec() filament.SinkSpec {
 
 // Name identifies this sink implementation.
 func (t *Sink) Name() string { return "mysql" }
+
+// TestConnection pings MySQL through a short-lived pool. It intentionally
+// clears the database name so validating a new destination does not require
+// that Open's CREATE DATABASE step has already run.
+func (t *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
+	dsn := cfg.Secret("dsn")
+	if dsn == "" {
+		return fmt.Errorf("mysql sink: dsn is required")
+	}
+	mc, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return fmt.Errorf("mysql sink: parse dsn: %w", err)
+	}
+	mc.DBName = ""
+	db, err := sql.Open("mysql", mc.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("mysql sink: open: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("mysql sink: ping: %w", err)
+	}
+	return nil
+}
 
 // Open reads dsn/database and opens a pool sized for the run's write parallelism. It
 // does no DDL beyond CREATE DATABASE — tables are created per resource by

--- a/connectors/mysql/source/mysql.go
+++ b/connectors/mysql/source/mysql.go
@@ -149,7 +149,14 @@ func (s *Source) TestConnection(ctx context.Context, cfg filament.Config) error 
 	if err := s.Validate(cfg); err != nil {
 		return err
 	}
-	db, err := sql.Open("mysql", cfg.Secret("dsn"))
+	mc, err := mysql.ParseDSN(cfg.Secret("dsn"))
+	if err != nil {
+		return fmt.Errorf("mysql source: parse dsn: %w", err)
+	}
+	if database := cfg.String("database"); database != "" {
+		mc.DBName = database
+	}
+	db, err := sql.Open("mysql", mc.FormatDSN())
 	if err != nil {
 		return fmt.Errorf("mysql source: open: %w", err)
 	}

--- a/connectors/object/s3.go
+++ b/connectors/object/s3.go
@@ -90,7 +90,10 @@ type upload struct {
 // New returns an unconfigured sink. Open wires it to S3.
 func New() *Sink { return &Sink{uploads: map[string]*upload{}} }
 
-var _ filament.Sink = (*Sink)(nil)
+var (
+	_ filament.Sink            = (*Sink)(nil)
+	_ filament.LiveValidatable = (*Sink)(nil)
+)
 
 // Spec describes the sink's config fields and write capabilities.
 func (s *Sink) Spec() filament.SinkSpec {
@@ -121,6 +124,23 @@ func (s *Sink) Spec() filament.SinkSpec {
 
 // Name identifies this sink implementation.
 func (s *Sink) Name() string { return "s3" }
+
+// TestConnection resolves the configured credential chain and checks access
+// to the destination bucket without creating an object.
+func (s *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
+	bucket := cfg.String("bucket")
+	if bucket == "" {
+		return fmt.Errorf("s3 sink: bucket is required")
+	}
+	client, err := s3Client(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	if _, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		return fmt.Errorf("s3 sink: access bucket %q: %w", bucket, err)
+	}
+	return nil
+}
 
 // Open reads the sink config, builds an S3 client, and resets per-run state.
 func (s *Sink) Open(ctx context.Context, run filament.RunSpec) error {
@@ -154,28 +174,41 @@ func (s *Sink) Open(ctx context.Context, run filament.RunSpec) error {
 		return &b
 	}}
 
+	client, err := s3Client(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	s.client = client
+	return nil
+}
+
+func s3Client(ctx context.Context, cfg filament.Config) (*s3.Client, error) {
 	var loadOpts []func(*awscfg.LoadOptions) error
 	if region := cfg.String("region"); region != "" {
 		loadOpts = append(loadOpts, awscfg.WithRegion(region))
 	}
-	if id, secret := cfg.Secret("access_key_id"), cfg.Secret("secret_access_key"); id != "" && secret != "" {
+	id, secret := cfg.Secret("access_key_id"), cfg.Secret("secret_access_key")
+	if (id == "") != (secret == "") {
+		return nil, fmt.Errorf("s3 sink: access_key_id and secret_access_key must be provided together")
+	}
+	if id != "" {
 		loadOpts = append(loadOpts, awscfg.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(id, secret, ""),
 		))
 	}
 	awsCfg, err := awscfg.LoadDefaultConfig(ctx, loadOpts...)
 	if err != nil {
-		return fmt.Errorf("s3 sink: load aws config: %w", err)
+		return nil, fmt.Errorf("s3 sink: load aws config: %w", err)
 	}
 
 	endpoint := cfg.String("endpoint")
-	s.client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
 		if endpoint != "" {
 			o.BaseEndpoint = aws.String(endpoint)
 			o.UsePathStyle = true // MinIO and most non-AWS gateways need path-style addressing.
 		}
 	})
-	return nil
+	return client, nil
 }
 
 // Write appends each record as one NDJSON line to its resource's part buffer. A

--- a/connectors/postgres/sink/postgres.go
+++ b/connectors/postgres/sink/postgres.go
@@ -57,8 +57,9 @@ const defaultSchema = "public"
 func New() *Sink { return &Sink{schema: defaultSchema} }
 
 var (
-	_ filament.Sink        = (*Sink)(nil)
-	_ filament.Schematized = (*Sink)(nil)
+	_ filament.Sink            = (*Sink)(nil)
+	_ filament.LiveValidatable = (*Sink)(nil)
+	_ filament.Schematized     = (*Sink)(nil)
 )
 
 // Spec describes the sink's config fields and write capabilities.
@@ -92,6 +93,28 @@ func (t *Sink) Spec() filament.SinkSpec {
 
 // Name identifies this sink implementation.
 func (t *Sink) Name() string { return "postgres" }
+
+// TestConnection opens a short-lived pool and verifies the configured
+// credentials without creating the destination schema.
+func (t *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
+	dsn := cfg.Secret("dsn")
+	if dsn == "" {
+		return fmt.Errorf("postgres sink: dsn is required")
+	}
+	poolCfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return fmt.Errorf("postgres sink: parse dsn: %w", err)
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return fmt.Errorf("postgres sink: open pool: %w", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		return fmt.Errorf("postgres sink: ping: %w", err)
+	}
+	return nil
+}
 
 // Open reads dsn/schema and opens a pool sized for the run's write parallelism. It
 // does no DDL — tables are created per resource by EnsureSchema before extraction.

--- a/server/connectors.go
+++ b/server/connectors.go
@@ -106,6 +106,13 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 		if err := validateConfigSchema(sink.Spec().Config, cfg, filament.ScopeConnection); err != nil {
 			return connect.NewResponse(validationError(err.Error())), nil
 		}
+		if req.Msg.GetLive() {
+			if live, ok := sink.(filament.LiveValidatable); ok {
+				if err := live.TestConnection(ctx, cfg); err != nil {
+					return connect.NewResponse(validationError(err.Error())), nil
+				}
+			}
+		}
 	default:
 		return connect.NewResponse(validationError("connector kind is required")), nil
 	}

--- a/server/connectors_test.go
+++ b/server/connectors_test.go
@@ -43,6 +43,48 @@ func (s *columnSource) CursorColumns(_ context.Context, resource string) ([]fila
 	}}, nil
 }
 
+type liveProbeSink struct {
+	probes *atomic.Int32
+	err    error
+}
+
+func (s *liveProbeSink) Spec() filament.SinkSpec                      { return filament.SinkSpec{Name: "live-sink"} }
+func (s *liveProbeSink) Open(context.Context, filament.RunSpec) error { return nil }
+func (s *liveProbeSink) Apply(context.Context, filament.Batch, filament.ApplyOptions) (filament.WriteReceipt, error) {
+	return filament.WriteReceipt{}, nil
+}
+func (s *liveProbeSink) Commit(context.Context) error { return nil }
+func (s *liveProbeSink) Abort(context.Context) error  { return nil }
+func (s *liveProbeSink) Name() string                 { return "live-sink" }
+func (s *liveProbeSink) TestConnection(context.Context, filament.Config) error {
+	s.probes.Add(1)
+	return s.err
+}
+
+func TestValidateConfigRunsLiveSinkProbe(t *testing.T) {
+	probes := &atomic.Int32{}
+	sinks := registry.NewSinks()
+	sinks.Register("live-sink", func() filament.Sink {
+		return &liveProbeSink{probes: probes, err: context.DeadlineExceeded}
+	})
+	api := New(registry.NewSources(), sinks, memory.New(), nil, nil)
+
+	response, err := api.ValidateConfig(context.Background(), connect.NewRequest(&ingestionv1.ValidateConfigRequest{
+		Connector: "live-sink",
+		Kind:      ingestionv1.ConnectorKind_CONNECTOR_KIND_SINK,
+		Live:      true,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Msg.GetValid() {
+		t.Fatalf("response = %#v, want validation failure", response.Msg)
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("live probes = %d, want 1", got)
+	}
+}
+
 func TestGetConnector(t *testing.T) {
 	sources := registry.NewSources()
 	sources.Register("columns", func() filament.Source { return &columnSource{counts: &columnSourceCounts{}} })

--- a/source.go
+++ b/source.go
@@ -181,7 +181,7 @@ func ReplicationOf(src Source, cfg Config) ReplicationMode {
 }
 
 // LiveValidatable is the optional contract for probing connectivity with a
-// config before any run uses it.
+// config before any run uses it. Both sources and sinks may implement it.
 type LiveValidatable interface {
 	TestConnection(ctx context.Context, cfg Config) error
 }


### PR DESCRIPTION
Enables validation checks for http manifests as well as all sinks

## Slop
This pull request introduces a new "live validation" capability to both source and sink connectors, allowing them to actively test their connection to external systems before a run begins. This is implemented through a new `LiveValidatable` interface, which is now adopted by several connectors (S3, MySQL, PostgreSQL, Iceberg, ClickHouse, HTTP). The server is updated to invoke this live validation when requested, and comprehensive tests are added to ensure correct behavior. Additionally, the HTTP connector and source are refactored to support live connection probing, and error handling is improved for S3 credentials.

### Live validation interface and server integration

* Added the new `LiveValidatable` interface, which defines a `TestConnection` method for both sources and sinks to implement live connection probing. The server now invokes this method during config validation when requested. [[1]](diffhunk://#diff-a4d006ab5233eeae48e5dc55c19a888b1a1ab4edcda548ba466e8a88909ed063L184-R184) [[2]](diffhunk://#diff-aabadc73c61e744ce697e14fceb0f4f0a9e958469294f49da36dbaeaa0e96318R109-R115)
* Updated test coverage to ensure that live validation is invoked and failures are correctly reported.

### Connector implementations of live validation

* Implemented `TestConnection` for S3, MySQL, PostgreSQL, Iceberg, and ClickHouse sinks, each performing a minimal connectivity/authentication check without mutating state. [[1]](diffhunk://#diff-f813d65982bc9ae9f96557dc4b8fcbcf9ca1c86fc14948afe2537ba3f45d7866R128-R144) [[2]](diffhunk://#diff-b2204f1b5099166c95501c9cda4b1e3577b72f17bc6e2597614e27f141dfeb73R96-R119) [[3]](diffhunk://#diff-5a8f22685d8ecdf1c6d7d392bda5b18c8443dd6a9a5f0ee22bbae2c0d485f3bfR97-R118) [[4]](diffhunk://#diff-c1d9f5d766b51ebd1ebfd80f5e40fd90021777154f8b15283de55024cb57f4a5R138-R155) [[5]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3R118-R136)
* Updated the MySQL source to improve DSN parsing and error handling during live validation.
* Registered the `LiveValidatable` interface in all relevant connectors. [[1]](diffhunk://#diff-f813d65982bc9ae9f96557dc4b8fcbcf9ca1c86fc14948afe2537ba3f45d7866L93-R96) [[2]](diffhunk://#diff-b2204f1b5099166c95501c9cda4b1e3577b72f17bc6e2597614e27f141dfeb73R59) [[3]](diffhunk://#diff-5a8f22685d8ecdf1c6d7d392bda5b18c8443dd6a9a5f0ee22bbae2c0d485f3bfR61) [[4]](diffhunk://#diff-c1d9f5d766b51ebd1ebfd80f5e40fd90021777154f8b15283de55024cb57f4a5R91) [[5]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3R78) [[6]](diffhunk://#diff-04d4359d2af0918a0e9a73886927e8694fd0635e74c68b7e9c93aab1e127afcdR47)

### HTTP connector and source enhancements

* Added `TestConnection` to the HTTP connector and source, performing a single authenticated request to validate credentials without extracting or persisting records. [[1]](diffhunk://#diff-0cc45536d4953feb739f2332ced4a39883914cdc7ef075460628de2929c31129R184-R216) [[2]](diffhunk://#diff-04d4359d2af0918a0e9a73886927e8694fd0635e74c68b7e9c93aab1e127afcdR159-R193)
* Refactored the HTTP source to build connectors for live validation and improved manifest loading error handling.
* Added a test to verify that HTTP source live validation makes exactly one authenticated request and correctly handles authentication errors.

### S3 connector improvements

* Refactored S3 client construction to better handle credential pairs and provide more informative errors if credentials are missing or mismatched.

### HTTP manifest improvements

* Added default error response handling to the Linear HTTP manifest, ensuring live validation can detect and report API errors.