### PR TITLE
Catalog adds + use logger and compile it

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -53,6 +53,7 @@ type Config struct {
 	Sources filament.SourceRegistry
 	Sinks   filament.SinkRegistry
 	UI      http.Handler
+	Log     filament.Logger
 }
 
 // Option mutates a Config. Options passed to Run override the defaults.
@@ -82,6 +83,9 @@ func WithSecrets(s filament.Secrets) Option { return func(c *Config) { c.Secrets
 // precedence; everything else falls through to the UI handler.
 func WithUI(h http.Handler) Option { return func(c *Config) { c.UI = h } }
 
+// WithLogger sets the structured logger used by the API and runtime modules.
+func WithLogger(log filament.Logger) Option { return func(c *Config) { c.Log = log } }
+
 func newConfig(opts ...Option) Config {
 	c := Config{
 		Bus:     inproc.New(),
@@ -104,13 +108,13 @@ func Run(ctx context.Context, opts ...Option) error {
 
 	orch := orchestrator.New()
 	api := server.New(cfg.Sources, cfg.Sinks, cfg.Store, orch, cfg.Bus,
-		server.WithSecrets(cfg.Secrets), server.WithMetricsStore(cfg.Metrics))
+		server.WithSecrets(cfg.Secrets), server.WithMetricsStore(cfg.Metrics), server.WithLogger(cfg.Log))
 	scheduleStore, ok := cfg.Store.(filament.ScheduleStore)
 	if !ok {
 		return fmt.Errorf("datastore %q does not support schedules", cfg.Store.Name())
 	}
 	sched := scheduler.New(scheduleStore)
-	deps := module.Deps{Bus: cfg.Bus, DataStore: cfg.Store, Secrets: cfg.Secrets, Sources: cfg.Sources, Sinks: cfg.Sinks}
+	deps := module.Deps{Bus: cfg.Bus, DataStore: cfg.Store, Secrets: cfg.Secrets, Sources: cfg.Sources, Sinks: cfg.Sinks, Log: cfg.Log}
 	mods, err := module.MountAll(ctx, deps, tracker.New(), engine.New(), orch, sched)
 	if err != nil {
 		return fmt.Errorf("mount: %w", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -135,7 +135,7 @@ func run(ctx context.Context, migrateOnly bool) error {
 	}
 	orch := orchestrator.New()
 	api := server.New(registry.DefaultSources, registry.DefaultSinks, store, orch, bus,
-		server.WithSecrets(secrets), server.WithMetricsStore(metricStore))
+		server.WithSecrets(secrets), server.WithMetricsStore(metricStore), server.WithLogger(lg))
 	mods, err := module.MountAll(ctx,
 		module.Deps{Bus: bus, DataStore: store, Sources: registry.DefaultSources, Sinks: registry.DefaultSinks, Log: lg, Metrics: metrics, Tracer: tracer},
 		orch,

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -15,6 +15,7 @@ import (
 	natsgo "github.com/nats-io/nats.go"
 
 	"github.com/galaxy-io/filament/app"
+	"github.com/galaxy-io/filament/cmd/internal/logger"
 	natsbus "github.com/galaxy-io/filament/eventbus/nats"
 	"github.com/galaxy-io/filament/events"
 	secretenv "github.com/galaxy-io/filament/secret/env"
@@ -34,6 +35,7 @@ func main() {
 }
 
 func run(ctx context.Context) error {
+	lg := logger.New()
 	dir := os.Getenv("NATS_STORE_DIR")
 	if dir == "" {
 		dir = filepath.Join(os.TempDir(), "filament-standalone")
@@ -69,6 +71,7 @@ func run(ctx context.Context) error {
 
 	return app.Run(ctx,
 		app.WithBus(bus),
+		app.WithLogger(lg),
 		app.WithSecrets(secretenv.New()),
 		app.WithUI(ui.Handler()),
 	)

--- a/connectors/http/stream.go
+++ b/connectors/http/stream.go
@@ -148,13 +148,6 @@ func (c *Connector) streamResource(
 
 	c.appendCaptures(res.Name, captured)
 
-	c.reporter.Report(pipeline.Event{
-		Type:         pipeline.EventResourceComplete,
-		Resource:     res.Name,
-		Connector:    c.manifest.Name,
-		TotalRecords: totalRecords,
-	})
-
 	return totalRecords, nil
 }
 

--- a/events/catalog.go
+++ b/events/catalog.go
@@ -28,6 +28,10 @@ type (
 	RunPartialEvent struct {
 		Error string `json:"error"`
 	}
+	// RunCanceledEvent marks a run stopped by a cancellation request.
+	RunCanceledEvent struct{}
+	// RunPausedEvent marks a run suspended for a later continuation.
+	RunPausedEvent struct{}
 	// HeartbeatEvent is the worker liveness and resource usage signal: the
 	// pod's cumulative cgroup CPU time and its current/peak working set.
 	HeartbeatEvent struct {
@@ -107,6 +111,8 @@ var (
 	RunCompleted = define[RunCompletedEvent]("run.completed")
 	RunFailed    = define[RunFailedEvent]("run.failed")
 	RunPartial   = define[RunPartialEvent]("run.partial")
+	RunCanceled  = define[RunCanceledEvent]("run.canceled")
+	RunPaused    = define[RunPausedEvent]("run.paused")
 	Heartbeat    = define[HeartbeatEvent]("run.heartbeat")
 
 	ResourceStarted   = define[ResourceStartedEvent]("resource.started")

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -50,6 +50,25 @@ func TestUnmarshalUnknownType(t *testing.T) {
 	}
 }
 
+func TestRunControlEventsAreCataloged(t *testing.T) {
+	for _, event := range []struct {
+		name string
+		data any
+	}{
+		{name: RunCanceled.Name(), data: RunCanceledEvent{}},
+		{name: RunPaused.Name(), data: RunPausedEvent{}},
+	} {
+		b, err := Marshal(Fact{Envelope: env(), Name: event.name, Data: event.data})
+		if err != nil {
+			t.Fatalf("marshal %s: %v", event.name, err)
+		}
+		fact, err := Unmarshal(b)
+		if err != nil || fact.Name != event.name {
+			t.Fatalf("round trip %s = %#v, %v", event.name, fact, err)
+		}
+	}
+}
+
 func TestCodecRoundTrip(t *testing.T) {
 	in := Fact{Envelope: env(), Name: RunFailed.Name(), Data: RunFailedEvent{Error: "boom"}}
 	b, err := Codec.Encode(in)

--- a/internal/runs/runs.go
+++ b/internal/runs/runs.go
@@ -44,22 +44,46 @@ func Submit(ctx context.Context, bus eventbus.Bus, ds filament.DataStore, req fi
 		RequestedAt: now,
 	}); err != nil {
 		if errors.Is(err, filament.ErrVersionConflict) {
-			return id, nil // already submitted — the winning intake dispatched it
+			state, loadErr := ds.LoadRun(ctx, id)
+			if loadErr != nil {
+				return "", fmt.Errorf("runs: inspect existing run %q: %w", id, loadErr)
+			}
+			// Requested with no observed start is also the shape left behind when
+			// dispatch and its compensating delete both failed. Publishing the
+			// idempotent trigger again repairs that row; progressed runs need no
+			// further dispatch.
+			if state.Status != filament.RunRequested || !state.StartedAt.IsZero() {
+				return id, nil
+			}
+			now = state.RequestedAt
+			if now.IsZero() {
+				now = time.Now()
+			}
+			if err := dispatch(ctx, bus, state.Request.Tenant, id, now); err != nil {
+				return "", err
+			}
+			return id, nil
 		}
 		return "", fmt.Errorf("runs: save run %q: %w", id, err)
 	}
 
-	env := events.Envelope{Tenant: req.Tenant, Run: id, At: now}
-	if err := events.Emit(ctx, bus, events.RunRequested, env, events.RunRequestedEvent{}); err != nil {
+	if err := dispatch(ctx, bus, req.Tenant, id, now); err != nil {
 		// A row with no trigger would sit Requested forever — reap it and
 		// surface the failure so the caller retries the whole submit.
-		err = fmt.Errorf("runs: dispatch run %q: %w", id, err)
 		if derr := ds.DeleteRun(ctx, id); derr != nil {
 			err = errors.Join(err, fmt.Errorf("runs: delete undispatched run %q: %w", id, derr))
 		}
 		return "", err
 	}
 	return id, nil
+}
+
+func dispatch(ctx context.Context, bus eventbus.Bus, tenant filament.TenantID, id filament.RunID, at time.Time) error {
+	env := events.Envelope{Tenant: tenant, Run: id, At: at}
+	if err := events.Emit(ctx, bus, events.RunRequested, env, events.RunRequestedEvent{}); err != nil {
+		return fmt.Errorf("runs: dispatch run %q: %w", id, err)
+	}
+	return nil
 }
 
 // Schedule pre-creates the run for an upcoming schedule occurrence: persisted

--- a/internal/runs/runs_test.go
+++ b/internal/runs/runs_test.go
@@ -1,12 +1,46 @@
 package runs
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/datastore/memory"
+	"github.com/galaxy-io/filament/eventbus"
+	"github.com/galaxy-io/filament/eventbus/inproc"
+	"github.com/galaxy-io/filament/events"
 )
+
+type failPublishBus struct {
+	eventbus.Bus
+	failures int
+}
+
+func (b *failPublishBus) Publish(ctx context.Context, subject string, payload any) error {
+	if b.failures > 0 {
+		b.failures--
+		return errors.New("publish unavailable")
+	}
+	return b.Bus.Publish(ctx, subject, payload)
+}
+
+type failDeleteStore struct {
+	filament.DataStore
+	failures int
+}
+
+func (s *failDeleteStore) DeleteRun(ctx context.Context, id filament.RunID) error {
+	if s.failures > 0 {
+		s.failures--
+		return errors.New("delete unavailable")
+	}
+	return s.DataStore.DeleteRun(ctx, id)
+}
 
 func TestIDForReturnsUUID(t *testing.T) {
 	req := filament.RunRequest{Tenant: filament.DefaultTenantID, IdempotencyKey: "client-token"}
@@ -23,5 +57,43 @@ func TestIDForReturnsUUID(t *testing.T) {
 		t.Fatalf("random ID unexpectedly matched deterministic ID %q", first)
 	} else if _, err := uuid.Parse(string(random)); err != nil {
 		t.Fatalf("IDFor returned a non-UUID random ID %q: %v", random, err)
+	}
+}
+
+func TestSubmitRetryRedispatchesStrandedRequestedRun(t *testing.T) {
+	ctx := context.Background()
+	baseBus := inproc.New()
+	sub, err := baseBus.Subscribe(events.SubjectPattern(events.RunRequested), eventbus.SubOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	bus := &failPublishBus{Bus: baseBus, failures: 1}
+	store := &failDeleteStore{DataStore: memory.New(), failures: 1}
+	req := filament.RunRequest{Tenant: filament.DefaultTenantID, IdempotencyKey: "retry-me"}
+	id := IDFor(req)
+
+	if _, err := Submit(ctx, bus, store, req); err == nil || !strings.Contains(err.Error(), "delete undispatched") {
+		t.Fatalf("first Submit error = %v, want joined dispatch/delete failure", err)
+	}
+	state, err := store.LoadRun(ctx, id)
+	if err != nil || state.Status != filament.RunRequested {
+		t.Fatalf("stranded state = %#v, err = %v", state, err)
+	}
+
+	got, err := Submit(ctx, bus, store, req)
+	if err != nil || got != id {
+		t.Fatalf("retry Submit = %q, %v; want %q, nil", got, err, id)
+	}
+	select {
+	case msg := <-sub.C():
+		fact, decodeErr := events.Decode(msg)
+		_ = msg.Ack()
+		if decodeErr != nil || fact.Run != id {
+			t.Fatalf("redispatched fact = %#v, err = %v", fact, decodeErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("retry did not publish run.requested")
 	}
 }

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -214,12 +214,12 @@ func TestPipelinePerResourceBatching(t *testing.T) {
 	_ = c
 }
 
-func TestPipelineDivergenceIsNonFatal(t *testing.T) {
+func TestPipelineDivergenceIsFatal(t *testing.T) {
 	sink := &fakeSink{corrupt: true}
 	recs := []filament.Record{rec("users", "1", `{}`), rec("users", "2", `{}`)}
 	c, err := run(t, sink, 2, recs)
-	if err != nil {
-		t.Fatalf("Wait: divergence should not fail the run, got %v", err)
+	if err == nil || !errContains(err, "CRC divergence") {
+		t.Fatalf("Wait error = %v, want CRC divergence", err)
 	}
 	if got := c.count(events.ChunkDivergence.Name()); got != 1 {
 		t.Errorf("divergence facts = %d, want 1", got)

--- a/pipeline/writer.go
+++ b/pipeline/writer.go
@@ -53,6 +53,8 @@ func (p *Pipeline) writer(ctx context.Context) {
 		}
 		p.publish(events.NewFact(events.ChunkDivergence, events.Envelope{Resource: b.Resource},
 			events.ChunkDivergenceEvent{CRC: readCRC}))
+		p.setErr(fmt.Errorf("write %s seq %d: CRC divergence: read %08x, write %08x", b.Resource, b.Seq, readCRC, receipt.WriteCRC))
+		return
 	}
 }
 

--- a/runner/extractor.go
+++ b/runner/extractor.go
@@ -157,13 +157,24 @@ func loadChangeCheckpoints(ctx context.Context, ds filament.DataStore, spec fila
 	return out, nil
 }
 
-// isResumableRun reports whether a failure can leave resumable progress: some
-// resource checkpoints and the run is not a CDC catch-up cycle.
+// isResumableRun reports whether a failure can leave progress that is safe to
+// replay into the sink. Append writes preserve already-applied rows, so retrying
+// an incremental append would duplicate them even when the source resumes from
+// its last checkpoint.
 func isResumableRun(spec filament.RunSpec, plan filament.IngestionPlan) bool {
 	if plan.RequiresCDC {
 		return false
 	}
 	incremental, checkpointed := partitionCheckpointing(spec)
+	for _, resource := range incremental {
+		policy, ok := plan.WritePolicies[resource]
+		if !ok {
+			policy, ok = plan.WritePolicies[""]
+		}
+		if !ok || policy.Capability.Mode == filament.WriteAppend {
+			return false
+		}
+	}
 	return len(incremental)+len(checkpointed) > 0
 }
 

--- a/runner/incremental_test.go
+++ b/runner/incremental_test.go
@@ -163,3 +163,22 @@ func TestResolveIngestionPlanUsesInsertOrderForSnapshotUpsert(t *testing.T) {
 		t.Fatalf("version strategy = %q, want %q", got, filament.VersionInsertOrder)
 	}
 }
+
+func TestIncrementalAppendFailureIsNotResumable(t *testing.T) {
+	spec := filament.RunSpec{
+		Resources:      []string{"users"},
+		IngestionTypes: map[string]filament.IngestionType{"users": filament.IngestionIncrementalAppend},
+	}
+	plan := filament.IngestionPlan{WritePolicies: map[string]filament.WritePolicy{
+		"users": filament.WritePolicyForIngestion(filament.IngestionIncrementalAppend),
+	}}
+	if isResumableRun(spec, plan) {
+		t.Fatal("incremental append must abort instead of resuming into preserved append data")
+	}
+
+	spec.IngestionTypes["users"] = filament.IngestionIncrementalUpsert
+	plan.WritePolicies["users"] = filament.WritePolicyForIngestion(filament.IngestionIncrementalUpsert)
+	if !isResumableRun(spec, plan) {
+		t.Fatal("incremental upsert should remain resumable")
+	}
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -154,7 +154,7 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 		if aerr := snk.Abort(ctx); aerr != nil && deps.Log != nil {
 			deps.Log.Error("runner: sink abort", aerr, filament.Field{Key: "run", Value: string(spec.Run)})
 		}
-		em.failed(err, nil, false)
+		em.failed(err, spec.Resources, false)
 		return
 	}
 
@@ -216,7 +216,7 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	}
 
 	if err := snk.Commit(ctx); err != nil {
-		em.failed(fmt.Errorf("commit sink %q: %w", spec.Sink.Provider, err), nil, false)
+		em.failed(fmt.Errorf("commit sink %q: %w", spec.Sink.Provider, err), resources, false)
 		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), abortWait)
 		defer cancel()
 		if aerr := snk.Abort(abortCtx); aerr != nil && deps.Log != nil {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -40,6 +40,7 @@ func TestRunOneCommitFailureAborts(t *testing.T) {
 	defer func() { _ = facts.Close() }()
 
 	failed := make(chan string, 1)
+	resourceFailed := make(chan string, 1)
 	go func() {
 		for msg := range facts.C() {
 			f, decodeErr := events.Decode(msg)
@@ -50,6 +51,9 @@ func TestRunOneCommitFailureAborts(t *testing.T) {
 			if d, ok := f.Data.(events.RunFailedEvent); ok {
 				failed <- d.Error
 				return
+			}
+			if d, ok := f.Data.(events.ResourceFailedEvent); ok && f.Resource == "users" {
+				resourceFailed <- d.Error
 			}
 		}
 	}()
@@ -81,6 +85,14 @@ func TestRunOneCommitFailureAborts(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("no run.failed fact published")
+	}
+	select {
+	case msg := <-resourceFailed:
+		if !strings.Contains(msg, "commit") {
+			t.Fatalf("resource.failed error = %q, want commit failure", msg)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no resource.failed fact published")
 	}
 	if got := sink.aborts.Load(); got != 1 {
 		t.Fatalf("Abort calls = %d, want 1", got)

--- a/server/api.go
+++ b/server/api.go
@@ -27,6 +27,7 @@ type Server struct {
 	schedules filament.PipelineScheduleStore
 	compiler  *compile.Compiler
 	metrics   filament.MetricsStore
+	log       filament.Logger
 }
 
 // Option configures a Server.
@@ -38,6 +39,9 @@ func WithSecrets(secrets filament.Secrets) Option { return func(s *Server) { s.s
 // WithMetricsStore sets the run metrics query backend. Unset leaves
 // MetricsService unimplemented.
 func WithMetricsStore(ms filament.MetricsStore) Option { return func(s *Server) { s.metrics = ms } }
+
+// WithLogger sets the structured logger used for API diagnostics.
+func WithLogger(log filament.Logger) Option { return func(s *Server) { s.log = log } }
 
 // New returns a Server wired to the given providers.
 func New(sources filament.SourceRegistry, sinks filament.SinkRegistry, store filament.DataStore, orch runSubmitter, bus eventbus.Bus, opts ...Option) *Server {

--- a/server/pipelines.go
+++ b/server/pipelines.go
@@ -366,7 +366,8 @@ func (a *Server) DeletePipeline(ctx context.Context, req *connect.Request[ingest
 	if a.schedules != nil {
 		if st, err := a.schedules.LoadPipelineSchedule(ctx, req.Msg.GetId()); err == nil {
 			if err := runs.DropScheduled(ctx, a.store, st.ID); err != nil {
-				fmt.Printf("[ingestion-api] drop scheduled runs schedule=%s err=%v\n", st.ID, err)
+				a.logError("ingestion-api: drop scheduled runs", err,
+					filament.Field{Key: "schedule", Value: string(st.ID)})
 			}
 		}
 	}
@@ -402,11 +403,22 @@ func (a *Server) submitPipeline(ctx context.Context, req *ingestionv1.RunPipelin
 		if err != nil {
 			return nil, err
 		}
-		fmt.Printf("[ingestion-api] RunPipeline route=%s source=%s sink=%s resources=%v run=%s\n", c.Edge, c.Req.Source.Provider, c.Req.Sink.Provider, c.Req.Resources, run)
+		if a.log != nil {
+			a.log.Info("ingestion-api: run submitted",
+				filament.Field{Key: "route", Value: c.Edge},
+				filament.Field{Key: "source", Value: c.Req.Source.Provider},
+				filament.Field{Key: "sink", Value: c.Req.Sink.Provider},
+				filament.Field{Key: "resources", Value: c.Req.Resources},
+				filament.Field{Key: "run", Value: string(run)})
+		}
 		state := filament.RunState{Run: run, Tenant: c.Req.Tenant, Request: c.Req, ScheduleID: c.Req.ScheduleID, Status: filament.RunRequested}
 		edgeRuns = append(edgeRuns, &ingestionv1.PipelineEdgeRun{PipelineEdgeKey: c.Edge, Run: runInfoToProto(state)})
 	}
-	fmt.Printf("[ingestion-api] RunPipeline pipeline=%s runs=%d\n", req.GetPipelineId(), len(edgeRuns))
+	if a.log != nil {
+		a.log.Info("ingestion-api: pipeline submitted",
+			filament.Field{Key: "pipeline", Value: req.GetPipelineId()},
+			filament.Field{Key: "runs", Value: len(edgeRuns)})
+	}
 	return edgeRuns, nil
 }
 
@@ -416,7 +428,14 @@ func (a *Server) submitPipeline(ctx context.Context, req *ingestionv1.RunPipelin
 // expected to fail here until the first version lands.
 func (a *Server) reconcileScheduledRunsBestEffort(ctx context.Context, st filament.ScheduleState) {
 	if err := runs.ReconcileScheduled(ctx, a.store, a.compiler, st); err != nil {
-		fmt.Printf("[ingestion-api] reconcile scheduled runs schedule=%s err=%v\n", st.ID, err)
+		a.logError("ingestion-api: reconcile scheduled runs", err,
+			filament.Field{Key: "schedule", Value: string(st.ID)})
+	}
+}
+
+func (a *Server) logError(msg string, err error, fields ...filament.Field) {
+	if a.log != nil {
+		a.log.Error(msg, err, fields...)
 	}
 }
 

--- a/server/schedules.go
+++ b/server/schedules.go
@@ -83,7 +83,8 @@ func (a *Server) DeletePipelineSchedule(ctx context.Context, req *connect.Reques
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if err := runs.DropScheduled(ctx, a.store, state.ID); err != nil {
-		fmt.Printf("[ingestion-api] drop scheduled runs schedule=%s err=%v\n", state.ID, err)
+		a.logError("ingestion-api: drop scheduled runs", err,
+			filament.Field{Key: "schedule", Value: string(state.ID)})
 	}
 	return connect.NewResponse(&ingestionv1.DeletePipelineScheduleResponse{}), nil
 }


### PR DESCRIPTION
-Create catalog entries for cancelled/paused
-Uses logger for important prints
-Fix resources emit EventResourceComplete twice
-All post resource.started failures now emit resource.failed
-CRC divergence calls setErr
-A retry of a stranded Requested run republishes run.requested
-incremental_append failures are non-resumable