### PR TITLE
Atterpac/db configs and small cleanup

### DIFF
--- a/connectors/clickhouse/sink/clickhouse.go
+++ b/connectors/clickhouse/sink/clickhouse.go
@@ -18,6 +18,7 @@ import (
 	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
 	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/connectors/internal/dbconfig"
 )
 
 const (
@@ -74,27 +75,32 @@ type table struct {
 func New() *Sink { return &Sink{} }
 
 var (
-	_ filament.Sink            = (*Sink)(nil)
-	_ filament.LiveValidatable = (*Sink)(nil)
-	_ filament.Schematized     = (*Sink)(nil)
+	_ filament.Sink              = (*Sink)(nil)
+	_ filament.ConfigValidatable = (*Sink)(nil)
+	_ filament.LiveValidatable   = (*Sink)(nil)
+	_ filament.Schematized       = (*Sink)(nil)
 )
 
 // Spec describes the sink's configuration and supported write policies.
 func (s *Sink) Spec() filament.SinkSpec {
+	fields := dbconfig.VisibleWhen(dbconfig.MethodFields)
 	return filament.SinkSpec{
 		Name:         "clickhouse",
 		DisplayName:  "ClickHouse",
 		DarkLogoURL:  "https://cdn.getgalaxy.io/sources/source-icon-clickhouse-dark.svg",
 		LightLogoURL: "https://cdn.getgalaxy.io/sources/source-icon-clickhouse-light.svg",
 		Description:  "Column-oriented analytics database with typed batch loading and primary-key upserts.",
-		Version:      "1",
+		Version:      "2",
 		Config: filament.ConfigSchema{Fields: []filament.ConfigField{
-			{Name: "host", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, Help: "ClickHouse server hostname; copied http:// or https:// endpoints are also accepted"},
-			{Name: "port", Type: filament.FieldInt, Default: defaultPort, Scope: filament.ScopeConnection, Help: "ClickHouse server port (9440 for secure native connections)"},
-			{Name: "protocol", Type: filament.FieldEnum, Default: protocolNative, Enum: []filament.EnumOption{{Value: protocolNative, Label: "Native"}, {Value: protocolHTTP, Label: "HTTP"}}, Scope: filament.ScopeConnection, Help: "ClickHouse wire protocol"},
-			{Name: "username", Type: filament.FieldString, Default: defaultUsername, Scope: filament.ScopeConnection, Help: "ClickHouse username"},
-			{Name: "password", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, Help: "ClickHouse password"},
-			{Name: "secure", Type: filament.FieldBool, Default: true, Scope: filament.ScopeConnection, Help: "Connect with TLS (required by ClickHouse Cloud)"},
+			dbconfig.MethodConfigField(),
+			dbconfig.DSNConfigField("ClickHouse connection URL"),
+			{Name: "host", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "ClickHouse server hostname; copied http:// or https:// endpoints are also accepted"},
+			{Name: "port", Type: filament.FieldInt, Default: defaultPort, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "ClickHouse server port (9440 for secure native connections)"},
+			{Name: "protocol", Type: filament.FieldEnum, Default: protocolNative, Enum: []filament.EnumOption{{Value: protocolNative, Label: "Native"}, {Value: protocolHTTP, Label: "HTTP"}}, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "ClickHouse wire protocol"},
+			{Name: "username", Type: filament.FieldString, Default: defaultUsername, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "ClickHouse username"},
+			{Name: "password", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "ClickHouse password"},
+			{Name: "database_name", Type: filament.FieldString, Default: defaultDatabase, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "Database encoded in the connection; pipeline configuration selects the destination database"},
+			{Name: "secure", Type: filament.FieldBool, Default: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "Connect with TLS (required by ClickHouse Cloud)"},
 			{Name: "database", Type: filament.FieldString, Default: defaultDatabase, Scope: filament.ScopePipeline, Help: "Destination database. Empty defaults to the normalized source connection name."},
 		}},
 		SchemaField: "database",
@@ -114,6 +120,14 @@ func (s *Sink) Spec() filament.SinkSpec {
 
 // Name identifies this sink implementation.
 func (s *Sink) Name() string { return "clickhouse" }
+
+// Validate checks connection syntax without opening a network connection.
+func (s *Sink) Validate(cfg filament.Config) error {
+	if _, err := connectionOptions(cfg); err != nil {
+		return fmt.Errorf("clickhouse sink: connection config: %w", err)
+	}
+	return nil
+}
 
 // TestConnection pings ClickHouse through a short-lived connection without
 // creating the configured destination database.
@@ -173,6 +187,25 @@ func (s *Sink) Open(ctx context.Context, run filament.RunSpec) error {
 }
 
 func connectionOptions(cfg filament.Config) (*ch.Options, error) {
+	method, err := dbconfig.Method(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if method == dbconfig.MethodURL {
+		dsn := cfg.Secret(dbconfig.DSNField)
+		if strings.TrimSpace(dsn) == "" {
+			return nil, fmt.Errorf("dsn is required when connection_method is %q", dbconfig.MethodURL)
+		}
+		opts, err := ch.ParseDSN(dsn)
+		if err != nil {
+			return nil, fmt.Errorf("parse dsn: %w", err)
+		}
+		if len(opts.Addr) == 0 {
+			return nil, fmt.Errorf("dsn has no server address")
+		}
+		return opts, nil
+	}
+
 	host, err := normalizeHost(cfg.String("host"))
 	if err != nil {
 		return nil, err
@@ -211,7 +244,7 @@ func connectionOptions(cfg filament.Config) (*ch.Options, error) {
 		Addr:     []string{net.JoinHostPort(host, strconv.Itoa(port))},
 		Protocol: driverProtocol,
 		Auth: ch.Auth{
-			Database: defaultDatabase,
+			Database: defaultString(cfg.String("database_name"), defaultDatabase),
 			Username: username,
 			Password: password,
 		},
@@ -224,6 +257,13 @@ func connectionOptions(cfg filament.Config) (*ch.Options, error) {
 		opts.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
 	return opts, nil
+}
+
+func defaultString(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
 }
 
 func normalizeHost(raw string) (string, error) {

--- a/connectors/clickhouse/sink/clickhouse_test.go
+++ b/connectors/clickhouse/sink/clickhouse_test.go
@@ -26,18 +26,34 @@ func TestSpecAdvertisesInitialWritePolicies(t *testing.T) {
 			t.Fatalf("policy %d mode = %q, want %q", i, policy.Mode, want[i])
 		}
 	}
-	if spec.Version != "1" {
+	if spec.Version != "2" {
 		t.Fatalf("version = %q, want 2", spec.Version)
 	}
 	fields := make(map[string]filament.ConfigField, len(spec.Config.Fields))
 	for _, field := range spec.Config.Fields {
 		fields[field.Name] = field
 	}
-	if _, ok := fields["dsn"]; ok {
-		t.Fatal("spec still exposes removed dsn field")
+	if got := fields["connection_method"].Default; got != "fields" {
+		t.Fatalf("connection_method default = %v, want fields", got)
+	}
+	if fields["dsn"].Type != filament.FieldSecret || !fields["dsn"].Required {
+		t.Fatalf("unexpected dsn field: %+v", fields["dsn"])
 	}
 	if !fields["host"].Required || fields["password"].Type != filament.FieldSecret || !fields["password"].Required {
 		t.Fatalf("unexpected connection fields: %+v", fields)
+	}
+}
+
+func TestConnectionOptionsFromDSN(t *testing.T) {
+	opts, err := connectionOptions(filament.NewConfig(map[string]any{
+		"connection_method": "url",
+		"dsn":               "clickhouse://loader:secret@localhost:9000/analytics?secure=false",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.Addr) != 1 || opts.Addr[0] != "localhost:9000" || opts.Auth.Username != "loader" || opts.Auth.Password != "secret" || opts.Auth.Database != "analytics" {
+		t.Fatalf("options = %#v", opts)
 	}
 }
 

--- a/connectors/http/catalog.go
+++ b/connectors/http/catalog.go
@@ -2,8 +2,6 @@ package httpapi
 
 import (
 	_ "embed"
-
-	"github.com/galaxy-io/filament"
 )
 
 //go:embed manifests/notion.yaml
@@ -32,42 +30,44 @@ var stripeManifest []byte
 
 // NewNotion returns a Source backed by the embedded Notion manifest.
 func NewNotion() *Source {
-	return NewManifestWithMetadata("notion", "Notion", "All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.", "https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg", notionManifest, manifestOwnedConfig())
+	return newCatalogSource(notionManifest)
 }
 
 // NewLinear returns a Source backed by the embedded Linear manifest.
 func NewLinear() *Source {
-	return NewManifestWithMetadata("linear", "Linear", "Modern issue tracking and project management tool built for high-performance teams.", "https://cdn.getgalaxy.io/sources/source-icon-linear-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-linear-light.svg", linearManifest, manifestOwnedConfig())
+	return newCatalogSource(linearManifest)
 }
 
 // NewAttio returns a Source backed by the embedded Attio REST API manifest.
 func NewAttio() *Source {
-	return NewManifestWithMetadata("attio", "Attio", "CRM platform designed for modern teams to centralize customer data, pipelines, and workflows.", "https://cdn.getgalaxy.io/sources/source-icon-attio-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-attio-light.svg", attioManifest, manifestOwnedConfig())
+	return newCatalogSource(attioManifest)
 }
 
 // NewGitHub returns a Source backed by the embedded GitHub REST API manifest.
 func NewGitHub() *Source {
-	return NewManifestWithMetadata("github", "GitHub", "Code hosting platform for version control, collaboration, and software development workflows.", "https://cdn.getgalaxy.io/sources/source-icon-github-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-github-light.svg", githubManifest, manifestOwnedConfig())
+	return newCatalogSource(githubManifest)
 }
 
 // NewSlack returns a Source backed by the embedded Slack Web API manifest.
 func NewSlack() *Source {
-	return NewManifestWithMetadata("slack", "Slack", "Messaging and collaboration platform designed for teams to communicate and work together efficiently.", "https://cdn.getgalaxy.io/sources/source-icon-slack-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-slack-light.svg", slackManifest, manifestOwnedConfig())
+	return newCatalogSource(slackManifest)
 }
 
 // NewResend returns a Source backed by the embedded Resend REST API manifest.
 func NewResend() *Source {
-	return NewManifestWithMetadata("resend", "Resend", "Email API for developers covering transactional sends, inbound mail, broadcasts, contacts, and audience management.", "https://cdn.getgalaxy.io/sources/source-icon-resend-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-resend-light.svg", resendManifest, manifestOwnedConfig())
+	return newCatalogSource(resendManifest)
 }
 
 // NewStripe returns a Source backed by the embedded Stripe REST API manifest.
 func NewStripe() *Source {
-	return NewManifestWithMetadata("stripe", "Stripe", "Payments platform covering charges, payment intents, invoicing, subscriptions, and the account balance ledger.", "https://cdn.getgalaxy.io/sources/source-icon-stripe-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-stripe-light.svg", stripeManifest, manifestOwnedConfig())
+	return newCatalogSource(stripeManifest)
 }
 
 // NewPostHog returns a Source backed by the embedded PostHog REST API manifest.
 func NewPostHog() *Source {
-	return NewManifestWithMetadata("posthog", "PostHog", "Product analytics platform covering people, events, cohorts, feature flags, experiments, and session replay.", "https://cdn.getgalaxy.io/sources/source-icon-posthog-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-posthog-light.svg", posthogManifest, manifestOwnedConfig())
+	return newCatalogSource(posthogManifest)
 }
 
-func manifestOwnedConfig() filament.ConfigSchema { return filament.ConfigSchema{} }
+func newCatalogSource(data []byte) *Source {
+	return NewManifest(data)
+}

--- a/connectors/http/connector.go
+++ b/connectors/http/connector.go
@@ -96,39 +96,48 @@ type extractOptions struct {
 }
 
 // SetManifestPath is called by the registry before Configure.
-func (c *Connector) SetManifestPath(path string) { c.manifestPath = path }
+func (c *Connector) SetManifestPath(path string) {
+	c.manifestPath = path
+	c.manifestData = nil
+	c.manifest = nil
+}
 
 // SetManifestData configures the connector from embedded manifest bytes.
-func (c *Connector) SetManifestData(data []byte) { c.manifestData = data }
+func (c *Connector) SetManifestData(data []byte) {
+	c.manifestPath = ""
+	c.manifestData = data
+	c.manifest = nil
+}
+
+// SetManifest configures the connector with an already parsed manifest.
+func (c *Connector) SetManifest(m *manifest.Manifest) { c.manifest = m }
 
 // SetCredentials injects the `config.*` template scope. Built per-source by
 // the registry's CredentialExtractor; the httpapi package stays proto-agnostic.
 func (c *Connector) SetCredentials(m map[string]string) { c.creds = m }
 
-// Validate checks that a manifest path or embedded manifest data is set.
+// Validate checks that a parsed manifest, manifest path, or embedded data is set.
 func (c *Connector) Validate() error {
-	if c.manifestPath == "" && len(c.manifestData) == 0 {
+	if c.manifest == nil && c.manifestPath == "" && len(c.manifestData) == 0 {
 		return fmt.Errorf("manifest_path is required")
 	}
 	return nil
 }
 
-// Configure loads the manifest and builds the auth, rate limiter, and HTTP clients.
+// Configure uses or loads the manifest and builds the auth, rate limiter, and HTTP clients.
 func (c *Connector) Configure(ctx context.Context) error {
-	if c.manifestPath == "" && len(c.manifestData) == 0 {
+	if c.manifest == nil && c.manifestPath == "" && len(c.manifestData) == 0 {
 		return fmt.Errorf("manifest_path not set — call SetManifestPath before Configure")
 	}
 
-	var (
-		m   *manifest.Manifest
-		err error
-	)
-	if len(c.manifestData) > 0 {
+	m := c.manifest
+	var err error
+	if m == nil && len(c.manifestData) > 0 {
 		m, err = manifest.Parse(c.manifestData)
 		if err != nil {
 			return fmt.Errorf("parse manifest: %w", err)
 		}
-	} else {
+	} else if m == nil {
 		m, err = manifest.Load(c.manifestPath)
 		if err != nil {
 			return fmt.Errorf("load manifest: %w", err)

--- a/connectors/http/discover.go
+++ b/connectors/http/discover.go
@@ -125,9 +125,8 @@ func projectResource(rec map[string]any, m manifest.ResourceMap) (filament.Resou
 }
 
 // resolveName walks NamePaths in order, then NamePath, returning the first
-// non-empty resolution. For Notion pages where the title property name varies
-// per database, this lets a manifest list every common candidate and the
-// extractor picks whichever exists on the record.
+// non-empty resolution. Name resolution is entirely manifest-driven so the
+// generic engine does not infer provider-specific response shapes.
 func resolveName(rec map[string]any, m manifest.ResourceMap) string {
 	candidates := m.NamePaths
 	if len(candidates) == 0 && m.NamePath != "" {
@@ -136,32 +135,6 @@ func resolveName(rec map[string]any, m manifest.ResourceMap) string {
 	for _, p := range candidates {
 		if s, _, err := paths.AsString(rec, p); err == nil && s != "" {
 			return s
-		}
-	}
-	// Last-resort fallback: scan properties.* for any value whose `type`
-	// is "title" and pull its first plain_text. Works for Notion pages
-	// regardless of which property holds the title (database-defined
-	// title columns can be named anything).
-	if props, ok := rec["properties"].(map[string]any); ok {
-		for _, v := range props {
-			prop, ok := v.(map[string]any)
-			if !ok {
-				continue
-			}
-			if t, _ := prop["type"].(string); t != "title" {
-				continue
-			}
-			arr, ok := prop["title"].([]any)
-			if !ok || len(arr) == 0 {
-				continue
-			}
-			first, ok := arr[0].(map[string]any)
-			if !ok {
-				continue
-			}
-			if s, ok := first["plain_text"].(string); ok && s != "" {
-				return s
-			}
 		}
 	}
 	return ""

--- a/connectors/http/discover_test.go
+++ b/connectors/http/discover_test.go
@@ -1,0 +1,31 @@
+package httpapi
+
+import (
+	"testing"
+
+	"github.com/galaxy-io/filament/connectors/http/manifest"
+)
+
+func TestResolveNameUsesOnlyDeclaredPaths(t *testing.T) {
+	record := map[string]any{
+		"display_name": "Declared name",
+		"properties": map[string]any{
+			"Arbitrary": map[string]any{
+				"type":  "title",
+				"title": []any{map[string]any{"plain_text": "Implicit provider name"}},
+			},
+		},
+	}
+
+	got := resolveName(record, manifest.ResourceMap{
+		NamePaths: []string{"missing", "display_name"},
+	})
+	if got != "Declared name" {
+		t.Fatalf("resolved name = %q, want declared path value", got)
+	}
+
+	got = resolveName(record, manifest.ResourceMap{NamePath: "missing"})
+	if got != "" {
+		t.Fatalf("resolved name = %q, want no provider-specific fallback", got)
+	}
+}

--- a/connectors/http/manifest/grammar.v1.json
+++ b/connectors/http/manifest/grammar.v1.json
@@ -2,11 +2,15 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "HTTP Connector Manifest v1",
   "type": "object",
-  "required": ["version", "name", "connection", "resources"],
+  "required": ["version", "name", "display_name", "description", "dark_logo_url", "light_logo_url", "connection", "resources"],
   "additionalProperties": false,
   "properties": {
     "version": { "const": 1 },
     "name": { "type": "string", "minLength": 1 },
+    "display_name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "dark_logo_url": { "type": "string", "format": "uri" },
+    "light_logo_url": { "type": "string", "format": "uri" },
     "config": {
       "type": "object",
       "additionalProperties": {

--- a/connectors/http/manifest/manifest.go
+++ b/connectors/http/manifest/manifest.go
@@ -10,6 +10,10 @@
 //
 //	version: 1
 //	name: notion
+//	display_name: Notion
+//	description: Workspace knowledge and collaboration
+//	dark_logo_url: https://cdn.example.com/notion-dark.svg
+//	light_logo_url: https://cdn.example.com/notion-light.svg
 //	connection:
 //	  base_url: https://api.notion.com/v1
 //	  auth: { type: bearer, token: "{{ config.api_key }}" }
@@ -59,13 +63,17 @@ const SupportedVersion = 1
 
 // Manifest is the root document describing one HTTP API connector.
 type Manifest struct {
-	Version    int                   `yaml:"version"`
-	Name       string                `yaml:"name"`
-	Config     map[string]ConfigSpec `yaml:"config,omitempty"`
-	Defaults   Defaults              `yaml:"defaults,omitempty"`
-	FieldSets  map[string]FieldList  `yaml:"field_sets,omitempty"`
-	Connection Connection            `yaml:"connection"`
-	Resources  []Resource            `yaml:"resources"`
+	Version      int                   `yaml:"version"`
+	Name         string                `yaml:"name"`
+	DisplayName  string                `yaml:"display_name,omitempty"`
+	Description  string                `yaml:"description,omitempty"`
+	DarkLogoURL  string                `yaml:"dark_logo_url,omitempty"`
+	LightLogoURL string                `yaml:"light_logo_url,omitempty"`
+	Config       map[string]ConfigSpec `yaml:"config,omitempty"`
+	Defaults     Defaults              `yaml:"defaults,omitempty"`
+	FieldSets    map[string]FieldList  `yaml:"field_sets,omitempty"`
+	Connection   Connection            `yaml:"connection"`
+	Resources    []Resource            `yaml:"resources"`
 	// Discovery, when set, lets the connector enumerate user-toggleable
 	// resources by reusing existing extraction streams. Each entry projects a
 	// distinct resource Kind (e.g. notion exposes both "database" and "page"

--- a/connectors/http/manifest/manifest.go
+++ b/connectors/http/manifest/manifest.go
@@ -120,9 +120,9 @@ type ResourceMap struct {
 	NamePath     string `yaml:"name"` // single path OR alias; see NamePaths
 	ParentIDPath string `yaml:"parent_id,omitempty"`
 	// NamePaths is an ordered list of fallback paths; the first non-empty
-	// resolution wins. Use it for shapes like Notion pages where the title
-	// lives under a property whose key varies per database. When set, takes
-	// precedence over NamePath; either field individually is sufficient.
+	// resolution wins. Use it when upstream response variants expose the same
+	// label at different paths. When set, it takes precedence over NamePath;
+	// either field individually is sufficient.
 	NamePaths      []string          `yaml:"name_paths,omitempty"`
 	DefaultEnabled string            `yaml:"default_enabled,omitempty"`
 	Metadata       map[string]string `yaml:"metadata,omitempty"`

--- a/connectors/http/manifest/manifest_test.go
+++ b/connectors/http/manifest/manifest_test.go
@@ -5,10 +5,39 @@ import (
 	"testing"
 )
 
+func TestParseCatalogMetadata(t *testing.T) {
+	m, err := Parse([]byte(`
+version: 1
+name: example
+display_name: Example API
+description: Example connector used to verify manifest-owned catalog metadata.
+dark_logo_url: https://cdn.example.com/example-dark.svg
+light_logo_url: https://cdn.example.com/example-light.svg
+connection:
+  base_url: https://example.com
+resources:
+  - name: records
+    path: /records
+`))
+	if err != nil {
+		t.Fatalf("parse manifest metadata: %v", err)
+	}
+	if m.DisplayName != "Example API" ||
+		m.Description != "Example connector used to verify manifest-owned catalog metadata." ||
+		m.DarkLogoURL != "https://cdn.example.com/example-dark.svg" ||
+		m.LightLogoURL != "https://cdn.example.com/example-light.svg" {
+		t.Fatalf("catalog metadata = %#v", m)
+	}
+}
+
 func TestParseConciseSyntaxNormalizesToRuntimeModel(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: concise
+display_name: Concise
+description: Test concise manifest.
+dark_logo_url: https://cdn.example.com/concise-dark.svg
+light_logo_url: https://cdn.example.com/concise-light.svg
 config:
   token:
     type: secret
@@ -105,6 +134,10 @@ func TestParseListConfig(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: list-config
+display_name: List Config
+description: Test list configuration manifest.
+dark_logo_url: https://cdn.example.com/list-dark.svg
+light_logo_url: https://cdn.example.com/list-light.svg
 config:
   kinds:
     type: list
@@ -133,6 +166,10 @@ func TestParseRejectsListConfigWithoutOptions(t *testing.T) {
 	_, err := Parse([]byte(`
 version: 1
 name: list-config
+display_name: List Config
+description: Test invalid list configuration manifest.
+dark_logo_url: https://cdn.example.com/list-dark.svg
+light_logo_url: https://cdn.example.com/list-light.svg
 config:
   kinds:
     type: list
@@ -162,7 +199,7 @@ func TestParseRejectsInvalidIncrementalContracts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Parse([]byte("version: 1\nname: test\nconnection:\n  base_url: https://example.com\nresources:\n  - name: items\n    path: /items\n    fields:\n      " + tt.field + "\n    " + tt.pagination + "\n    incremental:\n      " + tt.incremental + "\n"))
+			_, err := Parse([]byte("version: 1\nname: test\ndisplay_name: Test\ndescription: Test invalid incremental manifest.\ndark_logo_url: https://cdn.example.com/test-dark.svg\nlight_logo_url: https://cdn.example.com/test-light.svg\nconnection:\n  base_url: https://example.com\nresources:\n  - name: items\n    path: /items\n    fields:\n      " + tt.field + "\n    " + tt.pagination + "\n    incremental:\n      " + tt.incremental + "\n"))
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
@@ -174,6 +211,10 @@ func TestParseConciseBasicAuth(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: basic
+display_name: Basic
+description: Test basic authentication manifest.
+dark_logo_url: https://cdn.example.com/basic-dark.svg
+light_logo_url: https://cdn.example.com/basic-light.svg
 config:
   email:
     type: string
@@ -203,6 +244,10 @@ resources:
 	m, err = Parse([]byte(`
 version: 1
 name: basic-no-pass
+display_name: Basic No Password
+description: Test basic authentication without a password.
+dark_logo_url: https://cdn.example.com/basic-dark.svg
+light_logo_url: https://cdn.example.com/basic-light.svg
 config:
   api_key:
     type: secret
@@ -228,6 +273,10 @@ func TestParseConciseFieldRejectsUnknownType(t *testing.T) {
 	_, err := Parse([]byte(`
 version: 1
 name: invalid
+display_name: Invalid
+description: Test invalid authentication manifest.
+dark_logo_url: https://cdn.example.com/invalid-dark.svg
+light_logo_url: https://cdn.example.com/invalid-light.svg
 connection:
   base_url: https://example.com
 resources:
@@ -248,6 +297,10 @@ func TestParseAcceptsTemplatedBaseURL(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: regional
+display_name: Regional
+description: Test regional host manifest.
+dark_logo_url: https://cdn.example.com/regional-dark.svg
+light_logo_url: https://cdn.example.com/regional-light.svg
 config:
   host:
     type: string
@@ -270,6 +323,10 @@ func TestParseRejectsBaseURLWithUnresolvableScope(t *testing.T) {
 	_, err := Parse([]byte(`
 version: 1
 name: regional
+display_name: Regional
+description: Test invalid regional host manifest.
+dark_logo_url: https://cdn.example.com/regional-dark.svg
+light_logo_url: https://cdn.example.com/regional-light.svg
 connection:
   base_url: "{{ parent.host }}"
 resources:

--- a/connectors/http/manifests/attio.yaml
+++ b/connectors/http/manifests/attio.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: attio
+display_name: Attio
+description: CRM platform designed for modern teams to centralize customer data, pipelines, and workflows.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-attio-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-attio-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/github.yaml
+++ b/connectors/http/manifests/github.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: github
+display_name: GitHub
+description: Code hosting platform for version control, collaboration, and software development workflows.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-github-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-github-light.svg
 config:
   token:
     type: secret

--- a/connectors/http/manifests/linear.yaml
+++ b/connectors/http/manifests/linear.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: linear
+display_name: Linear
+description: Modern issue tracking and project management tool built for high-performance teams.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-linear-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-linear-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/notion.yaml
+++ b/connectors/http/manifests/notion.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: notion
+display_name: Notion
+description: All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/posthog.yaml
+++ b/connectors/http/manifests/posthog.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: posthog
+display_name: PostHog
+description: Product analytics platform covering people, events, cohorts, feature flags, experiments, and session replay.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-posthog-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-posthog-light.svg
 
 config:
   api_key:

--- a/connectors/http/manifests/resend.yaml
+++ b/connectors/http/manifests/resend.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: resend
+display_name: Resend
+description: Email API for developers covering transactional sends, inbound mail, broadcasts, contacts, and audience management.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-resend-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-resend-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/slack.yaml
+++ b/connectors/http/manifests/slack.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: slack
+display_name: Slack
+description: Messaging and collaboration platform designed for teams to communicate and work together efficiently.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-slack-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-slack-light.svg
 config:
   token:
     type: secret

--- a/connectors/http/manifests/stripe.yaml
+++ b/connectors/http/manifests/stripe.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: stripe
+display_name: Stripe
+description: Payments platform covering charges, payment intents, invoicing, subscriptions, and the account balance ledger.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-stripe-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-stripe-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests_test.go
+++ b/connectors/http/manifests_test.go
@@ -25,8 +25,12 @@ func TestManifests(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read manifest: %v", err)
 			}
-			if _, err := manifest.Parse(data); err != nil {
+			m, err := manifest.Parse(data)
+			if err != nil {
 				t.Fatalf("parse manifest: %v", err)
+			}
+			if m.DisplayName == "" || m.Description == "" || m.DarkLogoURL == "" || m.LightLogoURL == "" {
+				t.Fatalf("catalog metadata must be manifest-owned: %#v", m)
 			}
 		})
 	}

--- a/connectors/http/source.go
+++ b/connectors/http/source.go
@@ -37,7 +37,8 @@ type Source struct {
 	darkLogoURL      string
 	lightLogoURL     string
 	config           filament.ConfigSchema
-	manifestData     []byte
+	embeddedManifest *manifest.Manifest
+	manifestErr      error
 	dynamicResources map[string]string
 	// incrementalResources is populated by PlanIncremental for the resources in
 	// the current run. It keeps durable watermark extraction distinct from
@@ -71,12 +72,19 @@ func NewManifest(name, displayName string, manifestData []byte, config filament.
 // NewManifestWithMetadata returns a Source bound to embedded manifest bytes,
 // frontend catalog metadata, and a config schema.
 func NewManifestWithMetadata(name, displayName, description, darkLogoURL, lightLogoURL string, manifestData []byte, config filament.ConfigSchema) *Source {
-	return &Source{name: name, displayName: displayName, description: description, darkLogoURL: darkLogoURL, lightLogoURL: lightLogoURL, manifestData: manifestData, config: config}
+	m, err := manifest.Parse(manifestData)
+	if err == nil && len(m.Config) > 0 {
+		config = configSchemaFromManifest(m)
+	}
+	return &Source{
+		name: name, displayName: displayName, description: description,
+		darkLogoURL: darkLogoURL, lightLogoURL: lightLogoURL,
+		config: config, embeddedManifest: m, manifestErr: err,
+	}
 }
 
 // Spec reports the source's capabilities and configuration surface.
 func (s *Source) Spec() filament.ConnectorSpec {
-	config := s.configSchema()
 	modes := []filament.ReadMode{filament.ModeFull}
 	policies := []filament.IngestionType{
 		filament.IngestionFullReplace,
@@ -99,7 +107,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 		Version:        "1",
 		Modes:          modes,
 		SourcePolicies: filament.SourcePolicies(policies...),
-		Config:         config,
+		Config:         s.config,
 		Resources:      filament.ResourceCapabilities{Discoverable: true, PerResourceCursor: true},
 	}
 }
@@ -117,14 +125,15 @@ func (s *Source) canDeclareIncremental() bool {
 		}
 		return false
 	}
-	if len(s.manifestData) == 0 {
+	if s.embeddedManifest == nil {
+		// A nil manifest with no parse error is the generic manifest-path source.
+		// Its capabilities are unknown until it is configured.
+		if s.manifestErr != nil {
+			return false
+		}
 		return true
 	}
-	m, err := manifest.Parse(s.manifestData)
-	if err != nil {
-		return false
-	}
-	for _, resource := range m.Resources {
+	for _, resource := range s.embeddedManifest.Resources {
 		if resource.Incremental != nil {
 			return true
 		}
@@ -134,7 +143,10 @@ func (s *Source) canDeclareIncremental() bool {
 
 // Validate checks that all required config fields are present and non-empty.
 func (s *Source) Validate(cfg filament.Config) error {
-	for _, field := range s.configSchema().Fields {
+	if s.manifestErr != nil {
+		return fmt.Errorf("%s source: parse manifest: %w", s.name, s.manifestErr)
+	}
+	for _, field := range s.config.Fields {
 		if field.Required && !cfg.Has(field.Name) {
 			return fmt.Errorf("%s source: %s is required", s.name, field.Name)
 		}
@@ -170,14 +182,7 @@ func listLen(value any) int {
 	}
 }
 
-func (s *Source) configSchema() filament.ConfigSchema {
-	if len(s.manifestData) == 0 {
-		return s.config
-	}
-	m, err := manifest.Parse(s.manifestData)
-	if err != nil || len(m.Config) == 0 {
-		return s.config
-	}
+func configSchemaFromManifest(m *manifest.Manifest) filament.ConfigSchema {
 	names := make([]string, 0, len(m.Config))
 	for name := range m.Config {
 		names = append(names, name)
@@ -260,26 +265,21 @@ func (s *Source) TestConnection(ctx context.Context, cfg filament.Config) error 
 
 func (s *Source) connectorForConfig(cfg filament.Config) (*Connector, error) {
 	c := &Connector{}
-	if len(s.manifestData) > 0 {
-		c.SetManifestData(s.manifestData)
-	} else {
-		c.SetManifestPath(cfg.String("manifest_path"))
+	if s.manifestErr != nil {
+		return nil, fmt.Errorf("%s source: parse manifest: %w", s.name, s.manifestErr)
 	}
-	var configSpecs map[string]manifest.ConfigSpec
-	if len(s.manifestData) > 0 {
-		parsed, err := manifest.Parse(s.manifestData)
-		if err != nil {
-			return nil, fmt.Errorf("%s source: parse manifest: %w", s.name, err)
-		}
-		configSpecs = parsed.Config
-	} else {
-		parsed, err := manifest.Load(cfg.String("manifest_path"))
+	parsed := s.embeddedManifest
+	if parsed == nil {
+		path := cfg.String("manifest_path")
+		var err error
+		parsed, err = manifest.Load(path)
 		if err != nil {
 			return nil, fmt.Errorf("%s source: load manifest: %w", s.name, err)
 		}
-		configSpecs = parsed.Config
+		c.SetManifestPath(path)
 	}
-	c.SetCredentials(credentialsFromConfig(cfg, configSpecs))
+	c.SetManifest(parsed)
+	c.SetCredentials(credentialsFromConfig(cfg, parsed.Config))
 	return c, nil
 }
 

--- a/connectors/http/source.go
+++ b/connectors/http/source.go
@@ -64,22 +64,17 @@ func New() *Source {
 	return &Source{name: providerName, displayName: "HTTP API", config: genericConfig}
 }
 
-// NewManifest returns a Source bound to embedded manifest bytes and a config schema.
-func NewManifest(name, displayName string, manifestData []byte, config filament.ConfigSchema) *Source {
-	return NewManifestWithMetadata(name, displayName, "", "", "", manifestData, config)
-}
-
-// NewManifestWithMetadata returns a Source bound to embedded manifest bytes,
-// frontend catalog metadata, and a config schema.
-func NewManifestWithMetadata(name, displayName, description, darkLogoURL, lightLogoURL string, manifestData []byte, config filament.ConfigSchema) *Source {
+// NewManifest returns a Source whose identity, presentation metadata, and
+// configuration schema are all declared by the embedded manifest.
+func NewManifest(manifestData []byte) *Source {
 	m, err := manifest.Parse(manifestData)
-	if err == nil && len(m.Config) > 0 {
-		config = configSchemaFromManifest(m)
+	if err != nil {
+		return &Source{embeddedManifest: m, manifestErr: err}
 	}
 	return &Source{
-		name: name, displayName: displayName, description: description,
-		darkLogoURL: darkLogoURL, lightLogoURL: lightLogoURL,
-		config: config, embeddedManifest: m, manifestErr: err,
+		name: m.Name, displayName: m.DisplayName, description: m.Description,
+		darkLogoURL: m.DarkLogoURL, lightLogoURL: m.LightLogoURL,
+		config: configSchemaFromManifest(m), embeddedManifest: m,
 	}
 }
 

--- a/connectors/http/source_test.go
+++ b/connectors/http/source_test.go
@@ -87,6 +87,10 @@ func TestSourceTestConnectionMakesOneAuthenticatedRequest(t *testing.T) {
 	data := []byte(fmt.Sprintf(`
 version: 1
 name: probe
+display_name: Probe
+description: Test probe connector.
+dark_logo_url: https://cdn.example.com/probe-dark.svg
+light_logo_url: https://cdn.example.com/probe-light.svg
 config:
   token: {type: secret, required: true}
 connection:
@@ -102,7 +106,7 @@ resources:
         path: error
         when_present: true
 `, api.URL))
-	src := NewManifest("probe", "Probe", data, filament.ConfigSchema{})
+	src := NewManifest(data)
 	if err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
 		"token": "good-token",
 	})); err != nil {
@@ -663,7 +667,7 @@ func TestAttioUsesAPIKeyAsBearerToken(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(attioManifest), "https://api.attio.com", api.URL, 1))
-	src := NewManifest("attio", "Attio", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "attio-key"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -719,7 +723,7 @@ func TestSlackEmbeddedManifestAndMessageFanOut(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(slackManifest), "https://slack.com/api", api.URL, 1))
-	src := NewManifest("slack", "Slack", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"token": "xoxb-test"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -795,9 +799,13 @@ func TestCredentialsFromConfigJoinsStringLists(t *testing.T) {
 }
 
 func TestRequiredListConfigRejectsEmptySelection(t *testing.T) {
-	src := NewManifest("list", "List", []byte(`
+	src := NewManifest([]byte(`
 version: 1
 name: list
+display_name: List
+description: Test list connector.
+dark_logo_url: https://cdn.example.com/list-dark.svg
+light_logo_url: https://cdn.example.com/list-light.svg
 config:
   choices:
     type: list
@@ -812,7 +820,7 @@ resources:
     primary_key: [id]
     fields:
       id: string
-`), filament.ConfigSchema{})
+`))
 
 	if err := src.Validate(filament.NewConfig(map[string]any{"choices": []any{}})); err == nil {
 		t.Fatal("empty required list validated successfully")
@@ -823,9 +831,13 @@ resources:
 }
 
 func TestEmbeddedManifestIsParsedOnceAndReused(t *testing.T) {
-	src := NewManifest("cached", "Cached", []byte(`
+	src := NewManifest([]byte(`
 version: 1
 name: cached
+display_name: Cached
+description: Test cached connector.
+dark_logo_url: https://cdn.example.com/cached-dark.svg
+light_logo_url: https://cdn.example.com/cached-light.svg
 config:
   token:
     type: secret
@@ -839,7 +851,7 @@ resources:
     primary_key: [id]
     fields:
       id: string
-`), filament.ConfigSchema{})
+`))
 	if src.manifestErr != nil || src.embeddedManifest == nil {
 		t.Fatalf("constructor manifest = %#v, error = %v", src.embeddedManifest, src.manifestErr)
 	}
@@ -871,17 +883,11 @@ resources:
 }
 
 func TestEmbeddedManifestParseErrorIsCached(t *testing.T) {
-	fallback := filament.ConfigSchema{Fields: []filament.ConfigField{{
-		Name: "fallback", Type: filament.FieldString, Required: true,
-	}}}
-	src := NewManifest("broken", "Broken", []byte("version: ["), fallback)
+	src := NewManifest([]byte("version: ["))
 	if src.manifestErr == nil {
 		t.Fatal("constructor accepted invalid manifest")
 	}
-	if got := src.Spec().Config; len(got.Fields) != 1 || got.Fields[0].Name != "fallback" {
-		t.Fatalf("fallback config = %#v", got)
-	}
-	if err := src.Validate(filament.NewConfig(map[string]any{"fallback": "set"})); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+	if err := src.Validate(filament.NewConfig(nil)); err == nil || !strings.Contains(err.Error(), "parse manifest") {
 		t.Fatalf("validate error = %v, want cached manifest parse error", err)
 	}
 	if _, err := src.connectorForConfig(filament.NewConfig(nil)); err == nil || !strings.Contains(err.Error(), "parse manifest") {
@@ -968,6 +974,10 @@ func TestStaticDiscoveryChildSelectionScansButDoesNotEmitParents(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "static.yaml")
 	data := fmt.Sprintf(`version: 1
 name: static
+display_name: Static
+description: Test static connector.
+dark_logo_url: https://cdn.example.com/static-dark.svg
+light_logo_url: https://cdn.example.com/static-light.svg
 connection:
   base_url: %s
 resources:
@@ -1183,6 +1193,10 @@ func writeTestManifest(t *testing.T, baseURL string) string {
 	path := filepath.Join(t.TempDir(), "manifest.yaml")
 	data := fmt.Sprintf(`version: 1
 name: test_http
+display_name: Test HTTP
+description: Test HTTP connector.
+dark_logo_url: https://cdn.example.com/http-dark.svg
+light_logo_url: https://cdn.example.com/http-light.svg
 connection:
   base_url: %s
 resources:
@@ -1209,6 +1223,10 @@ func writeIncrementalTestManifest(t *testing.T, baseURL string) string {
 	path := filepath.Join(t.TempDir(), "manifest.yaml")
 	data := fmt.Sprintf(`version: 1
 name: test_http
+display_name: Test HTTP
+description: Test incremental HTTP connector.
+dark_logo_url: https://cdn.example.com/http-dark.svg
+light_logo_url: https://cdn.example.com/http-light.svg
 connection:
   base_url: %s
 resources:
@@ -1254,6 +1272,10 @@ func writeNotionTestManifest(t *testing.T, baseURL string) string {
 	path := filepath.Join(t.TempDir(), "notion.yaml")
 	data := fmt.Sprintf(`version: 1
 name: notion
+display_name: Notion
+description: Test Notion connector.
+dark_logo_url: https://cdn.example.com/notion-dark.svg
+light_logo_url: https://cdn.example.com/notion-light.svg
 connection:
   base_url: %s
   auth:
@@ -1410,7 +1432,7 @@ func TestResendPaginatesOnLastRecordIDAndSendsBearerToken(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1466,7 +1488,7 @@ func TestResendTestConnectionProbesEmails(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
 		"api_key": "re_test_123",
 	})); err != nil {
@@ -1503,7 +1525,7 @@ func TestResendEmailDetailsSingletonFanOutSendsNoListParams(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1562,7 +1584,7 @@ func TestResendDomainRecordsProjectNestedArrayFromDomainDetail(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1596,7 +1618,7 @@ func TestResendDomainRecordsProjectNestedArrayFromDomainDetail(t *testing.T) {
 	// A fresh Source: parent captures accumulate for the lifetime of a
 	// configured connector, so reusing the one above would fan the detail
 	// request out once per prior run.
-	settingsSrc := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	settingsSrc := NewManifest(manifestData)
 	if err := settingsSrc.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1645,7 +1667,7 @@ func TestResendWebhookAttemptsInheritWebhookIDThroughEventCapture(t *testing.T) 
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1712,7 +1734,7 @@ func TestResendTemplateDetailsAcceptArrayReplyTo(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1830,7 +1852,7 @@ func TestStripePaginatesOnLastRecordIDAndSendsBasicAuth(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1908,7 +1930,7 @@ func TestStripeSubscriptionItemFanOut(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1977,7 +1999,7 @@ func TestStripeInvoiceLineItemFanOut(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -2040,7 +2062,7 @@ func TestStripeIncrementalInjectsBracketedCreatedFilter(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -2102,7 +2124,7 @@ func TestStripeTestConnectionProbesCustomers(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
 		"api_key": "rk_test_123",
 	})); err != nil {
@@ -2225,7 +2247,7 @@ func TestPostHogPaginatesViaNextURLAndScopesToProject(t *testing.T) {
 	}))
 	defer api.Close()
 
-	src := NewManifest("posthog", "PostHog", unthrottledPostHogManifest(t), filament.ConfigSchema{})
+	src := NewManifest(unthrottledPostHogManifest(t))
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
 		"api_key":    "phx_test_123",
 		"project_id": "12345",
@@ -2296,7 +2318,7 @@ func TestPostHogEventsIncrementalInjectsAfterMinusOverlap(t *testing.T) {
 	}))
 	defer api.Close()
 
-	src := NewManifest("posthog", "PostHog", posthogManifest, filament.ConfigSchema{})
+	src := NewManifest(posthogManifest)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
 		"api_key":    "phx_test_123",
 		"project_id": "12345",
@@ -2378,7 +2400,7 @@ func TestPostHogIncrementalLeavesServerNextURLUntouched(t *testing.T) {
 	}))
 	defer api.Close()
 
-	src := NewManifest("posthog", "PostHog", unthrottledPostHogManifest(t), filament.ConfigSchema{})
+	src := NewManifest(unthrottledPostHogManifest(t))
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
 		"api_key":    "phx_test_123",
 		"project_id": "12345",

--- a/connectors/http/source_test.go
+++ b/connectors/http/source_test.go
@@ -822,6 +822,88 @@ resources:
 	}
 }
 
+func TestEmbeddedManifestIsParsedOnceAndReused(t *testing.T) {
+	src := NewManifest("cached", "Cached", []byte(`
+version: 1
+name: cached
+config:
+  token:
+    type: secret
+    required: true
+connection:
+  base_url: https://example.com
+resources:
+  - name: records
+    path: /records
+    records: $
+    primary_key: [id]
+    fields:
+      id: string
+`), filament.ConfigSchema{})
+	if src.manifestErr != nil || src.embeddedManifest == nil {
+		t.Fatalf("constructor manifest = %#v, error = %v", src.embeddedManifest, src.manifestErr)
+	}
+
+	for range 2 {
+		spec := src.Spec()
+		if len(spec.Config.Fields) != 1 || spec.Config.Fields[0].Name != "token" {
+			t.Fatalf("config fields = %#v, want cached token field", spec.Config.Fields)
+		}
+	}
+	cfg := filament.NewConfig(map[string]any{"token": "secret"})
+	if err := src.Validate(cfg); err != nil {
+		t.Fatalf("validate cached config schema: %v", err)
+	}
+
+	c, err := src.connectorForConfig(cfg)
+	if err != nil {
+		t.Fatalf("build connector: %v", err)
+	}
+	if c.manifest != src.embeddedManifest {
+		t.Fatal("connector did not receive the manifest parsed by the source constructor")
+	}
+	if err := c.Configure(context.Background()); err != nil {
+		t.Fatalf("configure with cached manifest: %v", err)
+	}
+	if c.manifest != src.embeddedManifest {
+		t.Fatal("connector replaced the cached manifest during Configure")
+	}
+}
+
+func TestEmbeddedManifestParseErrorIsCached(t *testing.T) {
+	fallback := filament.ConfigSchema{Fields: []filament.ConfigField{{
+		Name: "fallback", Type: filament.FieldString, Required: true,
+	}}}
+	src := NewManifest("broken", "Broken", []byte("version: ["), fallback)
+	if src.manifestErr == nil {
+		t.Fatal("constructor accepted invalid manifest")
+	}
+	if got := src.Spec().Config; len(got.Fields) != 1 || got.Fields[0].Name != "fallback" {
+		t.Fatalf("fallback config = %#v", got)
+	}
+	if err := src.Validate(filament.NewConfig(map[string]any{"fallback": "set"})); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+		t.Fatalf("validate error = %v, want cached manifest parse error", err)
+	}
+	if _, err := src.connectorForConfig(filament.NewConfig(nil)); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+		t.Fatalf("connector error = %v, want cached manifest parse error", err)
+	}
+}
+
+func TestManifestPathIsLoadedOncePerConnector(t *testing.T) {
+	path := writeTestManifest(t, "https://example.com")
+	src := New()
+	c, err := src.connectorForConfig(filament.NewConfig(map[string]any{"manifest_path": path}))
+	if err != nil {
+		t.Fatalf("build connector: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove manifest after initial load: %v", err)
+	}
+	if err := c.Configure(context.Background()); err != nil {
+		t.Fatalf("Configure reloaded manifest instead of using parsed value: %v", err)
+	}
+}
+
 func TestNewGitHubSpecAndEmbeddedManifest(t *testing.T) {
 	ctx := context.Background()
 	src := NewGitHub()

--- a/connectors/internal/dbconfig/dbconfig.go
+++ b/connectors/internal/dbconfig/dbconfig.go
@@ -1,0 +1,63 @@
+// Package dbconfig contains the connection-input convention shared by database
+// connectors. Individual connectors remain responsible for translating the
+// selected representation into their driver's native configuration.
+package dbconfig
+
+import (
+	"fmt"
+
+	"github.com/galaxy-io/filament"
+)
+
+const (
+	MethodField = "connection_method"
+	DSNField    = "dsn"
+
+	MethodFields = "fields"
+	MethodURL    = "url"
+)
+
+// Method returns the selected connection representation. Fields is the default
+// for new configurations; a missing method with a DSN remains URL mode for
+// backward compatibility with connections created before the selector existed.
+func Method(cfg filament.Config) (string, error) {
+	method := cfg.String(MethodField)
+	if method == "" {
+		if cfg.Secret(DSNField) != "" {
+			return MethodURL, nil
+		}
+		return MethodFields, nil
+	}
+	switch method {
+	case MethodFields, MethodURL:
+		return method, nil
+	default:
+		return "", fmt.Errorf("%s must be %q or %q", MethodField, MethodFields, MethodURL)
+	}
+}
+
+// MethodConfigField declares the shared fields-first selector.
+func MethodConfigField() filament.ConfigField {
+	return filament.ConfigField{
+		Name: MethodField, Type: filament.FieldEnum, Default: MethodFields,
+		Enum: []filament.EnumOption{
+			{Value: MethodFields, Label: "Details"},
+			{Value: MethodURL, Label: "URL"},
+		},
+		Scope: filament.ScopeConnection,
+		Help:  "Supply connection details as individual fields or as a connection URL (DSN)",
+	}
+}
+
+// VisibleWhen returns a condition for a field belonging to one input method.
+func VisibleWhen(method string) *filament.FieldCondition {
+	return &filament.FieldCondition{Field: MethodField, Values: []string{method}}
+}
+
+// DSNConfigField declares the URL-mode secret.
+func DSNConfigField(help string) filament.ConfigField {
+	return filament.ConfigField{
+		Name: DSNField, Type: filament.FieldSecret, Required: true,
+		Scope: filament.ScopeConnection, Help: help, VisibleWhen: VisibleWhen(MethodURL),
+	}
+}

--- a/connectors/internal/dbconfig/dbconfig.go
+++ b/connectors/internal/dbconfig/dbconfig.go
@@ -10,11 +10,15 @@ import (
 )
 
 const (
+	// MethodField is the config field selecting the connection representation.
 	MethodField = "connection_method"
-	DSNField    = "dsn"
+	// DSNField is the config field containing a connection URL or driver DSN.
+	DSNField = "dsn"
 
+	// MethodFields selects individually configured connection fields.
 	MethodFields = "fields"
-	MethodURL    = "url"
+	// MethodURL selects a connection URL or driver DSN.
+	MethodURL = "url"
 )
 
 // Method returns the selected connection representation. Fields is the default

--- a/connectors/mysql/internal/connection/connection.go
+++ b/connectors/mysql/internal/connection/connection.go
@@ -1,0 +1,94 @@
+package connection
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/connectors/internal/dbconfig"
+)
+
+const defaultPort = 3306
+
+func Fields() []filament.ConfigField {
+	fields := dbconfig.VisibleWhen(dbconfig.MethodFields)
+	return []filament.ConfigField{
+		dbconfig.MethodConfigField(),
+		dbconfig.DSNConfigField("MySQL DSN (user:password@tcp(host:port)/database)"),
+		{Name: "host", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL server hostname"},
+		{Name: "port", Type: filament.FieldInt, Default: defaultPort, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL server port"},
+		{Name: "username", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL username"},
+		{Name: "password", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL password"},
+		{Name: "database_name", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "Database to connect to"},
+		{Name: "tls_mode", Type: filament.FieldEnum, Default: "preferred", Enum: []filament.EnumOption{
+			{Value: "false", Label: "Disable"},
+			{Value: "preferred", Label: "Prefer"},
+			{Value: "true", Label: "Require"},
+			{Value: "skip-verify", Label: "Require, skip verification"},
+		}, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL TLS mode"},
+	}
+}
+
+func Resolve(cfg filament.Config) (*mysql.Config, error) {
+	method, err := dbconfig.Method(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if method == dbconfig.MethodURL {
+		dsn := cfg.Secret(dbconfig.DSNField)
+		if strings.TrimSpace(dsn) == "" {
+			return nil, fmt.Errorf("dsn is required when connection_method is %q", dbconfig.MethodURL)
+		}
+		parsed, err := mysql.ParseDSN(dsn)
+		if err != nil {
+			return nil, fmt.Errorf("parse dsn: %w", err)
+		}
+		return parsed, nil
+	}
+
+	host := strings.TrimSpace(cfg.String("host"))
+	if host == "" {
+		return nil, fmt.Errorf("host is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	port := cfg.Int("port")
+	if port == 0 {
+		port = defaultPort
+	}
+	if port < 1 || port > 65535 {
+		return nil, fmt.Errorf("port must be between 1 and 65535")
+	}
+	username := cfg.String("username")
+	if username == "" {
+		return nil, fmt.Errorf("username is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	password := cfg.Secret("password")
+	if password == "" {
+		return nil, fmt.Errorf("password is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	database := cfg.String("database_name")
+	if database == "" {
+		return nil, fmt.Errorf("database_name is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	tlsMode := cfg.String("tls_mode")
+	if tlsMode == "" {
+		tlsMode = "preferred"
+	}
+	switch tlsMode {
+	case "false", "preferred", "true", "skip-verify":
+	default:
+		return nil, fmt.Errorf("unsupported tls_mode %q", tlsMode)
+	}
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	resolved := mysql.NewConfig()
+	resolved.User = username
+	resolved.Passwd = password
+	resolved.Net = "tcp"
+	resolved.Addr = net.JoinHostPort(host, strconv.Itoa(port))
+	resolved.DBName = database
+	resolved.TLSConfig = tlsMode
+	return resolved, nil
+}

--- a/connectors/mysql/internal/connection/connection.go
+++ b/connectors/mysql/internal/connection/connection.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -18,7 +19,7 @@ func Fields() []filament.ConfigField {
 	fields := dbconfig.VisibleWhen(dbconfig.MethodFields)
 	return []filament.ConfigField{
 		dbconfig.MethodConfigField(),
-		dbconfig.DSNConfigField("MySQL DSN (user:password@tcp(host:port)/database)"),
+		dbconfig.DSNConfigField("MySQL URL or driver DSN"),
 		{Name: "host", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL server hostname"},
 		{Name: "port", Type: filament.FieldInt, Default: defaultPort, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL server port"},
 		{Name: "username", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "MySQL username"},
@@ -43,7 +44,7 @@ func Resolve(cfg filament.Config) (*mysql.Config, error) {
 		if strings.TrimSpace(dsn) == "" {
 			return nil, fmt.Errorf("dsn is required when connection_method is %q", dbconfig.MethodURL)
 		}
-		parsed, err := mysql.ParseDSN(dsn)
+		parsed, err := parseDSN(dsn)
 		if err != nil {
 			return nil, fmt.Errorf("parse dsn: %w", err)
 		}
@@ -90,5 +91,51 @@ func Resolve(cfg filament.Config) (*mysql.Config, error) {
 	resolved.Addr = net.JoinHostPort(host, strconv.Itoa(port))
 	resolved.DBName = database
 	resolved.TLSConfig = tlsMode
-	return resolved, nil
+	return mysql.ParseDSN(resolved.FormatDSN())
+}
+
+// parseDSN accepts both the go-sql-driver native DSN and the conventional
+// mysql:// URL form. The latter is translated to a driver Config before being
+// normalized by ParseDSN so both inputs have identical defaults and TLS state.
+func parseDSN(raw string) (*mysql.Config, error) {
+	lower := strings.ToLower(raw)
+	if strings.HasPrefix(lower, "mysql://") || strings.HasPrefix(lower, "mariadb://") {
+		parsedURL, err := url.Parse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse mysql URL: %w", err)
+		}
+		if parsedURL.Hostname() == "" {
+			return nil, fmt.Errorf("mysql URL has no hostname")
+		}
+		if parsedURL.Fragment != "" {
+			return nil, fmt.Errorf("mysql URL must not contain a fragment")
+		}
+		port := parsedURL.Port()
+		if port == "" {
+			port = strconv.Itoa(defaultPort)
+		}
+		portNumber, err := strconv.ParseUint(port, 10, 16)
+		if err != nil || portNumber == 0 {
+			return nil, fmt.Errorf("mysql URL port must be between 1 and 65535")
+		}
+
+		cfg := mysql.NewConfig()
+		cfg.Net = "tcp"
+		cfg.Addr = net.JoinHostPort(parsedURL.Hostname(), port)
+		if parsedURL.User != nil {
+			cfg.User = parsedURL.User.Username()
+			cfg.Passwd, _ = parsedURL.User.Password()
+		}
+		escapedDatabase := strings.TrimPrefix(parsedURL.EscapedPath(), "/")
+		cfg.DBName, err = url.PathUnescape(escapedDatabase)
+		if err != nil {
+			return nil, fmt.Errorf("invalid database name: %w", err)
+		}
+		driverDSN := cfg.FormatDSN()
+		if parsedURL.RawQuery != "" {
+			driverDSN += "?" + parsedURL.RawQuery
+		}
+		return mysql.ParseDSN(driverDSN)
+	}
+	return mysql.ParseDSN(raw)
 }

--- a/connectors/mysql/internal/connection/connection.go
+++ b/connectors/mysql/internal/connection/connection.go
@@ -15,6 +15,7 @@ import (
 
 const defaultPort = 3306
 
+// Fields returns the configuration fields for a MySQL connection.
 func Fields() []filament.ConfigField {
 	fields := dbconfig.VisibleWhen(dbconfig.MethodFields)
 	return []filament.ConfigField{
@@ -34,6 +35,7 @@ func Fields() []filament.ConfigField {
 	}
 }
 
+// Resolve translates connector configuration into a MySQL driver config.
 func Resolve(cfg filament.Config) (*mysql.Config, error) {
 	method, err := dbconfig.Method(cfg)
 	if err != nil {

--- a/connectors/mysql/internal/connection/connection_test.go
+++ b/connectors/mysql/internal/connection/connection_test.go
@@ -1,0 +1,41 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/galaxy-io/filament"
+)
+
+func TestResolveFields(t *testing.T) {
+	resolved, err := Resolve(filament.NewConfig(map[string]any{
+		"host": "2001:db8::1", "username": "loader", "password": "p@ss:/word",
+		"database_name": "app", "tls_mode": "true",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Addr != "[2001:db8::1]:3306" || resolved.User != "loader" || resolved.Passwd != "p@ss:/word" || resolved.DBName != "app" || resolved.TLSConfig != "true" {
+		t.Fatalf("connection config = %#v", resolved)
+	}
+}
+
+func TestResolveLegacyDSN(t *testing.T) {
+	resolved, err := Resolve(filament.NewConfig(map[string]any{
+		"dsn": "legacy:secret@tcp(localhost:3307)/app?tls=false",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Addr != "localhost:3307" || resolved.User != "legacy" || resolved.DBName != "app" {
+		t.Fatalf("connection config = %#v", resolved)
+	}
+}
+
+func TestResolveRejectsInvalidPort(t *testing.T) {
+	_, err := Resolve(filament.NewConfig(map[string]any{
+		"host": "localhost", "port": 70000, "username": "loader", "password": "secret", "database_name": "app",
+	}))
+	if err == nil {
+		t.Fatal("invalid port accepted")
+	}
+}

--- a/connectors/mysql/internal/connection/connection_test.go
+++ b/connectors/mysql/internal/connection/connection_test.go
@@ -17,6 +17,38 @@ func TestResolveFields(t *testing.T) {
 	if resolved.Addr != "[2001:db8::1]:3306" || resolved.User != "loader" || resolved.Passwd != "p@ss:/word" || resolved.DBName != "app" || resolved.TLSConfig != "true" {
 		t.Fatalf("connection config = %#v", resolved)
 	}
+	if resolved.TLS == nil || resolved.TLS.InsecureSkipVerify {
+		t.Fatalf("normalized TLS config = %#v", resolved.TLS)
+	}
+}
+
+func TestResolveMySQLURL(t *testing.T) {
+	resolved, err := Resolve(filament.NewConfig(map[string]any{
+		"connection_method": "url",
+		"dsn":               "mysql://user%40example.com:p%40ss%2Fword@[2001:db8::1]:3307/app%2Fdata?tls=true&parseTime=true",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Addr != "[2001:db8::1]:3307" || resolved.User != "user@example.com" || resolved.Passwd != "p@ss/word" || resolved.DBName != "app/data" {
+		t.Fatalf("connection config = %#v", resolved)
+	}
+	if resolved.TLS == nil || resolved.TLS.InsecureSkipVerify || !resolved.ParseTime {
+		t.Fatalf("URL options were not normalized: TLS=%#v ParseTime=%v", resolved.TLS, resolved.ParseTime)
+	}
+}
+
+func TestResolveMariaDBURLUsesDefaultPort(t *testing.T) {
+	resolved, err := Resolve(filament.NewConfig(map[string]any{
+		"connection_method": "url",
+		"dsn":               "mariadb://loader:secret@db.example.com/app?tls=preferred",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Addr != "db.example.com:3306" || resolved.TLS == nil || !resolved.AllowFallbackToPlaintext {
+		t.Fatalf("connection config = %#v", resolved)
+	}
 }
 
 func TestResolveLegacyDSN(t *testing.T) {
@@ -31,11 +63,33 @@ func TestResolveLegacyDSN(t *testing.T) {
 	}
 }
 
+func TestResolveNativeDSNWithMySQLUsername(t *testing.T) {
+	resolved, err := Resolve(filament.NewConfig(map[string]any{
+		"dsn": "mysql:secret@tcp(localhost:3307)/app",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.User != "mysql" || resolved.Passwd != "secret" {
+		t.Fatalf("credentials = %q/%q", resolved.User, resolved.Passwd)
+	}
+}
+
 func TestResolveRejectsInvalidPort(t *testing.T) {
 	_, err := Resolve(filament.NewConfig(map[string]any{
 		"host": "localhost", "port": 70000, "username": "loader", "password": "secret", "database_name": "app",
 	}))
 	if err == nil {
 		t.Fatal("invalid port accepted")
+	}
+}
+
+func TestResolveRejectsURLWithoutHost(t *testing.T) {
+	_, err := Resolve(filament.NewConfig(map[string]any{
+		"connection_method": "url",
+		"dsn":               "mysql:///app",
+	}))
+	if err == nil {
+		t.Fatal("URL without a host accepted")
 	}
 }

--- a/connectors/mysql/sink/mysql.go
+++ b/connectors/mysql/sink/mysql.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/go-sql-driver/mysql"
-
 	"github.com/galaxy-io/filament"
+	mysqlconnection "github.com/galaxy-io/filament/connectors/mysql/internal/connection"
 )
 
 // Sink loads each resource into its own typed table with native columns. The engine
@@ -55,9 +54,10 @@ func (t *Sink) resumableFor(resource string) bool {
 func New() *Sink { return &Sink{} }
 
 var (
-	_ filament.Sink            = (*Sink)(nil)
-	_ filament.LiveValidatable = (*Sink)(nil)
-	_ filament.Schematized     = (*Sink)(nil)
+	_ filament.Sink              = (*Sink)(nil)
+	_ filament.ConfigValidatable = (*Sink)(nil)
+	_ filament.LiveValidatable   = (*Sink)(nil)
+	_ filament.Schematized       = (*Sink)(nil)
 )
 
 // Spec describes the sink's config fields and write capabilities.
@@ -68,12 +68,11 @@ func (t *Sink) Spec() filament.SinkSpec {
 		Description:  "Widely-used open-source relational database known for speed, reliability, and ease of use.",
 		DarkLogoURL:  "https://cdn.getgalaxy.io/sources/source-icon-mysql-dark.svg",
 		LightLogoURL: "https://cdn.getgalaxy.io/sources/source-icon-mysql-light.svg",
-		Version:      "1",
-		Config: filament.ConfigSchema{Fields: []filament.ConfigField{
-			{Name: "dsn", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, Help: "MySQL connection string (user:pass@tcp(host:port)/dbname)"},
+		Version:      "2",
+		Config: filament.ConfigSchema{Fields: append(mysqlconnection.Fields(), []filament.ConfigField{
 			{Name: "database", Type: filament.FieldString, Scope: filament.ScopePipeline, Help: "Destination database. Empty defaults to the normalized source connection name."},
 			{Name: "mode", Type: filament.FieldEnum, Default: "typed", Enum: []filament.EnumOption{{Value: "typed", Label: "Typed"}}, Scope: filament.ScopePipeline, Help: "Destination table mode"},
-		}},
+		}...)},
 		SchemaField: "database",
 		Capabilities: filament.SinkCapabilities{
 			Schematized:        true,
@@ -93,17 +92,21 @@ func (t *Sink) Spec() filament.SinkSpec {
 // Name identifies this sink implementation.
 func (t *Sink) Name() string { return "mysql" }
 
+// Validate checks connection syntax without opening a network connection.
+func (t *Sink) Validate(cfg filament.Config) error {
+	if _, err := mysqlconnection.Resolve(cfg); err != nil {
+		return fmt.Errorf("mysql sink: connection config: %w", err)
+	}
+	return nil
+}
+
 // TestConnection pings MySQL through a short-lived pool. It intentionally
 // clears the database name so validating a new destination does not require
 // that Open's CREATE DATABASE step has already run.
 func (t *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
-	dsn := cfg.Secret("dsn")
-	if dsn == "" {
-		return fmt.Errorf("mysql sink: dsn is required")
-	}
-	mc, err := mysql.ParseDSN(dsn)
+	mc, err := mysqlconnection.Resolve(cfg)
 	if err != nil {
-		return fmt.Errorf("mysql sink: parse dsn: %w", err)
+		return fmt.Errorf("mysql sink: connection config: %w", err)
 	}
 	mc.DBName = ""
 	db, err := sql.Open("mysql", mc.FormatDSN())
@@ -122,13 +125,9 @@ func (t *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
 // EnsureSchema before extraction.
 func (t *Sink) Open(ctx context.Context, run filament.RunSpec) error {
 	cfg := filament.NewConfig(run.Sink.Config)
-	dsn := cfg.Secret("dsn")
-	if dsn == "" {
-		return fmt.Errorf("mysql sink: dsn is required")
-	}
-	mc, err := mysql.ParseDSN(dsn)
+	mc, err := mysqlconnection.Resolve(cfg)
 	if err != nil {
-		return fmt.Errorf("mysql sink: parse dsn: %w", err)
+		return fmt.Errorf("mysql sink: connection config: %w", err)
 	}
 	t.database = mc.DBName
 	if v := cfg.String("database"); v != "" {

--- a/connectors/mysql/source/cdc.go
+++ b/connectors/mysql/source/cdc.go
@@ -517,6 +517,7 @@ func (s *Source) binlogConfig() replication.BinlogSyncerConfig {
 		Port:       s.binlogPort,
 		User:       s.binlogUser,
 		Password:   s.binlogPass,
+		TLSConfig:  s.binlogTLS,
 		UseDecimal: true, // decimals as exact decimal values, not lossy float64
 	}
 }

--- a/connectors/mysql/source/mysql.go
+++ b/connectors/mysql/source/mysql.go
@@ -24,9 +24,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-sql-driver/mysql"
-
 	"github.com/galaxy-io/filament"
+	mysqlconnection "github.com/galaxy-io/filament/connectors/mysql/internal/connection"
 )
 
 const (
@@ -94,7 +93,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 		Description:  "Widely-used open-source relational database known for speed, reliability, and ease of use.",
 		DarkLogoURL:  "https://cdn.getgalaxy.io/sources/source-icon-mysql-dark.svg",
 		LightLogoURL: "https://cdn.getgalaxy.io/sources/source-icon-mysql-light.svg",
-		Version:      "1",
+		Version:      "2",
 		Modes:        []filament.ReadMode{filament.ModeFull, filament.ModeCDC},
 		SourcePolicies: filament.SourcePolicies(
 			filament.IngestionFullReplace,
@@ -102,8 +101,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 			filament.IngestionFullAppend,
 			filament.IngestionCDC,
 		),
-		Config: filament.ConfigSchema{Fields: []filament.ConfigField{
-			{Name: "dsn", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, Help: "MySQL connection string (user:pass@tcp(host:port)/dbname)"},
+		Config: filament.ConfigSchema{Fields: append(mysqlconnection.Fields(), []filament.ConfigField{
 			{Name: "replication", Type: filament.FieldEnum, Default: string(filament.ReplicationStandard), Enum: []filament.EnumOption{
 				{Value: string(filament.ReplicationStandard), Label: "Standard"},
 				{Value: string(filament.ReplicationCDC), Label: "Change Data Capture (CDC)"},
@@ -113,7 +111,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 			{Name: "shard_pages", Type: filament.FieldInt, Default: defaultShardPages, Scope: filament.ScopePipeline, Help: "InnoDB pages per shard; 0 disables sharding"},
 			{Name: "max_conns", Type: filament.FieldInt, Scope: filament.ScopePipeline, Help: "Maximum source database connections"},
 			{Name: "server_id", Type: filament.FieldInt, Default: defaultServerID, Scope: filament.ScopePipeline, Help: "Replication client server_id for CDC (must be unique in the replica topology)"},
-		}},
+		}...)},
 		Resources: filament.ResourceCapabilities{Discoverable: true},
 	}
 }
@@ -126,20 +124,14 @@ func (s *Source) Replication(cfg filament.Config) filament.ReplicationMode {
 	return filament.ReplicationStandard
 }
 
-// Validate rejects a config missing the connection string or one whose DSN names no
-// database when "database" is also unset.
+// Validate rejects an invalid DSN or incomplete individual connection fields.
 func (s *Source) Validate(cfg filament.Config) error {
-	if cfg.String("dsn") == "" {
-		return fmt.Errorf("mysql source: dsn is required")
+	mc, err := mysqlconnection.Resolve(cfg)
+	if err != nil {
+		return fmt.Errorf("mysql source: connection config: %w", err)
 	}
-	if cfg.String("database") == "" {
-		mc, err := mysql.ParseDSN(cfg.Secret("dsn"))
-		if err != nil {
-			return fmt.Errorf("mysql source: parse dsn: %w", err)
-		}
-		if mc.DBName == "" {
-			return fmt.Errorf("mysql source: dsn has no database and \"database\" is unset")
-		}
+	if cfg.String("database") == "" && mc.DBName == "" {
+		return fmt.Errorf("mysql source: connection has no database and \"database\" is unset")
 	}
 	return nil
 }
@@ -149,9 +141,9 @@ func (s *Source) TestConnection(ctx context.Context, cfg filament.Config) error 
 	if err := s.Validate(cfg); err != nil {
 		return err
 	}
-	mc, err := mysql.ParseDSN(cfg.Secret("dsn"))
+	mc, err := mysqlconnection.Resolve(cfg)
 	if err != nil {
-		return fmt.Errorf("mysql source: parse dsn: %w", err)
+		return fmt.Errorf("mysql source: connection config: %w", err)
 	}
 	if database := cfg.String("database"); database != "" {
 		mc.DBName = database
@@ -174,9 +166,9 @@ func (s *Source) Configure(ctx context.Context, cfg filament.Config) error {
 	if err := s.Validate(cfg); err != nil {
 		return err
 	}
-	mc, err := mysql.ParseDSN(cfg.Secret("dsn"))
+	mc, err := mysqlconnection.Resolve(cfg)
 	if err != nil {
-		return fmt.Errorf("mysql source: parse dsn: %w", err)
+		return fmt.Errorf("mysql source: connection config: %w", err)
 	}
 	s.database = mc.DBName
 	if v := cfg.String("database"); v != "" {

--- a/connectors/mysql/source/mysql.go
+++ b/connectors/mysql/source/mysql.go
@@ -18,9 +18,11 @@ package mysql
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"fmt"
 	"math"
+	"net"
 	"strconv"
 	"strings"
 
@@ -59,6 +61,7 @@ type Source struct {
 	binlogPort uint16
 	binlogUser string
 	binlogPass string
+	binlogTLS  *tls.Config
 }
 
 // New returns an unconfigured source.
@@ -190,9 +193,20 @@ func (s *Source) Configure(ctx context.Context, cfg filament.Config) error {
 			s.serverID = uint32(n)
 		}
 	}
-	host, port := splitHostPort(mc.Addr)
-	s.binlogHost, s.binlogPort = host, port
+	if mc.Net == "tcp" {
+		host, port, err := splitHostPort(mc.Addr)
+		if err != nil {
+			return fmt.Errorf("mysql source: replication address: %w", err)
+		}
+		s.binlogHost, s.binlogPort = host, port
+	} else if s.Replication(cfg) == filament.ReplicationCDC {
+		return fmt.Errorf("mysql source: CDC requires a TCP connection, got network %q", mc.Net)
+	}
 	s.binlogUser, s.binlogPass = mc.User, mc.Passwd
+	s.binlogTLS = nil
+	if mc.TLS != nil {
+		s.binlogTLS = mc.TLS.Clone()
+	}
 
 	db, err := sql.Open("mysql", mc.FormatDSN())
 	if err != nil {
@@ -442,16 +456,16 @@ func quoteIdent(s string) string {
 
 // splitHostPort splits a go-sql-driver Addr ("host:port", port optional) for the
 // replication client.
-func splitHostPort(addr string) (string, uint16) {
-	host, portStr, ok := strings.Cut(addr, ":")
-	if !ok {
-		return addr, 3306
+func splitHostPort(addr string) (string, uint16, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, fmt.Errorf("split %q: %w", addr, err)
 	}
 	n, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		return host, 3306
+	if err != nil || n == 0 {
+		return "", 0, fmt.Errorf("invalid port in %q", addr)
 	}
-	return host, uint16(n)
+	return host, uint16(n), nil
 }
 
 // quoteLiteral renders s as a single-quoted SQL string literal. Used only for
@@ -543,5 +557,6 @@ func (s *Source) Teardown(context.Context) error {
 		_ = s.db.Close()
 		s.db = nil
 	}
+	s.binlogTLS = nil
 	return nil
 }

--- a/connectors/postgres/internal/connection/connection.go
+++ b/connectors/postgres/internal/connection/connection.go
@@ -1,0 +1,110 @@
+package connection
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/connectors/internal/dbconfig"
+)
+
+const defaultPort = 5432
+
+type Resolved struct {
+	DSN  string
+	Pool *pgxpool.Config
+}
+
+func Fields() []filament.ConfigField {
+	fields := dbconfig.VisibleWhen(dbconfig.MethodFields)
+	return []filament.ConfigField{
+		dbconfig.MethodConfigField(),
+		dbconfig.DSNConfigField("PostgreSQL connection URL"),
+		{Name: "host", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "PostgreSQL server hostname"},
+		{Name: "port", Type: filament.FieldInt, Default: defaultPort, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "PostgreSQL server port"},
+		{Name: "username", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "PostgreSQL username"},
+		{Name: "password", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "PostgreSQL password"},
+		{Name: "database_name", Type: filament.FieldString, Required: true, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "Database to connect to"},
+		{Name: "ssl_mode", Type: filament.FieldEnum, Default: "prefer", Enum: []filament.EnumOption{
+			{Value: "disable", Label: "Disable"},
+			{Value: "allow", Label: "Allow"},
+			{Value: "prefer", Label: "Prefer"},
+			{Value: "require", Label: "Require"},
+			{Value: "verify-ca", Label: "Verify CA"},
+			{Value: "verify-full", Label: "Verify Full"},
+		}, Scope: filament.ScopeConnection, VisibleWhen: fields, Help: "PostgreSQL TLS verification mode"},
+	}
+}
+
+func Resolve(cfg filament.Config) (Resolved, error) {
+	method, err := dbconfig.Method(cfg)
+	if err != nil {
+		return Resolved{}, err
+	}
+	dsn := cfg.Secret(dbconfig.DSNField)
+	if method == dbconfig.MethodFields {
+		dsn, err = fieldsDSN(cfg)
+		if err != nil {
+			return Resolved{}, err
+		}
+	} else if strings.TrimSpace(dsn) == "" {
+		return Resolved{}, fmt.Errorf("dsn is required when connection_method is %q", dbconfig.MethodURL)
+	}
+	pool, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return Resolved{}, fmt.Errorf("parse dsn: %w", err)
+	}
+	return Resolved{DSN: dsn, Pool: pool}, nil
+}
+
+func fieldsDSN(cfg filament.Config) (string, error) {
+	host := strings.TrimSpace(cfg.String("host"))
+	if host == "" {
+		return "", fmt.Errorf("host is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	port := cfg.Int("port")
+	if port == 0 {
+		port = defaultPort
+	}
+	if port < 1 || port > 65535 {
+		return "", fmt.Errorf("port must be between 1 and 65535")
+	}
+	username := cfg.String("username")
+	if username == "" {
+		return "", fmt.Errorf("username is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	password := cfg.Secret("password")
+	if password == "" {
+		return "", fmt.Errorf("password is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	database := cfg.String("database_name")
+	if database == "" {
+		return "", fmt.Errorf("database_name is required when connection_method is %q", dbconfig.MethodFields)
+	}
+	sslMode := cfg.String("ssl_mode")
+	if sslMode == "" {
+		sslMode = "prefer"
+	}
+	switch sslMode {
+	case "disable", "allow", "prefer", "require", "verify-ca", "verify-full":
+	default:
+		return "", fmt.Errorf("unsupported ssl_mode %q", sslMode)
+	}
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	u := &url.URL{
+		Scheme:  "postgresql",
+		User:    url.UserPassword(username, password),
+		Host:    net.JoinHostPort(host, strconv.Itoa(port)),
+		Path:    "/" + database,
+		RawPath: "/" + url.PathEscape(database),
+	}
+	query := u.Query()
+	query.Set("sslmode", sslMode)
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}

--- a/connectors/postgres/internal/connection/connection.go
+++ b/connectors/postgres/internal/connection/connection.go
@@ -15,11 +15,13 @@ import (
 
 const defaultPort = 5432
 
+// Resolved contains the PostgreSQL connection string and parsed pool config.
 type Resolved struct {
 	DSN  string
 	Pool *pgxpool.Config
 }
 
+// Fields returns the configuration fields for a PostgreSQL connection.
 func Fields() []filament.ConfigField {
 	fields := dbconfig.VisibleWhen(dbconfig.MethodFields)
 	return []filament.ConfigField{
@@ -41,6 +43,7 @@ func Fields() []filament.ConfigField {
 	}
 }
 
+// Resolve translates connector configuration into a PostgreSQL pool config.
 func Resolve(cfg filament.Config) (Resolved, error) {
 	method, err := dbconfig.Method(cfg)
 	if err != nil {

--- a/connectors/postgres/internal/connection/connection_test.go
+++ b/connectors/postgres/internal/connection/connection_test.go
@@ -1,0 +1,45 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/galaxy-io/filament"
+)
+
+func TestResolveFields(t *testing.T) {
+	resolved, err := Resolve(filament.NewConfig(map[string]any{
+		"host": "2001:db8::1", "username": "user@example.com", "password": "p@ss:/word",
+		"database_name": "app/data", "ssl_mode": "verify-full",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Pool.ConnConfig.Host != "2001:db8::1" || resolved.Pool.ConnConfig.Port != 5432 {
+		t.Fatalf("address = %s:%d", resolved.Pool.ConnConfig.Host, resolved.Pool.ConnConfig.Port)
+	}
+	if resolved.Pool.ConnConfig.User != "user@example.com" || resolved.Pool.ConnConfig.Password != "p@ss:/word" || resolved.Pool.ConnConfig.Database != "app/data" {
+		t.Fatalf("connection config = %#v", resolved.Pool.ConnConfig)
+	}
+}
+
+func TestResolveLegacyDSN(t *testing.T) {
+	resolved, err := Resolve(filament.NewConfig(map[string]any{
+		"dsn": "postgres://legacy:secret@localhost:5433/app?sslmode=disable",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Pool.ConnConfig.Host != "localhost" || resolved.Pool.ConnConfig.Port != 5433 {
+		t.Fatalf("address = %s:%d", resolved.Pool.ConnConfig.Host, resolved.Pool.ConnConfig.Port)
+	}
+}
+
+func TestResolveSelectedModeDoesNotMixInputs(t *testing.T) {
+	_, err := Resolve(filament.NewConfig(map[string]any{
+		"connection_method": "fields",
+		"dsn":               "postgres://legacy:secret@localhost/app",
+	}))
+	if err == nil {
+		t.Fatal("fields mode accepted the inactive dsn")
+	}
+}

--- a/connectors/postgres/sink/postgres.go
+++ b/connectors/postgres/sink/postgres.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/galaxy-io/filament"
+	pgconnection "github.com/galaxy-io/filament/connectors/postgres/internal/connection"
 )
 
 // Sink loads each resource into its own typed table with native columns. The engine
@@ -57,9 +58,10 @@ const defaultSchema = "public"
 func New() *Sink { return &Sink{schema: defaultSchema} }
 
 var (
-	_ filament.Sink            = (*Sink)(nil)
-	_ filament.LiveValidatable = (*Sink)(nil)
-	_ filament.Schematized     = (*Sink)(nil)
+	_ filament.Sink              = (*Sink)(nil)
+	_ filament.ConfigValidatable = (*Sink)(nil)
+	_ filament.LiveValidatable   = (*Sink)(nil)
+	_ filament.Schematized       = (*Sink)(nil)
 )
 
 // Spec describes the sink's config fields and write capabilities.
@@ -70,12 +72,11 @@ func (t *Sink) Spec() filament.SinkSpec {
 		Description:  "Popular open-source relational database management system known for reliability and advanced features.",
 		DarkLogoURL:  "https://cdn.getgalaxy.io/sources/source-icon-postgres-dark.svg",
 		LightLogoURL: "https://cdn.getgalaxy.io/sources/source-icon-postgres-light.svg",
-		Version:      "1",
-		Config: filament.ConfigSchema{Fields: []filament.ConfigField{
-			{Name: "dsn", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, Help: "PostgreSQL connection string"},
+		Version:      "2",
+		Config: filament.ConfigSchema{Fields: append(pgconnection.Fields(), []filament.ConfigField{
 			{Name: "schema", Type: filament.FieldString, Default: defaultSchema, Scope: filament.ScopePipeline, Help: "Destination schema. Empty defaults to the normalized source connection name."},
 			{Name: "mode", Type: filament.FieldEnum, Default: "typed", Enum: []filament.EnumOption{{Value: "typed", Label: "Typed"}}, Scope: filament.ScopePipeline, Help: "Destination table mode"},
-		}},
+		}...)},
 		SchemaField: "schema",
 		Capabilities: filament.SinkCapabilities{
 			Schematized: true,
@@ -94,18 +95,22 @@ func (t *Sink) Spec() filament.SinkSpec {
 // Name identifies this sink implementation.
 func (t *Sink) Name() string { return "postgres" }
 
+// Validate checks connection syntax without opening a network connection.
+func (t *Sink) Validate(cfg filament.Config) error {
+	if _, err := pgconnection.Resolve(cfg); err != nil {
+		return fmt.Errorf("postgres sink: connection config: %w", err)
+	}
+	return nil
+}
+
 // TestConnection opens a short-lived pool and verifies the configured
 // credentials without creating the destination schema.
 func (t *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
-	dsn := cfg.Secret("dsn")
-	if dsn == "" {
-		return fmt.Errorf("postgres sink: dsn is required")
-	}
-	poolCfg, err := pgxpool.ParseConfig(dsn)
+	resolved, err := pgconnection.Resolve(cfg)
 	if err != nil {
-		return fmt.Errorf("postgres sink: parse dsn: %w", err)
+		return fmt.Errorf("postgres sink: connection config: %w", err)
 	}
-	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	pool, err := pgxpool.NewWithConfig(ctx, resolved.Pool)
 	if err != nil {
 		return fmt.Errorf("postgres sink: open pool: %w", err)
 	}
@@ -120,10 +125,11 @@ func (t *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
 // does no DDL — tables are created per resource by EnsureSchema before extraction.
 func (t *Sink) Open(ctx context.Context, run filament.RunSpec) error {
 	cfg := filament.NewConfig(run.Sink.Config)
-	t.dsn = cfg.Secret("dsn")
-	if t.dsn == "" {
-		return fmt.Errorf("postgres sink: dsn is required")
+	resolved, err := pgconnection.Resolve(cfg)
+	if err != nil {
+		return fmt.Errorf("postgres sink: connection config: %w", err)
 	}
+	t.dsn = resolved.DSN
 	if v := cfg.String("schema"); v != "" {
 		t.schema = v
 	}
@@ -132,10 +138,7 @@ func (t *Sink) Open(ctx context.Context, run filament.RunSpec) error {
 	t.written.Store(0)
 	t.tables = map[string]*table{}
 
-	poolCfg, err := pgxpool.ParseConfig(t.dsn)
-	if err != nil {
-		return fmt.Errorf("postgres sink: parse dsn: %w", err)
-	}
+	poolCfg := resolved.Pool
 	if n := run.Options.SnapshotParallelism; n > 0 && n <= math.MaxInt32 {
 		poolCfg.MaxConns = max(poolCfg.MaxConns, int32(n))
 	}

--- a/connectors/postgres/source/postgres.go
+++ b/connectors/postgres/source/postgres.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/galaxy-io/filament"
+	pgconnection "github.com/galaxy-io/filament/connectors/postgres/internal/connection"
 )
 
 const (
@@ -121,7 +122,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 		Description:  "Popular open-source relational database management system known for reliability and advanced features.",
 		DarkLogoURL:  "https://cdn.getgalaxy.io/sources/source-icon-postgres-dark.svg",
 		LightLogoURL: "https://cdn.getgalaxy.io/sources/source-icon-postgres-light.svg",
-		Version:      "1",
+		Version:      "2",
 		Modes:        []filament.ReadMode{filament.ModeFull, filament.ModeIncremental, filament.ModeCDC},
 		SourcePolicies: filament.SourcePolicies(
 			filament.IngestionFullReplace,
@@ -131,8 +132,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 			filament.IngestionIncrementalUpsert,
 			filament.IngestionCDC,
 		),
-		Config: filament.ConfigSchema{Fields: []filament.ConfigField{
-			{Name: "dsn", Type: filament.FieldSecret, Required: true, Scope: filament.ScopeConnection, Help: "PostgreSQL connection string"},
+		Config: filament.ConfigSchema{Fields: append(pgconnection.Fields(), []filament.ConfigField{
 			{Name: "replication", Type: filament.FieldEnum, Default: replicationStandard, Enum: []filament.EnumOption{
 				{Value: replicationStandard, Label: "Standard"},
 				{Value: replicationCDC, Label: "Change Data Capture (CDC)"},
@@ -162,7 +162,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 				Help:        "Create the CDC publication and add selected tables when needed",
 			},
 			{Name: "slot_name", Type: filament.FieldString, Default: defaultSlotName, Scope: filament.ScopePipeline, Help: "Persistent logical replication slot; use a unique slot per CDC pipeline"},
-		}},
+		}...)},
 		Resources: filament.ResourceCapabilities{Discoverable: true, PerResourceCursor: true},
 	}
 }
@@ -175,10 +175,10 @@ func (s *Source) Replication(cfg filament.Config) filament.ReplicationMode {
 	return filament.ReplicationStandard
 }
 
-// Validate rejects a config missing the connection string.
+// Validate rejects an invalid URL or incomplete individual connection fields.
 func (s *Source) Validate(cfg filament.Config) error {
-	if cfg.String("dsn") == "" {
-		return fmt.Errorf("postgres source: dsn is required")
+	if _, err := pgconnection.Resolve(cfg); err != nil {
+		return fmt.Errorf("postgres source: connection config: %w", err)
 	}
 	for field, fallback := range map[string]string{"publication": defaultPublication, "slot_name": defaultSlotName} {
 		value := cfg.String(field)
@@ -197,11 +197,11 @@ func (s *Source) TestConnection(ctx context.Context, cfg filament.Config) error 
 	if err := s.Validate(cfg); err != nil {
 		return err
 	}
-	poolCfg, err := pgxpool.ParseConfig(cfg.Secret("dsn"))
+	resolved, err := pgconnection.Resolve(cfg)
 	if err != nil {
-		return fmt.Errorf("postgres source: parse dsn: %w", err)
+		return fmt.Errorf("postgres source: connection config: %w", err)
 	}
-	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	pool, err := pgxpool.NewWithConfig(ctx, resolved.Pool)
 	if err != nil {
 		return fmt.Errorf("postgres source: open pool: %w", err)
 	}
@@ -247,11 +247,12 @@ func (s *Source) Configure(ctx context.Context, cfg filament.Config) error {
 	if cfg.Has("manage_publication") {
 		s.managePublication = cfg.Bool("manage_publication")
 	}
-	s.dsn = cfg.Secret("dsn")
-	poolCfg, err := pgxpool.ParseConfig(s.dsn)
+	resolved, err := pgconnection.Resolve(cfg)
 	if err != nil {
-		return fmt.Errorf("postgres source: parse dsn: %w", err)
+		return fmt.Errorf("postgres source: connection config: %w", err)
 	}
+	s.dsn = resolved.DSN
+	poolCfg := resolved.Pool
 	if cfg.Has("max_conns") {
 		if n := cfg.Int("max_conns"); n > 0 && n <= math.MaxInt32 {
 			poolCfg.MaxConns = int32(n)

--- a/server/connections.go
+++ b/server/connections.go
@@ -39,7 +39,7 @@ func (a *Server) CreateConnection(ctx context.Context, req *connect.Request[inge
 		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
 	}
 	effective = overlayConfig(effective, cfg)
-	if err := validateConfigSchema(schema, filament.NewConfig(effective), filament.ScopeConnection); err != nil {
+	if err := validateConfigSchema(schema, filament.NewConfig(effective)); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if err := a.validateConnectionConnectorConfig(req.Msg.GetKind(), req.Msg.GetConnector(), filament.NewConfig(effective)); err != nil {
@@ -112,7 +112,7 @@ func (a *Server) UpdateConnection(ctx context.Context, req *connect.Request[inge
 	}
 	effective = overlayConfig(effective, cfg)
 	canonicalizeConnectionConfig(schema, effective, cloneStrings(refs))
-	if err := validateConfigSchema(schema, filament.NewConfig(effective), filament.ScopeConnection); err != nil {
+	if err := validateConfigSchema(schema, filament.NewConfig(effective)); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if err := a.validateConnectionConnectorConfig(in.GetKind(), in.GetConnector(), filament.NewConfig(effective)); err != nil {

--- a/server/connections.go
+++ b/server/connections.go
@@ -25,16 +25,28 @@ func (a *Server) CreateConnection(ctx context.Context, req *connect.Request[inge
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	cfg := structMap(req.Msg.GetConfig())
+	refs := cloneStrings(req.Msg.GetSecretRefs())
+	tenant := defaultTenant(req.Msg.GetTenantId())
+	canonicalizeConnectionConfig(schema, cfg, refs)
+	if err := validateSecretRefTenant(refs, tenant); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
 	if err := compile.ValidateConnectionConfig(schema, cfg); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	effective := map[string]any{}
+	if err := a.resolveConnectionSecrets(ctx, filament.Connection{ID: "new", Tenant: tenant, SecretRefs: refs}, effective); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	effective = overlayConfig(effective, cfg)
+	if err := validateConfigSchema(schema, filament.NewConfig(effective), filament.ScopeConnection); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := a.validateConnectionConnectorConfig(req.Msg.GetKind(), req.Msg.GetConnector(), filament.NewConfig(effective)); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	id := uuid.NewString()
-	tenant := defaultTenant(req.Msg.GetTenantId())
-	refs := cloneStrings(req.Msg.GetSecretRefs())
-	if err := validateSecretRefTenant(refs, tenant); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
 	written, err := a.storeSecretFields(ctx, schema, tenant, id, 1, cfg, refs, false)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
@@ -86,7 +98,24 @@ func (a *Server) UpdateConnection(ctx context.Context, req *connect.Request[inge
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	cfg := structMap(in.GetConfig())
+	refs := cloneStrings(in.GetSecretRefs())
+	canonicalizeConnectionConfig(schema, cfg, refs)
+	if err := validateSecretRefTenant(refs, stored.Tenant); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
 	if err := compile.ValidateConnectionConfig(schema, cfg); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	effective := cloneConfigMap(stored.Config)
+	if err := a.resolveConnectionSecrets(ctx, filament.Connection{ID: stored.ID, Tenant: stored.Tenant, SecretRefs: refs}, effective); err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	effective = overlayConfig(effective, cfg)
+	canonicalizeConnectionConfig(schema, effective, cloneStrings(refs))
+	if err := validateConfigSchema(schema, filament.NewConfig(effective), filament.ScopeConnection); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := a.validateConnectionConnectorConfig(in.GetKind(), in.GetConnector(), filament.NewConfig(effective)); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if stored.Kind == filament.ConnectorKindSource {
@@ -99,10 +128,6 @@ func (a *Server) UpdateConnection(ctx context.Context, req *connect.Request[inge
 		if before != after {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("connection replication mode is immutable; create a new connection to change from %s to %s", before, after))
 		}
-	}
-	refs := cloneStrings(in.GetSecretRefs())
-	if err := validateSecretRefTenant(refs, stored.Tenant); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	// A newly submitted value gets a versioned ref. The old value remains active
 	// until the optimistic connection update succeeds.
@@ -159,6 +184,10 @@ func (a *Server) ListConnections(ctx context.Context, req *connect.Request[inges
 }
 
 func (a *Server) connectionForResponse(conn filament.Connection) *ingestionv1.Connection {
+	conn.Config = cloneConfigMap(conn.Config)
+	if schema, err := a.schemaFor(connectionKindToProto(conn.Kind), conn.Connector); err == nil {
+		canonicalizeConnectionConfig(schema, conn.Config, cloneStrings(conn.SecretRefs))
+	}
 	out := connectionToProto(conn)
 	if conn.Kind != filament.ConnectorKindSource {
 		return out
@@ -336,6 +365,55 @@ func overlayConfig(base, overlay map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+func cloneConfigMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+// canonicalizeConnectionConfig materializes the fields-first database selector
+// and removes known fields from inactive conditional branches. A missing
+// selector with an existing DSN remains URL mode for legacy connections.
+func canonicalizeConnectionConfig(schema filament.ConfigSchema, cfg map[string]any, refs map[string]string) {
+	if hasConfigField(schema.Fields, "connection_method") {
+		if method, _ := cfg["connection_method"].(string); method == "" {
+			if dsn, _ := cfg["dsn"].(string); dsn != "" || refs["dsn"] != "" {
+				cfg["connection_method"] = "url"
+			} else {
+				cfg["connection_method"] = "fields"
+			}
+		}
+	}
+	pruneInactiveFields(schema.Fields, cfg, refs, "")
+}
+
+func hasConfigField(fields []filament.ConfigField, name string) bool {
+	for _, field := range fields {
+		if field.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func pruneInactiveFields(fields []filament.ConfigField, cfg map[string]any, refs map[string]string, parent string) {
+	config := filament.NewConfig(cfg)
+	for _, field := range fields {
+		path := joinConfigPath(parent, field.Name)
+		if !fieldIsVisible(field, config) {
+			delete(cfg, field.Name)
+			delete(refs, path)
+			continue
+		}
+		nested, ok := cfg[field.Name].(map[string]any)
+		if ok && len(field.Fields) > 0 {
+			pruneInactiveFields(field.Fields, nested, refs, path)
+		}
+	}
 }
 
 func joinConfigPath(parent, field string) string {

--- a/server/connections.go
+++ b/server/connections.go
@@ -350,19 +350,27 @@ func (a *Server) loadConnectionForTenant(ctx context.Context, id, tenant string)
 	return conn, nil
 }
 
-// overlayConfig shallow-merges overlay over base, like mergeConfig, except a
-// blank string in overlay means "not supplied" and defers to base — so an
-// untouched secret field never clobbers a resolved value with "".
+// overlayConfig recursively merges overlay over base. A blank string at any
+// depth means "not supplied" and defers to base, so an untouched secret field
+// never clobbers a resolved value with "" inside a nested config object.
 func overlayConfig(base, overlay map[string]any) map[string]any {
 	out := make(map[string]any, len(base)+len(overlay))
 	for k, v := range base {
-		out[k] = v
+		out[k] = cloneConfigValue(v)
 	}
 	for k, v := range overlay {
 		if s, ok := v.(string); ok && s == "" {
 			continue
 		}
-		out[k] = v
+		if nestedOverlay, ok := v.(map[string]any); ok {
+			if nestedBase, ok := out[k].(map[string]any); ok {
+				out[k] = overlayConfig(nestedBase, nestedOverlay)
+				continue
+			}
+			out[k] = overlayConfig(nil, nestedOverlay)
+			continue
+		}
+		out[k] = cloneConfigValue(v)
 	}
 	return out
 }
@@ -370,9 +378,16 @@ func overlayConfig(base, overlay map[string]any) map[string]any {
 func cloneConfigMap(in map[string]any) map[string]any {
 	out := make(map[string]any, len(in))
 	for key, value := range in {
-		out[key] = value
+		out[key] = cloneConfigValue(value)
 	}
 	return out
+}
+
+func cloneConfigValue(value any) any {
+	if nested, ok := value.(map[string]any); ok {
+		return cloneConfigMap(nested)
+	}
+	return value
 }
 
 // canonicalizeConnectionConfig materializes the fields-first database selector

--- a/server/connectors.go
+++ b/server/connectors.go
@@ -100,7 +100,6 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 		}
 		config = overlayConfig(conn.Config, config)
 	}
-	cfg := filament.NewConfig(config)
 	switch req.Msg.GetKind() {
 	case ingestionv1.ConnectorKind_CONNECTOR_KIND_SOURCE:
 		source, err := a.sources.Resolve(req.Msg.GetConnector())
@@ -108,8 +107,8 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
 		canonicalizeConnectionConfig(source.Spec().Config, config, nil)
-		cfg = filament.NewConfig(config)
-		if err := validateConfigSchema(source.Spec().Config, cfg, filament.ScopeConnection); err != nil {
+		cfg := filament.NewConfig(config)
+		if err := validateConfigSchema(source.Spec().Config, cfg); err != nil {
 			return connect.NewResponse(schemaValidationError(err)), nil
 		}
 		if err := source.Validate(cfg); err != nil {
@@ -121,8 +120,8 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
 		canonicalizeConnectionConfig(sink.Spec().Config, config, nil)
-		cfg = filament.NewConfig(config)
-		if err := validateConfigSchema(sink.Spec().Config, cfg, filament.ScopeConnection); err != nil {
+		cfg := filament.NewConfig(config)
+		if err := validateConfigSchema(sink.Spec().Config, cfg); err != nil {
 			return connect.NewResponse(schemaValidationError(err)), nil
 		}
 		if validator, ok := sink.(filament.ConfigValidatable); ok {

--- a/server/connectors.go
+++ b/server/connectors.go
@@ -107,6 +107,11 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 		if err != nil {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
+		canonicalizeConnectionConfig(source.Spec().Config, config, nil)
+		cfg = filament.NewConfig(config)
+		if err := validateConfigSchema(source.Spec().Config, cfg, filament.ScopeConnection); err != nil {
+			return connect.NewResponse(validationError(err.Error())), nil
+		}
 		if err := source.Validate(cfg); err != nil {
 			return connect.NewResponse(validationError(err.Error())), nil
 		}
@@ -115,13 +120,42 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 		if err != nil {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
+		canonicalizeConnectionConfig(sink.Spec().Config, config, nil)
+		cfg = filament.NewConfig(config)
 		if err := validateConfigSchema(sink.Spec().Config, cfg, filament.ScopeConnection); err != nil {
 			return connect.NewResponse(validationError(err.Error())), nil
+		}
+		if validator, ok := sink.(filament.ConfigValidatable); ok {
+			if err := validator.Validate(cfg); err != nil {
+				return connect.NewResponse(validationError(err.Error())), nil
+			}
 		}
 	default:
 		return connect.NewResponse(validationError("connector kind is required")), nil
 	}
 	return connect.NewResponse(&ingestionv1.ValidateConfigResponse{Valid: true}), nil
+}
+
+func (a *Server) validateConnectionConnectorConfig(kind ingestionv1.ConnectorKind, connector string, cfg filament.Config) error {
+	switch kind {
+	case ingestionv1.ConnectorKind_CONNECTOR_KIND_SOURCE:
+		source, err := a.sources.Resolve(connector)
+		if err != nil {
+			return err
+		}
+		return source.Validate(cfg)
+	case ingestionv1.ConnectorKind_CONNECTOR_KIND_SINK:
+		sink, err := a.sinks.Resolve(connector)
+		if err != nil {
+			return err
+		}
+		if validator, ok := sink.(filament.ConfigValidatable); ok {
+			return validator.Validate(cfg)
+		}
+		return nil
+	default:
+		return fmt.Errorf("connector kind is required")
+	}
 }
 
 // DiscoverResources configures the source and lists its selectable resources.

--- a/server/connectors.go
+++ b/server/connectors.go
@@ -110,7 +110,7 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 		canonicalizeConnectionConfig(source.Spec().Config, config, nil)
 		cfg = filament.NewConfig(config)
 		if err := validateConfigSchema(source.Spec().Config, cfg, filament.ScopeConnection); err != nil {
-			return connect.NewResponse(validationError(err.Error())), nil
+			return connect.NewResponse(schemaValidationError(err)), nil
 		}
 		if err := source.Validate(cfg); err != nil {
 			return connect.NewResponse(validationError(err.Error())), nil
@@ -123,7 +123,7 @@ func (a *Server) ValidateConfig(ctx context.Context, req *connect.Request[ingest
 		canonicalizeConnectionConfig(sink.Spec().Config, config, nil)
 		cfg = filament.NewConfig(config)
 		if err := validateConfigSchema(sink.Spec().Config, cfg, filament.ScopeConnection); err != nil {
-			return connect.NewResponse(validationError(err.Error())), nil
+			return connect.NewResponse(schemaValidationError(err)), nil
 		}
 		if validator, ok := sink.(filament.ConfigValidatable); ok {
 			if err := validator.Validate(cfg); err != nil {

--- a/server/connectors_test.go
+++ b/server/connectors_test.go
@@ -84,6 +84,48 @@ func TestValidateConfigDoesNotRunLiveSinkProbe(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeDatabaseConnectionConfig(t *testing.T) {
+	schema := filament.ConfigSchema{Fields: []filament.ConfigField{
+		{Name: "connection_method", Type: filament.FieldEnum, Default: "fields", Scope: filament.ScopeConnection},
+		{Name: "dsn", Type: filament.FieldSecret, Scope: filament.ScopeConnection, VisibleWhen: &filament.FieldCondition{Field: "connection_method", Values: []string{"url"}}},
+		{Name: "host", Type: filament.FieldString, Scope: filament.ScopeConnection, VisibleWhen: &filament.FieldCondition{Field: "connection_method", Values: []string{"fields"}}},
+		{Name: "password", Type: filament.FieldSecret, Scope: filament.ScopeConnection, VisibleWhen: &filament.FieldCondition{Field: "connection_method", Values: []string{"fields"}}},
+	}}
+
+	t.Run("legacy dsn infers url", func(t *testing.T) {
+		cfg := map[string]any{"host": "stale"}
+		refs := map[string]string{"dsn": "filament/tenant/connection/id/dsn/v1", "password": "filament/tenant/connection/id/password/v1"}
+		canonicalizeConnectionConfig(schema, cfg, refs)
+		if cfg["connection_method"] != "url" || cfg["host"] != nil || refs["password"] != "" {
+			t.Fatalf("config = %#v, refs = %#v", cfg, refs)
+		}
+	})
+
+	t.Run("new config defaults to fields", func(t *testing.T) {
+		cfg := map[string]any{"host": "localhost", "dsn": "stale"}
+		refs := map[string]string{}
+		canonicalizeConnectionConfig(schema, cfg, refs)
+		// A supplied DSN is a legacy URL configuration even without the selector.
+		if cfg["connection_method"] != "url" {
+			t.Fatalf("method = %v, want url", cfg["connection_method"])
+		}
+		cfg = map[string]any{"host": "localhost"}
+		canonicalizeConnectionConfig(schema, cfg, refs)
+		if cfg["connection_method"] != "fields" || cfg["host"] != "localhost" {
+			t.Fatalf("config = %#v", cfg)
+		}
+	})
+
+	t.Run("explicit fields removes dsn", func(t *testing.T) {
+		cfg := map[string]any{"connection_method": "fields", "host": "localhost", "dsn": "stale"}
+		refs := map[string]string{"dsn": "filament/tenant/connection/id/dsn/v1"}
+		canonicalizeConnectionConfig(schema, cfg, refs)
+		if cfg["dsn"] != nil || refs["dsn"] != "" {
+			t.Fatalf("config = %#v, refs = %#v", cfg, refs)
+		}
+	})
+}
+
 func TestGetConnector(t *testing.T) {
 	sources := registry.NewSources()
 	sources.RegisterWithMaturity("columns", filament.MaturityBeta, func() filament.Source {

--- a/server/convert.go
+++ b/server/convert.go
@@ -484,6 +484,9 @@ func validateConfigField(field filament.ConfigField, cfg filament.Config, path s
 	if field.Required && !cfg.Has(field.Name) {
 		return fmt.Errorf("%s is required", path)
 	}
+	if field.Required && (field.Type == filament.FieldString || field.Type == filament.FieldSecret || field.Type == filament.FieldEnum) && strings.TrimSpace(cfg.String(field.Name)) == "" {
+		return fmt.Errorf("%s is required", path)
+	}
 	if field.Required && field.Type == filament.FieldList && configListLen(cfg.Raw()[field.Name]) == 0 {
 		return fmt.Errorf("%s is required", path)
 	}

--- a/server/convert.go
+++ b/server/convert.go
@@ -465,6 +465,25 @@ func validationError(message string) *ingestionv1.ValidateConfigResponse {
 	}
 }
 
+func schemaValidationError(err error) *ingestionv1.ValidateConfigResponse {
+	response := validationError(err.Error())
+	if fieldErr, ok := err.(*configValidationError); ok {
+		response.Errors[0].Field = fieldErr.Field
+	}
+	return response
+}
+
+type configValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *configValidationError) Error() string { return e.Message }
+
+func requiredConfigFieldError(path string) error {
+	return &configValidationError{Field: path, Message: path + " is required"}
+}
+
 func validateConfigSchema(schema filament.ConfigSchema, cfg filament.Config, scope filament.FieldScope) error {
 	for _, field := range schema.Fields {
 		if field.Scope != scope {
@@ -482,13 +501,13 @@ func validateConfigField(field filament.ConfigField, cfg filament.Config, path s
 		return nil
 	}
 	if field.Required && !cfg.Has(field.Name) {
-		return fmt.Errorf("%s is required", path)
+		return requiredConfigFieldError(path)
 	}
 	if field.Required && (field.Type == filament.FieldString || field.Type == filament.FieldSecret || field.Type == filament.FieldEnum) && strings.TrimSpace(cfg.String(field.Name)) == "" {
-		return fmt.Errorf("%s is required", path)
+		return requiredConfigFieldError(path)
 	}
 	if field.Required && field.Type == filament.FieldList && configListLen(cfg.Raw()[field.Name]) == 0 {
-		return fmt.Errorf("%s is required", path)
+		return requiredConfigFieldError(path)
 	}
 	if !cfg.Has(field.Name) || len(field.Fields) == 0 {
 		return nil

--- a/server/convert.go
+++ b/server/convert.go
@@ -484,9 +484,9 @@ func requiredConfigFieldError(path string) error {
 	return &configValidationError{Field: path, Message: path + " is required"}
 }
 
-func validateConfigSchema(schema filament.ConfigSchema, cfg filament.Config, scope filament.FieldScope) error {
+func validateConfigSchema(schema filament.ConfigSchema, cfg filament.Config) error {
 	for _, field := range schema.Fields {
-		if field.Scope != scope {
+		if field.Scope != filament.ScopeConnection {
 			continue
 		}
 		if err := validateConfigField(field, cfg, field.Name); err != nil {

--- a/source.go
+++ b/source.go
@@ -187,6 +187,13 @@ type LiveValidatable interface {
 	TestConnection(ctx context.Context, cfg Config) error
 }
 
+// ConfigValidatable is the optional contract for connector-specific, pure
+// configuration validation. Unlike LiveValidatable it must not access the
+// network, so the API can safely use it while accepting connection settings.
+type ConfigValidatable interface {
+	Validate(cfg Config) error
+}
+
 // ConnectorSpec is a source's self-description: identity, supported modes and
 // policies, config schema, and resource capabilities. It powers the catalog.
 type ConnectorSpec struct {

--- a/ui/src/components/fields/Field.tsx
+++ b/ui/src/components/fields/Field.tsx
@@ -43,7 +43,7 @@ interface FieldProps {
   isDisabled?: boolean;
   path?: string;
   getError?: (path: string) => string | undefined;
-  hasStoredSecret?: boolean;
+  storedSecretRefs?: Record<string, string>;
 }
 
 const Field = ({
@@ -54,7 +54,7 @@ const Field = ({
   isDisabled = false,
   path = field.name,
   getError,
-  hasStoredSecret,
+  storedSecretRefs,
 }: FieldProps) => {
   const label = useMemo(() => formatFieldName(field.name), [field.name]);
 
@@ -87,7 +87,7 @@ const Field = ({
                 isDisabled={isDisabled}
                 path={`${path}.${child.name}`}
                 getError={getError}
-                hasStoredSecret={hasStoredSecret}
+                storedSecretRefs={storedSecretRefs}
               />
             ))}
         </FlexWrapper>
@@ -107,7 +107,7 @@ const Field = ({
       isDisabled={isDisabled}
       variant={variant}
       label={label}
-      hasStoredSecret={hasStoredSecret}
+      hasStoredSecret={Boolean(storedSecretRefs?.[path])}
     />
   );
 };

--- a/ui/src/components/fields/utils.ts
+++ b/ui/src/components/fields/utils.ts
@@ -14,6 +14,7 @@ const ACRONYMS_TO_CAPITALIZE: string[] = [
   "http",
   "ssh",
   "ssl",
+  "tls",
   "dsn",
   "uri",
   "kb",

--- a/ui/src/pages/connectors/components/edit/EditConnectionModal.tsx
+++ b/ui/src/pages/connectors/components/edit/EditConnectionModal.tsx
@@ -103,6 +103,7 @@ const EditConnectionModalContent = ({ connection, onClose }: EditConnectionModal
       connectorName={connection.connector}
       connectorKind={connection.kind}
       connectionId={connection.id}
+      secretRefs={connection.secretRefs}
       onSubmit={handleUpdateConnection}
       onClose={onClose}
     />

--- a/ui/src/pages/connectors/components/form/ConnectionForm.tsx
+++ b/ui/src/pages/connectors/components/form/ConnectionForm.tsx
@@ -80,6 +80,7 @@ interface ConnectionFormProps {
   connectorName: ConnectorSpec["name"];
   connectorKind: ConnectorKind;
   connectionId?: Connection["id"];
+  secretRefs?: Connection["secretRefs"];
   onSubmit: () => void;
   onClose: () => void;
   onBack?: () => void;
@@ -89,6 +90,7 @@ const ConnectionForm = ({
   connectorName,
   connectorKind,
   connectionId,
+  secretRefs,
   onSubmit,
   onClose,
   onBack,
@@ -261,7 +263,7 @@ const ConnectionForm = ({
               onChange={(value) => handleFieldChange(field.name, value)}
               getError={getFieldError}
               isDisabled={isDisabled}
-              hasStoredSecret={!!connectionId}
+              storedSecretRefs={secretRefs}
             />
           ))}
       </>


### PR DESCRIPTION
Breaks apart dsn url vs dedicated field declaration for mysql, postgres, clickhouse

Fixes mysql dsn parsing bug, we were handing mysql:// but the engine wanted no protocol prefix.

Fixes nested secret bug 

## Slop
This pull request introduces a unified, flexible connection configuration system for both the ClickHouse and MySQL sinks, supporting both field-based and DSN/URL-based connection methods. It adds a shared internal package for database connection configuration, updates the ClickHouse and MySQL sinks to use this mechanism, and provides comprehensive validation and tests for both connection approaches. Both connectors increment their configuration version to reflect these breaking and additive changes.

**Connection configuration unification and improvements:**

* Introduced a new internal package `connectors/internal/dbconfig/dbconfig.go` that defines a shared convention for selecting between field-based and DSN/URL-based connection inputs, including helper methods and config field declarations.
* Updated the ClickHouse sink (`connectors/clickhouse/sink/clickhouse.go`) to support both field-based and DSN/URL-based connection methods, using the new `dbconfig` helpers. The configuration schema now includes a `connection_method` selector, and the sink validates and resolves connection options accordingly. The config version is incremented to "2". [[1]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3R21) [[2]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3R79-R103) [[3]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3R124-R131) [[4]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3R190-R208) [[5]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3L214-R247) [[6]](diffhunk://#diff-b85b3f5771c6758ba9577238597b9d6b9e94f2dbf1e1d6c81dc15eeb036113e3R262-R268) [[7]](diffhunk://#diff-589cacadf3ec5ad7e304622d50f6e90ea3d78b8aa3aa72aa9fafd96d3a461aa8L29-R59)
* Added comprehensive tests for both field-based and DSN/URL-based connection options in the ClickHouse sink (`connectors/clickhouse/sink/clickhouse_test.go`).

**MySQL connector refactoring and feature parity:**

* Added a new internal package `connectors/mysql/internal/connection/connection.go` that provides field and DSN/URL-based configuration, normalization, and validation for MySQL connections. This includes support for both native DSN and `mysql://`/`mariadb://` URLs, with robust error handling and normalization.
* Refactored the MySQL sink (`connectors/mysql/sink/mysql.go`) to use the new connection package for configuration, validation, and connection resolution. The configuration schema now supports both methods, and the config version is incremented to "2". [[1]](diffhunk://#diff-b2204f1b5099166c95501c9cda4b1e3577b72f17bc6e2597614e27f141dfeb73L10-R11) [[2]](diffhunk://#diff-b2204f1b5099166c95501c9cda4b1e3577b72f17bc6e2597614e27f141dfeb73R58) [[3]](diffhunk://#diff-b2204f1b5099166c95501c9cda4b1e3577b72f17bc6e2597614e27f141dfeb73L71-R75) [[4]](diffhunk://#diff-b2204f1b5099166c95501c9cda4b1e3577b72f17bc6e2597614e27f141dfeb73R95-R109) [[5]](diffhunk://#diff-b2204f1b5099166c95501c9cda4b1e3577b72f17bc6e2597614e27f141dfeb73L125-R130)
* Added thorough tests for the new MySQL connection resolution logic, covering both field-based and DSN/URL-based configurations, as well as edge cases and error handling (`connectors/mysql/internal/connection/connection_test.go`).