### PR TITLE
Atterpac/http config

### DIFF
--- a/connectors/http/catalog.go
+++ b/connectors/http/catalog.go
@@ -2,8 +2,6 @@ package httpapi
 
 import (
 	_ "embed"
-
-	"github.com/galaxy-io/filament"
 )
 
 //go:embed manifests/notion.yaml
@@ -32,42 +30,44 @@ var stripeManifest []byte
 
 // NewNotion returns a Source backed by the embedded Notion manifest.
 func NewNotion() *Source {
-	return NewManifestWithMetadata("notion", "Notion", "All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.", "https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg", notionManifest, manifestOwnedConfig())
+	return newCatalogSource(notionManifest)
 }
 
 // NewLinear returns a Source backed by the embedded Linear manifest.
 func NewLinear() *Source {
-	return NewManifestWithMetadata("linear", "Linear", "Modern issue tracking and project management tool built for high-performance teams.", "https://cdn.getgalaxy.io/sources/source-icon-linear-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-linear-light.svg", linearManifest, manifestOwnedConfig())
+	return newCatalogSource(linearManifest)
 }
 
 // NewAttio returns a Source backed by the embedded Attio REST API manifest.
 func NewAttio() *Source {
-	return NewManifestWithMetadata("attio", "Attio", "CRM platform designed for modern teams to centralize customer data, pipelines, and workflows.", "https://cdn.getgalaxy.io/sources/source-icon-attio-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-attio-light.svg", attioManifest, manifestOwnedConfig())
+	return newCatalogSource(attioManifest)
 }
 
 // NewGitHub returns a Source backed by the embedded GitHub REST API manifest.
 func NewGitHub() *Source {
-	return NewManifestWithMetadata("github", "GitHub", "Code hosting platform for version control, collaboration, and software development workflows.", "https://cdn.getgalaxy.io/sources/source-icon-github-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-github-light.svg", githubManifest, manifestOwnedConfig())
+	return newCatalogSource(githubManifest)
 }
 
 // NewSlack returns a Source backed by the embedded Slack Web API manifest.
 func NewSlack() *Source {
-	return NewManifestWithMetadata("slack", "Slack", "Messaging and collaboration platform designed for teams to communicate and work together efficiently.", "https://cdn.getgalaxy.io/sources/source-icon-slack-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-slack-light.svg", slackManifest, manifestOwnedConfig())
+	return newCatalogSource(slackManifest)
 }
 
 // NewResend returns a Source backed by the embedded Resend REST API manifest.
 func NewResend() *Source {
-	return NewManifestWithMetadata("resend", "Resend", "Email API for developers covering transactional sends, inbound mail, broadcasts, contacts, and audience management.", "https://cdn.getgalaxy.io/sources/source-icon-resend-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-resend-light.svg", resendManifest, manifestOwnedConfig())
+	return newCatalogSource(resendManifest)
 }
 
 // NewStripe returns a Source backed by the embedded Stripe REST API manifest.
 func NewStripe() *Source {
-	return NewManifestWithMetadata("stripe", "Stripe", "Payments platform covering charges, payment intents, invoicing, subscriptions, and the account balance ledger.", "https://cdn.getgalaxy.io/sources/source-icon-stripe-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-stripe-light.svg", stripeManifest, manifestOwnedConfig())
+	return newCatalogSource(stripeManifest)
 }
 
 // NewPostHog returns a Source backed by the embedded PostHog REST API manifest.
 func NewPostHog() *Source {
-	return NewManifestWithMetadata("posthog", "PostHog", "Product analytics platform covering people, events, cohorts, feature flags, experiments, and session replay.", "https://cdn.getgalaxy.io/sources/source-icon-posthog-dark.svg", "https://cdn.getgalaxy.io/sources/source-icon-posthog-light.svg", posthogManifest, manifestOwnedConfig())
+	return newCatalogSource(posthogManifest)
 }
 
-func manifestOwnedConfig() filament.ConfigSchema { return filament.ConfigSchema{} }
+func newCatalogSource(data []byte) *Source {
+	return NewManifest(data)
+}

--- a/connectors/http/connector.go
+++ b/connectors/http/connector.go
@@ -96,39 +96,48 @@ type extractOptions struct {
 }
 
 // SetManifestPath is called by the registry before Configure.
-func (c *Connector) SetManifestPath(path string) { c.manifestPath = path }
+func (c *Connector) SetManifestPath(path string) {
+	c.manifestPath = path
+	c.manifestData = nil
+	c.manifest = nil
+}
 
 // SetManifestData configures the connector from embedded manifest bytes.
-func (c *Connector) SetManifestData(data []byte) { c.manifestData = data }
+func (c *Connector) SetManifestData(data []byte) {
+	c.manifestPath = ""
+	c.manifestData = data
+	c.manifest = nil
+}
+
+// SetManifest configures the connector with an already parsed manifest.
+func (c *Connector) SetManifest(m *manifest.Manifest) { c.manifest = m }
 
 // SetCredentials injects the `config.*` template scope. Built per-source by
 // the registry's CredentialExtractor; the httpapi package stays proto-agnostic.
 func (c *Connector) SetCredentials(m map[string]string) { c.creds = m }
 
-// Validate checks that a manifest path or embedded manifest data is set.
+// Validate checks that a parsed manifest, manifest path, or embedded data is set.
 func (c *Connector) Validate() error {
-	if c.manifestPath == "" && len(c.manifestData) == 0 {
+	if c.manifest == nil && c.manifestPath == "" && len(c.manifestData) == 0 {
 		return fmt.Errorf("manifest_path is required")
 	}
 	return nil
 }
 
-// Configure loads the manifest and builds the auth, rate limiter, and HTTP clients.
+// Configure uses or loads the manifest and builds the auth, rate limiter, and HTTP clients.
 func (c *Connector) Configure(ctx context.Context) error {
-	if c.manifestPath == "" && len(c.manifestData) == 0 {
+	if c.manifest == nil && c.manifestPath == "" && len(c.manifestData) == 0 {
 		return fmt.Errorf("manifest_path not set — call SetManifestPath before Configure")
 	}
 
-	var (
-		m   *manifest.Manifest
-		err error
-	)
-	if len(c.manifestData) > 0 {
+	m := c.manifest
+	var err error
+	if m == nil && len(c.manifestData) > 0 {
 		m, err = manifest.Parse(c.manifestData)
 		if err != nil {
 			return fmt.Errorf("parse manifest: %w", err)
 		}
-	} else {
+	} else if m == nil {
 		m, err = manifest.Load(c.manifestPath)
 		if err != nil {
 			return fmt.Errorf("load manifest: %w", err)

--- a/connectors/http/discover.go
+++ b/connectors/http/discover.go
@@ -125,9 +125,8 @@ func projectResource(rec map[string]any, m manifest.ResourceMap) (filament.Resou
 }
 
 // resolveName walks NamePaths in order, then NamePath, returning the first
-// non-empty resolution. For Notion pages where the title property name varies
-// per database, this lets a manifest list every common candidate and the
-// extractor picks whichever exists on the record.
+// non-empty resolution. Name resolution is entirely manifest-driven so the
+// generic engine does not infer provider-specific response shapes.
 func resolveName(rec map[string]any, m manifest.ResourceMap) string {
 	candidates := m.NamePaths
 	if len(candidates) == 0 && m.NamePath != "" {
@@ -136,32 +135,6 @@ func resolveName(rec map[string]any, m manifest.ResourceMap) string {
 	for _, p := range candidates {
 		if s, _, err := paths.AsString(rec, p); err == nil && s != "" {
 			return s
-		}
-	}
-	// Last-resort fallback: scan properties.* for any value whose `type`
-	// is "title" and pull its first plain_text. Works for Notion pages
-	// regardless of which property holds the title (database-defined
-	// title columns can be named anything).
-	if props, ok := rec["properties"].(map[string]any); ok {
-		for _, v := range props {
-			prop, ok := v.(map[string]any)
-			if !ok {
-				continue
-			}
-			if t, _ := prop["type"].(string); t != "title" {
-				continue
-			}
-			arr, ok := prop["title"].([]any)
-			if !ok || len(arr) == 0 {
-				continue
-			}
-			first, ok := arr[0].(map[string]any)
-			if !ok {
-				continue
-			}
-			if s, ok := first["plain_text"].(string); ok && s != "" {
-				return s
-			}
 		}
 	}
 	return ""

--- a/connectors/http/discover_test.go
+++ b/connectors/http/discover_test.go
@@ -1,0 +1,31 @@
+package httpapi
+
+import (
+	"testing"
+
+	"github.com/galaxy-io/filament/connectors/http/manifest"
+)
+
+func TestResolveNameUsesOnlyDeclaredPaths(t *testing.T) {
+	record := map[string]any{
+		"display_name": "Declared name",
+		"properties": map[string]any{
+			"Arbitrary": map[string]any{
+				"type":  "title",
+				"title": []any{map[string]any{"plain_text": "Implicit provider name"}},
+			},
+		},
+	}
+
+	got := resolveName(record, manifest.ResourceMap{
+		NamePaths: []string{"missing", "display_name"},
+	})
+	if got != "Declared name" {
+		t.Fatalf("resolved name = %q, want declared path value", got)
+	}
+
+	got = resolveName(record, manifest.ResourceMap{NamePath: "missing"})
+	if got != "" {
+		t.Fatalf("resolved name = %q, want no provider-specific fallback", got)
+	}
+}

--- a/connectors/http/manifest/grammar.v1.json
+++ b/connectors/http/manifest/grammar.v1.json
@@ -2,11 +2,15 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "HTTP Connector Manifest v1",
   "type": "object",
-  "required": ["version", "name", "connection", "resources"],
+  "required": ["version", "name", "display_name", "description", "dark_logo_url", "light_logo_url", "connection", "resources"],
   "additionalProperties": false,
   "properties": {
     "version": { "const": 1 },
     "name": { "type": "string", "minLength": 1 },
+    "display_name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "dark_logo_url": { "type": "string", "format": "uri" },
+    "light_logo_url": { "type": "string", "format": "uri" },
     "config": {
       "type": "object",
       "additionalProperties": {

--- a/connectors/http/manifest/manifest.go
+++ b/connectors/http/manifest/manifest.go
@@ -10,6 +10,10 @@
 //
 //	version: 1
 //	name: notion
+//	display_name: Notion
+//	description: Workspace knowledge and collaboration
+//	dark_logo_url: https://cdn.example.com/notion-dark.svg
+//	light_logo_url: https://cdn.example.com/notion-light.svg
 //	connection:
 //	  base_url: https://api.notion.com/v1
 //	  auth: { type: bearer, token: "{{ config.api_key }}" }
@@ -59,13 +63,17 @@ const SupportedVersion = 1
 
 // Manifest is the root document describing one HTTP API connector.
 type Manifest struct {
-	Version    int                   `yaml:"version"`
-	Name       string                `yaml:"name"`
-	Config     map[string]ConfigSpec `yaml:"config,omitempty"`
-	Defaults   Defaults              `yaml:"defaults,omitempty"`
-	FieldSets  map[string]FieldList  `yaml:"field_sets,omitempty"`
-	Connection Connection            `yaml:"connection"`
-	Resources  []Resource            `yaml:"resources"`
+	Version      int                   `yaml:"version"`
+	Name         string                `yaml:"name"`
+	DisplayName  string                `yaml:"display_name,omitempty"`
+	Description  string                `yaml:"description,omitempty"`
+	DarkLogoURL  string                `yaml:"dark_logo_url,omitempty"`
+	LightLogoURL string                `yaml:"light_logo_url,omitempty"`
+	Config       map[string]ConfigSpec `yaml:"config,omitempty"`
+	Defaults     Defaults              `yaml:"defaults,omitempty"`
+	FieldSets    map[string]FieldList  `yaml:"field_sets,omitempty"`
+	Connection   Connection            `yaml:"connection"`
+	Resources    []Resource            `yaml:"resources"`
 	// Discovery, when set, lets the connector enumerate user-toggleable
 	// resources by reusing existing extraction streams. Each entry projects a
 	// distinct resource Kind (e.g. notion exposes both "database" and "page"

--- a/connectors/http/manifest/manifest.go
+++ b/connectors/http/manifest/manifest.go
@@ -120,9 +120,9 @@ type ResourceMap struct {
 	NamePath     string `yaml:"name"` // single path OR alias; see NamePaths
 	ParentIDPath string `yaml:"parent_id,omitempty"`
 	// NamePaths is an ordered list of fallback paths; the first non-empty
-	// resolution wins. Use it for shapes like Notion pages where the title
-	// lives under a property whose key varies per database. When set, takes
-	// precedence over NamePath; either field individually is sufficient.
+	// resolution wins. Use it when upstream response variants expose the same
+	// label at different paths. When set, it takes precedence over NamePath;
+	// either field individually is sufficient.
 	NamePaths      []string          `yaml:"name_paths,omitempty"`
 	DefaultEnabled string            `yaml:"default_enabled,omitempty"`
 	Metadata       map[string]string `yaml:"metadata,omitempty"`

--- a/connectors/http/manifest/manifest_test.go
+++ b/connectors/http/manifest/manifest_test.go
@@ -5,10 +5,39 @@ import (
 	"testing"
 )
 
+func TestParseCatalogMetadata(t *testing.T) {
+	m, err := Parse([]byte(`
+version: 1
+name: example
+display_name: Example API
+description: Example connector used to verify manifest-owned catalog metadata.
+dark_logo_url: https://cdn.example.com/example-dark.svg
+light_logo_url: https://cdn.example.com/example-light.svg
+connection:
+  base_url: https://example.com
+resources:
+  - name: records
+    path: /records
+`))
+	if err != nil {
+		t.Fatalf("parse manifest metadata: %v", err)
+	}
+	if m.DisplayName != "Example API" ||
+		m.Description != "Example connector used to verify manifest-owned catalog metadata." ||
+		m.DarkLogoURL != "https://cdn.example.com/example-dark.svg" ||
+		m.LightLogoURL != "https://cdn.example.com/example-light.svg" {
+		t.Fatalf("catalog metadata = %#v", m)
+	}
+}
+
 func TestParseConciseSyntaxNormalizesToRuntimeModel(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: concise
+display_name: Concise
+description: Test concise manifest.
+dark_logo_url: https://cdn.example.com/concise-dark.svg
+light_logo_url: https://cdn.example.com/concise-light.svg
 config:
   token:
     type: secret
@@ -105,6 +134,10 @@ func TestParseListConfig(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: list-config
+display_name: List Config
+description: Test list configuration manifest.
+dark_logo_url: https://cdn.example.com/list-dark.svg
+light_logo_url: https://cdn.example.com/list-light.svg
 config:
   kinds:
     type: list
@@ -133,6 +166,10 @@ func TestParseRejectsListConfigWithoutOptions(t *testing.T) {
 	_, err := Parse([]byte(`
 version: 1
 name: list-config
+display_name: List Config
+description: Test invalid list configuration manifest.
+dark_logo_url: https://cdn.example.com/list-dark.svg
+light_logo_url: https://cdn.example.com/list-light.svg
 config:
   kinds:
     type: list
@@ -162,7 +199,7 @@ func TestParseRejectsInvalidIncrementalContracts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Parse([]byte("version: 1\nname: test\nconnection:\n  base_url: https://example.com\nresources:\n  - name: items\n    path: /items\n    fields:\n      " + tt.field + "\n    " + tt.pagination + "\n    incremental:\n      " + tt.incremental + "\n"))
+			_, err := Parse([]byte("version: 1\nname: test\ndisplay_name: Test\ndescription: Test invalid incremental manifest.\ndark_logo_url: https://cdn.example.com/test-dark.svg\nlight_logo_url: https://cdn.example.com/test-light.svg\nconnection:\n  base_url: https://example.com\nresources:\n  - name: items\n    path: /items\n    fields:\n      " + tt.field + "\n    " + tt.pagination + "\n    incremental:\n      " + tt.incremental + "\n"))
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
@@ -174,6 +211,10 @@ func TestParseConciseBasicAuth(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: basic
+display_name: Basic
+description: Test basic authentication manifest.
+dark_logo_url: https://cdn.example.com/basic-dark.svg
+light_logo_url: https://cdn.example.com/basic-light.svg
 config:
   email:
     type: string
@@ -203,6 +244,10 @@ resources:
 	m, err = Parse([]byte(`
 version: 1
 name: basic-no-pass
+display_name: Basic No Password
+description: Test basic authentication without a password.
+dark_logo_url: https://cdn.example.com/basic-dark.svg
+light_logo_url: https://cdn.example.com/basic-light.svg
 config:
   api_key:
     type: secret
@@ -228,6 +273,10 @@ func TestParseConciseFieldRejectsUnknownType(t *testing.T) {
 	_, err := Parse([]byte(`
 version: 1
 name: invalid
+display_name: Invalid
+description: Test invalid authentication manifest.
+dark_logo_url: https://cdn.example.com/invalid-dark.svg
+light_logo_url: https://cdn.example.com/invalid-light.svg
 connection:
   base_url: https://example.com
 resources:
@@ -248,6 +297,10 @@ func TestParseAcceptsTemplatedBaseURL(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1
 name: regional
+display_name: Regional
+description: Test regional host manifest.
+dark_logo_url: https://cdn.example.com/regional-dark.svg
+light_logo_url: https://cdn.example.com/regional-light.svg
 config:
   host:
     type: string
@@ -270,6 +323,10 @@ func TestParseRejectsBaseURLWithUnresolvableScope(t *testing.T) {
 	_, err := Parse([]byte(`
 version: 1
 name: regional
+display_name: Regional
+description: Test invalid regional host manifest.
+dark_logo_url: https://cdn.example.com/regional-dark.svg
+light_logo_url: https://cdn.example.com/regional-light.svg
 connection:
   base_url: "{{ parent.host }}"
 resources:

--- a/connectors/http/manifests/attio.yaml
+++ b/connectors/http/manifests/attio.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: attio
+display_name: Attio
+description: CRM platform designed for modern teams to centralize customer data, pipelines, and workflows.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-attio-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-attio-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/github.yaml
+++ b/connectors/http/manifests/github.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: github
+display_name: GitHub
+description: Code hosting platform for version control, collaboration, and software development workflows.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-github-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-github-light.svg
 config:
   token:
     type: secret

--- a/connectors/http/manifests/linear.yaml
+++ b/connectors/http/manifests/linear.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: linear
+display_name: Linear
+description: Modern issue tracking and project management tool built for high-performance teams.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-linear-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-linear-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/notion.yaml
+++ b/connectors/http/manifests/notion.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: notion
+display_name: Notion
+description: All-in-one productivity app for notes, tasks, databases, and knowledge collaboration.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-notion-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-notion-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/posthog.yaml
+++ b/connectors/http/manifests/posthog.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: posthog
+display_name: PostHog
+description: Product analytics platform covering people, events, cohorts, feature flags, experiments, and session replay.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-posthog-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-posthog-light.svg
 
 config:
   api_key:

--- a/connectors/http/manifests/resend.yaml
+++ b/connectors/http/manifests/resend.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: resend
+display_name: Resend
+description: Email API for developers covering transactional sends, inbound mail, broadcasts, contacts, and audience management.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-resend-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-resend-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests/slack.yaml
+++ b/connectors/http/manifests/slack.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: slack
+display_name: Slack
+description: Messaging and collaboration platform designed for teams to communicate and work together efficiently.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-slack-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-slack-light.svg
 config:
   token:
     type: secret

--- a/connectors/http/manifests/stripe.yaml
+++ b/connectors/http/manifests/stripe.yaml
@@ -1,5 +1,9 @@
 version: 1
 name: stripe
+display_name: Stripe
+description: Payments platform covering charges, payment intents, invoicing, subscriptions, and the account balance ledger.
+dark_logo_url: https://cdn.getgalaxy.io/sources/source-icon-stripe-dark.svg
+light_logo_url: https://cdn.getgalaxy.io/sources/source-icon-stripe-light.svg
 config:
   api_key:
     type: secret

--- a/connectors/http/manifests_test.go
+++ b/connectors/http/manifests_test.go
@@ -25,8 +25,12 @@ func TestManifests(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read manifest: %v", err)
 			}
-			if _, err := manifest.Parse(data); err != nil {
+			m, err := manifest.Parse(data)
+			if err != nil {
 				t.Fatalf("parse manifest: %v", err)
+			}
+			if m.DisplayName == "" || m.Description == "" || m.DarkLogoURL == "" || m.LightLogoURL == "" {
+				t.Fatalf("catalog metadata must be manifest-owned: %#v", m)
 			}
 		})
 	}

--- a/connectors/http/source.go
+++ b/connectors/http/source.go
@@ -37,7 +37,8 @@ type Source struct {
 	darkLogoURL      string
 	lightLogoURL     string
 	config           filament.ConfigSchema
-	manifestData     []byte
+	embeddedManifest *manifest.Manifest
+	manifestErr      error
 	dynamicResources map[string]string
 	// incrementalResources is populated by PlanIncremental for the resources in
 	// the current run. It keeps durable watermark extraction distinct from
@@ -71,12 +72,19 @@ func NewManifest(name, displayName string, manifestData []byte, config filament.
 // NewManifestWithMetadata returns a Source bound to embedded manifest bytes,
 // frontend catalog metadata, and a config schema.
 func NewManifestWithMetadata(name, displayName, description, darkLogoURL, lightLogoURL string, manifestData []byte, config filament.ConfigSchema) *Source {
-	return &Source{name: name, displayName: displayName, description: description, darkLogoURL: darkLogoURL, lightLogoURL: lightLogoURL, manifestData: manifestData, config: config}
+	m, err := manifest.Parse(manifestData)
+	if err == nil && len(m.Config) > 0 {
+		config = configSchemaFromManifest(m)
+	}
+	return &Source{
+		name: name, displayName: displayName, description: description,
+		darkLogoURL: darkLogoURL, lightLogoURL: lightLogoURL,
+		config: config, embeddedManifest: m, manifestErr: err,
+	}
 }
 
 // Spec reports the source's capabilities and configuration surface.
 func (s *Source) Spec() filament.ConnectorSpec {
-	config := s.configSchema()
 	modes := []filament.ReadMode{filament.ModeFull}
 	policies := []filament.IngestionType{
 		filament.IngestionFullReplace,
@@ -99,7 +107,7 @@ func (s *Source) Spec() filament.ConnectorSpec {
 		Version:        "1",
 		Modes:          modes,
 		SourcePolicies: filament.SourcePolicies(policies...),
-		Config:         config,
+		Config:         s.config,
 		Resources:      filament.ResourceCapabilities{Discoverable: true, PerResourceCursor: true},
 	}
 }
@@ -117,14 +125,15 @@ func (s *Source) canDeclareIncremental() bool {
 		}
 		return false
 	}
-	if len(s.manifestData) == 0 {
+	if s.embeddedManifest == nil {
+		// A nil manifest with no parse error is the generic manifest-path source.
+		// Its capabilities are unknown until it is configured.
+		if s.manifestErr != nil {
+			return false
+		}
 		return true
 	}
-	m, err := manifest.Parse(s.manifestData)
-	if err != nil {
-		return false
-	}
-	for _, resource := range m.Resources {
+	for _, resource := range s.embeddedManifest.Resources {
 		if resource.Incremental != nil {
 			return true
 		}
@@ -134,7 +143,10 @@ func (s *Source) canDeclareIncremental() bool {
 
 // Validate checks that all required config fields are present and non-empty.
 func (s *Source) Validate(cfg filament.Config) error {
-	for _, field := range s.configSchema().Fields {
+	if s.manifestErr != nil {
+		return fmt.Errorf("%s source: parse manifest: %w", s.name, s.manifestErr)
+	}
+	for _, field := range s.config.Fields {
 		if field.Required && !cfg.Has(field.Name) {
 			return fmt.Errorf("%s source: %s is required", s.name, field.Name)
 		}
@@ -170,14 +182,7 @@ func listLen(value any) int {
 	}
 }
 
-func (s *Source) configSchema() filament.ConfigSchema {
-	if len(s.manifestData) == 0 {
-		return s.config
-	}
-	m, err := manifest.Parse(s.manifestData)
-	if err != nil || len(m.Config) == 0 {
-		return s.config
-	}
+func configSchemaFromManifest(m *manifest.Manifest) filament.ConfigSchema {
 	names := make([]string, 0, len(m.Config))
 	for name := range m.Config {
 		names = append(names, name)
@@ -260,26 +265,21 @@ func (s *Source) TestConnection(ctx context.Context, cfg filament.Config) error 
 
 func (s *Source) connectorForConfig(cfg filament.Config) (*Connector, error) {
 	c := &Connector{}
-	if len(s.manifestData) > 0 {
-		c.SetManifestData(s.manifestData)
-	} else {
-		c.SetManifestPath(cfg.String("manifest_path"))
+	if s.manifestErr != nil {
+		return nil, fmt.Errorf("%s source: parse manifest: %w", s.name, s.manifestErr)
 	}
-	var configSpecs map[string]manifest.ConfigSpec
-	if len(s.manifestData) > 0 {
-		parsed, err := manifest.Parse(s.manifestData)
-		if err != nil {
-			return nil, fmt.Errorf("%s source: parse manifest: %w", s.name, err)
-		}
-		configSpecs = parsed.Config
-	} else {
-		parsed, err := manifest.Load(cfg.String("manifest_path"))
+	parsed := s.embeddedManifest
+	if parsed == nil {
+		path := cfg.String("manifest_path")
+		var err error
+		parsed, err = manifest.Load(path)
 		if err != nil {
 			return nil, fmt.Errorf("%s source: load manifest: %w", s.name, err)
 		}
-		configSpecs = parsed.Config
+		c.SetManifestPath(path)
 	}
-	c.SetCredentials(credentialsFromConfig(cfg, configSpecs))
+	c.SetManifest(parsed)
+	c.SetCredentials(credentialsFromConfig(cfg, parsed.Config))
 	return c, nil
 }
 

--- a/connectors/http/source.go
+++ b/connectors/http/source.go
@@ -64,22 +64,17 @@ func New() *Source {
 	return &Source{name: providerName, displayName: "HTTP API", config: genericConfig}
 }
 
-// NewManifest returns a Source bound to embedded manifest bytes and a config schema.
-func NewManifest(name, displayName string, manifestData []byte, config filament.ConfigSchema) *Source {
-	return NewManifestWithMetadata(name, displayName, "", "", "", manifestData, config)
-}
-
-// NewManifestWithMetadata returns a Source bound to embedded manifest bytes,
-// frontend catalog metadata, and a config schema.
-func NewManifestWithMetadata(name, displayName, description, darkLogoURL, lightLogoURL string, manifestData []byte, config filament.ConfigSchema) *Source {
+// NewManifest returns a Source whose identity, presentation metadata, and
+// configuration schema are all declared by the embedded manifest.
+func NewManifest(manifestData []byte) *Source {
 	m, err := manifest.Parse(manifestData)
-	if err == nil && len(m.Config) > 0 {
-		config = configSchemaFromManifest(m)
+	if err != nil {
+		return &Source{embeddedManifest: m, manifestErr: err}
 	}
 	return &Source{
-		name: name, displayName: displayName, description: description,
-		darkLogoURL: darkLogoURL, lightLogoURL: lightLogoURL,
-		config: config, embeddedManifest: m, manifestErr: err,
+		name: m.Name, displayName: m.DisplayName, description: m.Description,
+		darkLogoURL: m.DarkLogoURL, lightLogoURL: m.LightLogoURL,
+		config: configSchemaFromManifest(m), embeddedManifest: m,
 	}
 }
 

--- a/connectors/http/source_test.go
+++ b/connectors/http/source_test.go
@@ -87,6 +87,10 @@ func TestSourceTestConnectionMakesOneAuthenticatedRequest(t *testing.T) {
 	data := []byte(fmt.Sprintf(`
 version: 1
 name: probe
+display_name: Probe
+description: Test probe connector.
+dark_logo_url: https://cdn.example.com/probe-dark.svg
+light_logo_url: https://cdn.example.com/probe-light.svg
 config:
   token: {type: secret, required: true}
 connection:
@@ -102,7 +106,7 @@ resources:
         path: error
         when_present: true
 `, api.URL))
-	src := NewManifest("probe", "Probe", data, filament.ConfigSchema{})
+	src := NewManifest(data)
 	if err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
 		"token": "good-token",
 	})); err != nil {
@@ -663,7 +667,7 @@ func TestAttioUsesAPIKeyAsBearerToken(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(attioManifest), "https://api.attio.com", api.URL, 1))
-	src := NewManifest("attio", "Attio", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "attio-key"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -719,7 +723,7 @@ func TestSlackEmbeddedManifestAndMessageFanOut(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(slackManifest), "https://slack.com/api", api.URL, 1))
-	src := NewManifest("slack", "Slack", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"token": "xoxb-test"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -795,9 +799,13 @@ func TestCredentialsFromConfigJoinsStringLists(t *testing.T) {
 }
 
 func TestRequiredListConfigRejectsEmptySelection(t *testing.T) {
-	src := NewManifest("list", "List", []byte(`
+	src := NewManifest([]byte(`
 version: 1
 name: list
+display_name: List
+description: Test list connector.
+dark_logo_url: https://cdn.example.com/list-dark.svg
+light_logo_url: https://cdn.example.com/list-light.svg
 config:
   choices:
     type: list
@@ -812,7 +820,7 @@ resources:
     primary_key: [id]
     fields:
       id: string
-`), filament.ConfigSchema{})
+`))
 
 	if err := src.Validate(filament.NewConfig(map[string]any{"choices": []any{}})); err == nil {
 		t.Fatal("empty required list validated successfully")
@@ -823,9 +831,13 @@ resources:
 }
 
 func TestEmbeddedManifestIsParsedOnceAndReused(t *testing.T) {
-	src := NewManifest("cached", "Cached", []byte(`
+	src := NewManifest([]byte(`
 version: 1
 name: cached
+display_name: Cached
+description: Test cached connector.
+dark_logo_url: https://cdn.example.com/cached-dark.svg
+light_logo_url: https://cdn.example.com/cached-light.svg
 config:
   token:
     type: secret
@@ -839,7 +851,7 @@ resources:
     primary_key: [id]
     fields:
       id: string
-`), filament.ConfigSchema{})
+`))
 	if src.manifestErr != nil || src.embeddedManifest == nil {
 		t.Fatalf("constructor manifest = %#v, error = %v", src.embeddedManifest, src.manifestErr)
 	}
@@ -871,17 +883,11 @@ resources:
 }
 
 func TestEmbeddedManifestParseErrorIsCached(t *testing.T) {
-	fallback := filament.ConfigSchema{Fields: []filament.ConfigField{{
-		Name: "fallback", Type: filament.FieldString, Required: true,
-	}}}
-	src := NewManifest("broken", "Broken", []byte("version: ["), fallback)
+	src := NewManifest([]byte("version: ["))
 	if src.manifestErr == nil {
 		t.Fatal("constructor accepted invalid manifest")
 	}
-	if got := src.Spec().Config; len(got.Fields) != 1 || got.Fields[0].Name != "fallback" {
-		t.Fatalf("fallback config = %#v", got)
-	}
-	if err := src.Validate(filament.NewConfig(map[string]any{"fallback": "set"})); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+	if err := src.Validate(filament.NewConfig(nil)); err == nil || !strings.Contains(err.Error(), "parse manifest") {
 		t.Fatalf("validate error = %v, want cached manifest parse error", err)
 	}
 	if _, err := src.connectorForConfig(filament.NewConfig(nil)); err == nil || !strings.Contains(err.Error(), "parse manifest") {
@@ -968,6 +974,10 @@ func TestStaticDiscoveryChildSelectionScansButDoesNotEmitParents(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "static.yaml")
 	data := fmt.Sprintf(`version: 1
 name: static
+display_name: Static
+description: Test static connector.
+dark_logo_url: https://cdn.example.com/static-dark.svg
+light_logo_url: https://cdn.example.com/static-light.svg
 connection:
   base_url: %s
 resources:
@@ -1183,6 +1193,10 @@ func writeTestManifest(t *testing.T, baseURL string) string {
 	path := filepath.Join(t.TempDir(), "manifest.yaml")
 	data := fmt.Sprintf(`version: 1
 name: test_http
+display_name: Test HTTP
+description: Test HTTP connector.
+dark_logo_url: https://cdn.example.com/http-dark.svg
+light_logo_url: https://cdn.example.com/http-light.svg
 connection:
   base_url: %s
 resources:
@@ -1209,6 +1223,10 @@ func writeIncrementalTestManifest(t *testing.T, baseURL string) string {
 	path := filepath.Join(t.TempDir(), "manifest.yaml")
 	data := fmt.Sprintf(`version: 1
 name: test_http
+display_name: Test HTTP
+description: Test incremental HTTP connector.
+dark_logo_url: https://cdn.example.com/http-dark.svg
+light_logo_url: https://cdn.example.com/http-light.svg
 connection:
   base_url: %s
 resources:
@@ -1254,6 +1272,10 @@ func writeNotionTestManifest(t *testing.T, baseURL string) string {
 	path := filepath.Join(t.TempDir(), "notion.yaml")
 	data := fmt.Sprintf(`version: 1
 name: notion
+display_name: Notion
+description: Test Notion connector.
+dark_logo_url: https://cdn.example.com/notion-dark.svg
+light_logo_url: https://cdn.example.com/notion-light.svg
 connection:
   base_url: %s
   auth:
@@ -1410,7 +1432,7 @@ func TestResendPaginatesOnLastRecordIDAndSendsBearerToken(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1466,7 +1488,7 @@ func TestResendTestConnectionProbesEmails(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
 		"api_key": "re_test_123",
 	})); err != nil {
@@ -1503,7 +1525,7 @@ func TestResendEmailDetailsSingletonFanOutSendsNoListParams(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1562,7 +1584,7 @@ func TestResendDomainRecordsProjectNestedArrayFromDomainDetail(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1596,7 +1618,7 @@ func TestResendDomainRecordsProjectNestedArrayFromDomainDetail(t *testing.T) {
 	// A fresh Source: parent captures accumulate for the lifetime of a
 	// configured connector, so reusing the one above would fan the detail
 	// request out once per prior run.
-	settingsSrc := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	settingsSrc := NewManifest(manifestData)
 	if err := settingsSrc.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1645,7 +1667,7 @@ func TestResendWebhookAttemptsInheritWebhookIDThroughEventCapture(t *testing.T) 
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1712,7 +1734,7 @@ func TestResendTemplateDetailsAcceptArrayReplyTo(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(resendManifest), "https://api.resend.com", api.URL, 1))
-	src := NewManifest("resend", "Resend", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "re_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1830,7 +1852,7 @@ func TestStripePaginatesOnLastRecordIDAndSendsBasicAuth(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1908,7 +1930,7 @@ func TestStripeSubscriptionItemFanOut(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -1977,7 +1999,7 @@ func TestStripeInvoiceLineItemFanOut(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -2040,7 +2062,7 @@ func TestStripeIncrementalInjectsBracketedCreatedFilter(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"api_key": "rk_test_123"})); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
@@ -2102,7 +2124,7 @@ func TestStripeTestConnectionProbesCustomers(t *testing.T) {
 	defer api.Close()
 
 	manifestData := []byte(strings.Replace(string(stripeManifest), "https://api.stripe.com", api.URL, 1))
-	src := NewManifest("stripe", "Stripe", manifestData, filament.ConfigSchema{})
+	src := NewManifest(manifestData)
 	if err := src.TestConnection(context.Background(), filament.NewConfig(map[string]any{
 		"api_key": "rk_test_123",
 	})); err != nil {
@@ -2225,7 +2247,7 @@ func TestPostHogPaginatesViaNextURLAndScopesToProject(t *testing.T) {
 	}))
 	defer api.Close()
 
-	src := NewManifest("posthog", "PostHog", unthrottledPostHogManifest(t), filament.ConfigSchema{})
+	src := NewManifest(unthrottledPostHogManifest(t))
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
 		"api_key":    "phx_test_123",
 		"project_id": "12345",
@@ -2296,7 +2318,7 @@ func TestPostHogEventsIncrementalInjectsAfterMinusOverlap(t *testing.T) {
 	}))
 	defer api.Close()
 
-	src := NewManifest("posthog", "PostHog", posthogManifest, filament.ConfigSchema{})
+	src := NewManifest(posthogManifest)
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
 		"api_key":    "phx_test_123",
 		"project_id": "12345",
@@ -2378,7 +2400,7 @@ func TestPostHogIncrementalLeavesServerNextURLUntouched(t *testing.T) {
 	}))
 	defer api.Close()
 
-	src := NewManifest("posthog", "PostHog", unthrottledPostHogManifest(t), filament.ConfigSchema{})
+	src := NewManifest(unthrottledPostHogManifest(t))
 	if err := src.Configure(ctx, filament.NewConfig(map[string]any{
 		"api_key":    "phx_test_123",
 		"project_id": "12345",

--- a/connectors/http/source_test.go
+++ b/connectors/http/source_test.go
@@ -822,6 +822,88 @@ resources:
 	}
 }
 
+func TestEmbeddedManifestIsParsedOnceAndReused(t *testing.T) {
+	src := NewManifest("cached", "Cached", []byte(`
+version: 1
+name: cached
+config:
+  token:
+    type: secret
+    required: true
+connection:
+  base_url: https://example.com
+resources:
+  - name: records
+    path: /records
+    records: $
+    primary_key: [id]
+    fields:
+      id: string
+`), filament.ConfigSchema{})
+	if src.manifestErr != nil || src.embeddedManifest == nil {
+		t.Fatalf("constructor manifest = %#v, error = %v", src.embeddedManifest, src.manifestErr)
+	}
+
+	for range 2 {
+		spec := src.Spec()
+		if len(spec.Config.Fields) != 1 || spec.Config.Fields[0].Name != "token" {
+			t.Fatalf("config fields = %#v, want cached token field", spec.Config.Fields)
+		}
+	}
+	cfg := filament.NewConfig(map[string]any{"token": "secret"})
+	if err := src.Validate(cfg); err != nil {
+		t.Fatalf("validate cached config schema: %v", err)
+	}
+
+	c, err := src.connectorForConfig(cfg)
+	if err != nil {
+		t.Fatalf("build connector: %v", err)
+	}
+	if c.manifest != src.embeddedManifest {
+		t.Fatal("connector did not receive the manifest parsed by the source constructor")
+	}
+	if err := c.Configure(context.Background()); err != nil {
+		t.Fatalf("configure with cached manifest: %v", err)
+	}
+	if c.manifest != src.embeddedManifest {
+		t.Fatal("connector replaced the cached manifest during Configure")
+	}
+}
+
+func TestEmbeddedManifestParseErrorIsCached(t *testing.T) {
+	fallback := filament.ConfigSchema{Fields: []filament.ConfigField{{
+		Name: "fallback", Type: filament.FieldString, Required: true,
+	}}}
+	src := NewManifest("broken", "Broken", []byte("version: ["), fallback)
+	if src.manifestErr == nil {
+		t.Fatal("constructor accepted invalid manifest")
+	}
+	if got := src.Spec().Config; len(got.Fields) != 1 || got.Fields[0].Name != "fallback" {
+		t.Fatalf("fallback config = %#v", got)
+	}
+	if err := src.Validate(filament.NewConfig(map[string]any{"fallback": "set"})); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+		t.Fatalf("validate error = %v, want cached manifest parse error", err)
+	}
+	if _, err := src.connectorForConfig(filament.NewConfig(nil)); err == nil || !strings.Contains(err.Error(), "parse manifest") {
+		t.Fatalf("connector error = %v, want cached manifest parse error", err)
+	}
+}
+
+func TestManifestPathIsLoadedOncePerConnector(t *testing.T) {
+	path := writeTestManifest(t, "https://example.com")
+	src := New()
+	c, err := src.connectorForConfig(filament.NewConfig(map[string]any{"manifest_path": path}))
+	if err != nil {
+		t.Fatalf("build connector: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove manifest after initial load: %v", err)
+	}
+	if err := c.Configure(context.Background()); err != nil {
+		t.Fatalf("Configure reloaded manifest instead of using parsed value: %v", err)
+	}
+}
+
 func TestNewGitHubSpecAndEmbeddedManifest(t *testing.T) {
 	ctx := context.Background()
 	src := NewGitHub()


### PR DESCRIPTION
HTTP manifest fixes:
- Manifests now report fully qualified config with logos/display name etc
- Removed notion specific branch (that was also unused code)
- Fix double parse

## Slop
This pull request updates the HTTP connector framework to make catalog metadata (such as display name, description, and logos) manifest-owned, simplifying how connectors are defined and configured. It also removes provider-specific fallback logic from the generic name resolution, ensuring all behavior is manifest-driven. The changes update the manifest schema, refactor catalog source construction, and add comprehensive tests for the new behaviors.

**Manifest and Catalog Metadata Overhaul:**

* The manifest schema now requires catalog metadata fields: `display_name`, `description`, `dark_logo_url`, and `light_logo_url`. All built-in manifests are updated to include these fields, and the schema and runtime structs are updated accordingly. [[1]](diffhunk://#diff-b93f3d3e005a1fd47b7879d6f634560e52efd23d8349d37cb72bddb27ef8ed40L5-R13) [[2]](diffhunk://#diff-1a3e1c7b3e90db2e55f3e8dee6597d8307a2362e85dbdca752ff43f3c045b9edR68-R71) [[3]](diffhunk://#diff-d4720afe91accef5f2eeda09419633c0c165118aedae93eddb659d5c4e502ce5R3-R6) [[4]](diffhunk://#diff-ee21f24616526e8ad02aca55f86f0e984ba62fe1905e8275a9787c96fb95397eR3-R6) [[5]](diffhunk://#diff-23a61a9e4be6350aca0ee14f0dc09f5975b614c1d89a4aa46ceedff18a1beb26R3-R6) [[6]](diffhunk://#diff-bff74589261866953549335bc1c102421b32448e780cefb1c9795e8aeedcee12R3-R6) [[7]](diffhunk://#diff-7b78b603c6acdd6b823ec02af0545147e7fc4e514dc8dd69c4607f80da968fb8R3-R6)
* The catalog source constructors in `catalog.go` are refactored to use only manifest-owned metadata, removing the need to pass metadata explicitly in code.

**Manifest Parsing and Testing:**

* Manifest parsing tests are updated and expanded to cover the new required metadata fields, ensuring correct parsing and validation. [[1]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R8-R40) [[2]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R137-R140) [[3]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R169-R172) [[4]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817L165-R202) [[5]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R214-R217) [[6]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R247-R250) [[7]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R276-R279) [[8]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R300-R303) [[9]](diffhunk://#diff-779bfb7eabbeb5ec617ae43aec93c6cda5eef690f31f75d721798890c302d817R326-R329)

**Connector Configuration Refactor:**

* The connector configuration logic is refactored to prioritize a parsed manifest, and to ensure that setting the manifest path, data, or parsed manifest resets other state. This allows for more flexible and predictable connector setup.

**Name Resolution Logic:**

* Provider-specific fallback logic is removed from the generic `resolveName` function; name resolution is now entirely manifest-driven. A new test ensures that only declared paths are used for name resolution. [[1]](diffhunk://#diff-5d5536420ada2556705e7c457aea8307cee06bea94a588f9bd1b3c9f37b3b6b5L128-R129) [[2]](diffhunk://#diff-5d5536420ada2556705e7c457aea8307cee06bea94a588f9bd1b3c9f37b3b6b5L141-L166) [[3]](diffhunk://#diff-4c35fa6636996c48944e84c3796322e320f09e184513d299530959688900909fR1-R31)

**Documentation and Schema Comments:**

* Documentation and schema comments are updated to reflect the new manifest metadata and clarify the behavior of fields like `NamePaths`. [[1]](diffhunk://#diff-1a3e1c7b3e90db2e55f3e8dee6597d8307a2362e85dbdca752ff43f3c045b9edR13-R16) [[2]](diffhunk://#diff-1a3e1c7b3e90db2e55f3e8dee6597d8307a2362e85dbdca752ff43f3c045b9edL123-R133)

**Other:**

* Removes an unused import from `catalog.go`.