### PR TITLE
Atterpac/pause resume wiring

### DIFF
--- a/datastore/memory/memory.go
+++ b/datastore/memory/memory.go
@@ -200,9 +200,15 @@ func (s *Store) LoadRun(ctx context.Context, id filament.RunID) (filament.RunSta
 }
 
 // TransitionRun atomically changes a run when its current status is admitted.
-// Resume resets attempt-local lifecycle and counters while preserving the
-// request and run-scoped checkpoints used to continue extraction.
-func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []filament.RunStatus, to filament.RunStatus, resetExecution bool) (filament.RunState, error) {
+// Resume resets attempt-local lifecycle while optionally preserving counters
+// whose sink output and source checkpoints survive into the next attempt.
+func (s *Store) TransitionRun(
+	ctx context.Context,
+	id filament.RunID,
+	from []filament.RunStatus,
+	to filament.RunStatus,
+	opts filament.RunTransitionOptions,
+) (filament.RunState, error) {
 	if err := ctx.Err(); err != nil {
 		return filament.RunState{}, err
 	}
@@ -217,19 +223,23 @@ func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []fil
 	}
 	state.Status = to
 	state.UpdatedAt = time.Now()
-	if resetExecution {
+	if opts.ResetExecution {
 		state.RequestedAt = time.Now()
 		state.StartedAt = time.Time{}
 		state.EndedAt = nil
 		state.Error = ""
-		state.Records = 0
-		state.Bytes = 0
+		if !opts.PreserveProgress {
+			state.Records = 0
+			state.Bytes = 0
+		}
 		state.CPUSeconds = 0
 		state.MemoryPeakBytes = 0
 		for resource, rs := range s.resources[id] {
 			rs.Status = filament.RunRequested
-			rs.Records = 0
-			rs.Bytes = 0
+			if !opts.PreserveProgress {
+				rs.Records = 0
+				rs.Bytes = 0
+			}
 			rs.Error = ""
 			s.resources[id][resource] = rs
 		}

--- a/datastore/memory/memory.go
+++ b/datastore/memory/memory.go
@@ -199,6 +199,46 @@ func (s *Store) LoadRun(ctx context.Context, id filament.RunID) (filament.RunSta
 	return r, nil
 }
 
+// TransitionRun atomically changes a run when its current status is admitted.
+// Resume resets attempt-local lifecycle and counters while preserving the
+// request and run-scoped checkpoints used to continue extraction.
+func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []filament.RunStatus, to filament.RunStatus, resetExecution bool) (filament.RunState, error) {
+	if err := ctx.Err(); err != nil {
+		return filament.RunState{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.runs[id]
+	if !ok {
+		return filament.RunState{}, fmt.Errorf("transition run %q: %w", id, filament.ErrNotFound)
+	}
+	if !slices.Contains(from, state.Status) {
+		return filament.RunState{}, fmt.Errorf("transition run %q from status %d: %w", id, state.Status, filament.ErrVersionConflict)
+	}
+	state.Status = to
+	state.UpdatedAt = time.Now()
+	if resetExecution {
+		state.RequestedAt = time.Now()
+		state.StartedAt = time.Time{}
+		state.EndedAt = nil
+		state.Error = ""
+		state.Records = 0
+		state.Bytes = 0
+		state.CPUSeconds = 0
+		state.MemoryPeakBytes = 0
+		for resource, rs := range s.resources[id] {
+			rs.Status = filament.RunRequested
+			rs.Records = 0
+			rs.Bytes = 0
+			rs.Error = ""
+			s.resources[id][resource] = rs
+		}
+	}
+	s.runs[id] = state
+	state.Resources = s.listResourcesLocked(id)
+	return state, nil
+}
+
 // DeleteRun removes the run with its resources and checkpoints; missing is a no-op.
 func (s *Store) DeleteRun(ctx context.Context, id filament.RunID) error {
 	if err := ctx.Err(); err != nil {

--- a/datastore/memory/memory.go
+++ b/datastore/memory/memory.go
@@ -488,10 +488,5 @@ func matchRun(r filament.RunState, f filament.RunFilter) bool {
 	if len(f.Status) > 0 && !slices.Contains(f.Status, r.Status) {
 		return false
 	}
-	if f.Source != "" &&
-		r.Request.Source.ConfigRef != f.Source &&
-		r.Request.Source.Provider != f.Source {
-		return false
-	}
 	return true
 }

--- a/datastore/postgres/queries/run_resource_states.sql
+++ b/datastore/postgres/queries/run_resource_states.sql
@@ -16,8 +16,8 @@ FROM run_resource_states WHERE run_id = @run_id ORDER BY resource_name;
 -- name: ResetRunResources :exec
 UPDATE run_resource_states SET
     status = @status,
-    records = 0,
-    bytes = 0,
+    records = CASE WHEN @preserve_progress::boolean THEN records ELSE 0 END,
+    bytes = CASE WHEN @preserve_progress::boolean THEN bytes ELSE 0 END,
     error = NULL,
     updated_at = now()
 WHERE run_id = @run_id;

--- a/datastore/postgres/queries/run_resource_states.sql
+++ b/datastore/postgres/queries/run_resource_states.sql
@@ -12,3 +12,12 @@ ON CONFLICT (run_id, resource_name) DO UPDATE SET
 -- name: ListResources :many
 SELECT run_id, resource_name, tenant_id, status, records, bytes, coalesce(error, '')::text AS error
 FROM run_resource_states WHERE run_id = @run_id ORDER BY resource_name;
+
+-- name: ResetRunResources :exec
+UPDATE run_resource_states SET
+    status = @status,
+    records = 0,
+    bytes = 0,
+    error = NULL,
+    updated_at = now()
+WHERE run_id = @run_id;

--- a/datastore/postgres/queries/runs.sql
+++ b/datastore/postgres/queries/runs.sql
@@ -51,6 +51,26 @@ WHERE runs.status = @from_status;
 -- name: DeleteRun :exec
 DELETE FROM runs WHERE id = @run_id;
 
+-- name: LockRunStatus :one
+SELECT status FROM runs WHERE id = @run_id FOR UPDATE;
+
+-- name: TransitionRun :exec
+UPDATE runs SET status = @status, updated_at = now() WHERE id = @run_id;
+
+-- name: ResetRunExecution :exec
+UPDATE runs SET
+    status = @status,
+    records = 0,
+    bytes = 0,
+    cpu_seconds = 0,
+    memory_peak_bytes = 0,
+    requested_at = now(),
+    started_at = NULL,
+    ended_at = NULL,
+    error = NULL,
+    updated_at = now()
+WHERE id = @run_id;
+
 -- Reaps a pipeline's pre-created scheduled runs by the pipeline_id column:
 -- deleting the schedules row SET-NULLs runs.schedule_id, so schedule-scoped
 -- lookups cannot find these rows once the delete tx is underway.

--- a/datastore/postgres/queries/runs.sql
+++ b/datastore/postgres/queries/runs.sql
@@ -60,8 +60,8 @@ UPDATE runs SET status = @status, updated_at = now() WHERE id = @run_id;
 -- name: ResetRunExecution :exec
 UPDATE runs SET
     status = @status,
-    records = 0,
-    bytes = 0,
+    records = CASE WHEN @preserve_progress::boolean THEN records ELSE 0 END,
+    bytes = CASE WHEN @preserve_progress::boolean THEN bytes ELSE 0 END,
     cpu_seconds = 0,
     memory_peak_bytes = 0,
     requested_at = now(),

--- a/datastore/postgres/sqlcgen/run_resource_states.sql.go
+++ b/datastore/postgres/sqlcgen/run_resource_states.sql.go
@@ -52,6 +52,26 @@ func (q *Queries) ListResources(ctx context.Context, runID string) ([]*ListResou
 	return items, nil
 }
 
+const resetRunResources = `-- name: ResetRunResources :exec
+UPDATE run_resource_states SET
+    status = $1,
+    records = 0,
+    bytes = 0,
+    error = NULL,
+    updated_at = now()
+WHERE run_id = $2
+`
+
+type ResetRunResourcesParams struct {
+	Status int16
+	RunID  string
+}
+
+func (q *Queries) ResetRunResources(ctx context.Context, arg ResetRunResourcesParams) error {
+	_, err := q.db.Exec(ctx, resetRunResources, arg.Status, arg.RunID)
+	return err
+}
+
 const upsertResource = `-- name: UpsertResource :exec
 INSERT INTO run_resource_states (run_id, resource_name, tenant_id, status, records, bytes, error, updated_at)
 VALUES ($1, $2, $3, $4, $5, $6, nullif($7::text, ''), now())

--- a/datastore/postgres/sqlcgen/run_resource_states.sql.go
+++ b/datastore/postgres/sqlcgen/run_resource_states.sql.go
@@ -55,20 +55,21 @@ func (q *Queries) ListResources(ctx context.Context, runID string) ([]*ListResou
 const resetRunResources = `-- name: ResetRunResources :exec
 UPDATE run_resource_states SET
     status = $1,
-    records = 0,
-    bytes = 0,
+    records = CASE WHEN $2::boolean THEN records ELSE 0 END,
+    bytes = CASE WHEN $2::boolean THEN bytes ELSE 0 END,
     error = NULL,
     updated_at = now()
-WHERE run_id = $2
+WHERE run_id = $3
 `
 
 type ResetRunResourcesParams struct {
-	Status int16
-	RunID  string
+	Status           int16
+	PreserveProgress bool
+	RunID            string
 }
 
 func (q *Queries) ResetRunResources(ctx context.Context, arg ResetRunResourcesParams) error {
-	_, err := q.db.Exec(ctx, resetRunResources, arg.Status, arg.RunID)
+	_, err := q.db.Exec(ctx, resetRunResources, arg.Status, arg.PreserveProgress, arg.RunID)
 	return err
 }
 

--- a/datastore/postgres/sqlcgen/runs.sql.go
+++ b/datastore/postgres/sqlcgen/runs.sql.go
@@ -157,6 +157,42 @@ func (q *Queries) LoadRun(ctx context.Context, runID string) (*LoadRunRow, error
 	return &i, err
 }
 
+const lockRunStatus = `-- name: LockRunStatus :one
+SELECT status FROM runs WHERE id = $1 FOR UPDATE
+`
+
+func (q *Queries) LockRunStatus(ctx context.Context, runID string) (int16, error) {
+	row := q.db.QueryRow(ctx, lockRunStatus, runID)
+	var status int16
+	err := row.Scan(&status)
+	return status, err
+}
+
+const resetRunExecution = `-- name: ResetRunExecution :exec
+UPDATE runs SET
+    status = $1,
+    records = 0,
+    bytes = 0,
+    cpu_seconds = 0,
+    memory_peak_bytes = 0,
+    requested_at = now(),
+    started_at = NULL,
+    ended_at = NULL,
+    error = NULL,
+    updated_at = now()
+WHERE id = $2
+`
+
+type ResetRunExecutionParams struct {
+	Status int16
+	RunID  string
+}
+
+func (q *Queries) ResetRunExecution(ctx context.Context, arg ResetRunExecutionParams) error {
+	_, err := q.db.Exec(ctx, resetRunExecution, arg.Status, arg.RunID)
+	return err
+}
+
 const saveRun = `-- name: SaveRun :exec
 INSERT INTO runs (id, tenant_id, pipeline_id, pipeline_version_id, schedule_id, status, request, records, bytes, scheduled_at, requested_at, started_at, ended_at, error, cpu_seconds, memory_peak_bytes, updated_at)
 VALUES ($1, $2, nullif($3::text, '')::uuid, nullif($4::text, '')::uuid, nullif($5::text, '')::uuid, $6, $7, $8, $9, $10, $11, $12, $13, nullif($14::text, ''), $15, $16, now())
@@ -221,5 +257,19 @@ func (q *Queries) SaveRun(ctx context.Context, arg SaveRunParams) error {
 		arg.CpuSeconds,
 		arg.MemoryPeakBytes,
 	)
+	return err
+}
+
+const transitionRun = `-- name: TransitionRun :exec
+UPDATE runs SET status = $1, updated_at = now() WHERE id = $2
+`
+
+type TransitionRunParams struct {
+	Status int16
+	RunID  string
+}
+
+func (q *Queries) TransitionRun(ctx context.Context, arg TransitionRunParams) error {
+	_, err := q.db.Exec(ctx, transitionRun, arg.Status, arg.RunID)
 	return err
 }

--- a/datastore/postgres/sqlcgen/runs.sql.go
+++ b/datastore/postgres/sqlcgen/runs.sql.go
@@ -171,8 +171,8 @@ func (q *Queries) LockRunStatus(ctx context.Context, runID string) (int16, error
 const resetRunExecution = `-- name: ResetRunExecution :exec
 UPDATE runs SET
     status = $1,
-    records = 0,
-    bytes = 0,
+    records = CASE WHEN $2::boolean THEN records ELSE 0 END,
+    bytes = CASE WHEN $2::boolean THEN bytes ELSE 0 END,
     cpu_seconds = 0,
     memory_peak_bytes = 0,
     requested_at = now(),
@@ -180,16 +180,17 @@ UPDATE runs SET
     ended_at = NULL,
     error = NULL,
     updated_at = now()
-WHERE id = $2
+WHERE id = $3
 `
 
 type ResetRunExecutionParams struct {
-	Status int16
-	RunID  string
+	Status           int16
+	PreserveProgress bool
+	RunID            string
 }
 
 func (q *Queries) ResetRunExecution(ctx context.Context, arg ResetRunExecutionParams) error {
-	_, err := q.db.Exec(ctx, resetRunExecution, arg.Status, arg.RunID)
+	_, err := q.db.Exec(ctx, resetRunExecution, arg.Status, arg.PreserveProgress, arg.RunID)
 	return err
 }
 

--- a/datastore/postgres/store.go
+++ b/datastore/postgres/store.go
@@ -102,7 +102,13 @@ func (s *Store) SaveRun(ctx context.Context, r filament.RunState) error {
 
 // TransitionRun serializes lifecycle commands on the run row and updates it
 // only when the current status belongs to from.
-func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []filament.RunStatus, to filament.RunStatus, resetExecution bool) (filament.RunState, error) {
+func (s *Store) TransitionRun(
+	ctx context.Context,
+	id filament.RunID,
+	from []filament.RunStatus,
+	to filament.RunStatus,
+	opts filament.RunTransitionOptions,
+) (filament.RunState, error) {
 	status, err := runStatusValue(to)
 	if err != nil {
 		return filament.RunState{}, err
@@ -123,11 +129,15 @@ func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []fil
 	if !slices.Contains(from, filament.RunStatus(current)) {
 		return filament.RunState{}, fmt.Errorf("transition run %q from status %d: %w", id, current, filament.ErrVersionConflict)
 	}
-	if resetExecution {
-		if err := q.ResetRunExecution(ctx, sqlcgen.ResetRunExecutionParams{RunID: string(id), Status: status}); err != nil {
+	if opts.ResetExecution {
+		if err := q.ResetRunExecution(ctx, sqlcgen.ResetRunExecutionParams{
+			RunID: string(id), Status: status, PreserveProgress: opts.PreserveProgress,
+		}); err != nil {
 			return filament.RunState{}, fmt.Errorf("datastore/postgres: reset run transition: %w", err)
 		}
-		if err := q.ResetRunResources(ctx, sqlcgen.ResetRunResourcesParams{RunID: string(id), Status: int16(filament.RunRequested)}); err != nil {
+		if err := q.ResetRunResources(ctx, sqlcgen.ResetRunResourcesParams{
+			RunID: string(id), Status: int16(filament.RunRequested), PreserveProgress: opts.PreserveProgress,
+		}); err != nil {
 			return filament.RunState{}, fmt.Errorf("datastore/postgres: reset resource transition: %w", err)
 		}
 	} else {

--- a/datastore/postgres/store.go
+++ b/datastore/postgres/store.go
@@ -275,9 +275,6 @@ func (s *Store) ListRuns(ctx context.Context, f filament.RunFilter) ([]filament.
 	if f.Schedule != "" {
 		q += " AND schedule_id = " + arg(string(f.Schedule))
 	}
-	if f.Source != "" {
-		q += " AND (request->'Source'->>'Provider' = " + arg(f.Source) + " OR request->'Source'->>'ConfigRef' = " + arg(f.Source) + ")"
-	}
 	if !f.Since.IsZero() {
 		q += " AND started_at >= " + arg(f.Since)
 	}

--- a/datastore/postgres/store.go
+++ b/datastore/postgres/store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -97,6 +98,43 @@ func (s *Store) SaveRun(ctx context.Context, r filament.RunState) error {
 		return fmt.Errorf("datastore/postgres: commit: %w", err)
 	}
 	return nil
+}
+
+// TransitionRun serializes lifecycle commands on the run row and updates it
+// only when the current status belongs to from.
+func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []filament.RunStatus, to filament.RunStatus, resetExecution bool) (filament.RunState, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return filament.RunState{}, fmt.Errorf("datastore/postgres: begin run transition: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := s.q.WithTx(tx)
+	current, err := q.LockRunStatus(ctx, string(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return filament.RunState{}, fmt.Errorf("transition run %q: %w", id, filament.ErrNotFound)
+		}
+		return filament.RunState{}, fmt.Errorf("datastore/postgres: lock run transition: %w", err)
+	}
+	if !slices.Contains(from, filament.RunStatus(current)) {
+		return filament.RunState{}, fmt.Errorf("transition run %q from status %d: %w", id, current, filament.ErrVersionConflict)
+	}
+	if resetExecution {
+		if err := q.ResetRunExecution(ctx, sqlcgen.ResetRunExecutionParams{RunID: string(id), Status: int16(to)}); err != nil {
+			return filament.RunState{}, fmt.Errorf("datastore/postgres: reset run transition: %w", err)
+		}
+		if err := q.ResetRunResources(ctx, sqlcgen.ResetRunResourcesParams{RunID: string(id), Status: int16(filament.RunRequested)}); err != nil {
+			return filament.RunState{}, fmt.Errorf("datastore/postgres: reset resource transition: %w", err)
+		}
+	} else {
+		if err := q.TransitionRun(ctx, sqlcgen.TransitionRunParams{RunID: string(id), Status: int16(to)}); err != nil {
+			return filament.RunState{}, fmt.Errorf("datastore/postgres: run transition: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return filament.RunState{}, fmt.Errorf("datastore/postgres: commit run transition: %w", err)
+	}
+	return s.LoadRun(ctx, id)
 }
 
 // CreateRun inserts the run or promotes a pre-created RunScheduled row; a row

--- a/datastore/postgres/store.go
+++ b/datastore/postgres/store.go
@@ -103,6 +103,10 @@ func (s *Store) SaveRun(ctx context.Context, r filament.RunState) error {
 // TransitionRun serializes lifecycle commands on the run row and updates it
 // only when the current status belongs to from.
 func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []filament.RunStatus, to filament.RunStatus, resetExecution bool) (filament.RunState, error) {
+	status, err := runStatusValue(to)
+	if err != nil {
+		return filament.RunState{}, err
+	}
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return filament.RunState{}, fmt.Errorf("datastore/postgres: begin run transition: %w", err)
@@ -120,14 +124,14 @@ func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []fil
 		return filament.RunState{}, fmt.Errorf("transition run %q from status %d: %w", id, current, filament.ErrVersionConflict)
 	}
 	if resetExecution {
-		if err := q.ResetRunExecution(ctx, sqlcgen.ResetRunExecutionParams{RunID: string(id), Status: int16(to)}); err != nil {
+		if err := q.ResetRunExecution(ctx, sqlcgen.ResetRunExecutionParams{RunID: string(id), Status: status}); err != nil {
 			return filament.RunState{}, fmt.Errorf("datastore/postgres: reset run transition: %w", err)
 		}
 		if err := q.ResetRunResources(ctx, sqlcgen.ResetRunResourcesParams{RunID: string(id), Status: int16(filament.RunRequested)}); err != nil {
 			return filament.RunState{}, fmt.Errorf("datastore/postgres: reset resource transition: %w", err)
 		}
 	} else {
-		if err := q.TransitionRun(ctx, sqlcgen.TransitionRunParams{RunID: string(id), Status: int16(to)}); err != nil {
+		if err := q.TransitionRun(ctx, sqlcgen.TransitionRunParams{RunID: string(id), Status: status}); err != nil {
 			return filament.RunState{}, fmt.Errorf("datastore/postgres: run transition: %w", err)
 		}
 	}
@@ -135,6 +139,13 @@ func (s *Store) TransitionRun(ctx context.Context, id filament.RunID, from []fil
 		return filament.RunState{}, fmt.Errorf("datastore/postgres: commit run transition: %w", err)
 	}
 	return s.LoadRun(ctx, id)
+}
+
+func runStatusValue(status filament.RunStatus) (int16, error) {
+	if status < -1<<15 || status > 1<<15-1 {
+		return 0, fmt.Errorf("datastore/postgres: run status %d is out of range", status)
+	}
+	return int16(status), nil //nolint:gosec // bounds checked above
 }
 
 // CreateRun inserts the run or promotes a pre-created RunScheduled row; a row

--- a/eventbus/nats/nats.go
+++ b/eventbus/nats/nats.go
@@ -457,6 +457,7 @@ func (s *subscription) pump() {
 				}
 				payload, derr := s.bus.codec.Decode(msg.Data())
 				if derr != nil {
+					s.bus.logDecodeFailure(msg.Subject(), derr)
 					_ = msg.Term()
 					continue
 				}
@@ -495,6 +496,13 @@ func (s *subscription) pump() {
 		case <-time.After(defaultFetchWait):
 		}
 	}
+}
+
+func (b *Bus) logDecodeFailure(subject string, err error) {
+	if b.logf == nil {
+		return
+	}
+	b.logf("eventbus/nats: decode %q: %v; terminating poison message", subject, err)
 }
 
 type message struct {

--- a/eventbus/nats/nats_test.go
+++ b/eventbus/nats/nats_test.go
@@ -3,6 +3,8 @@ package nats
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/galaxy-io/filament/eventbus"
@@ -16,6 +18,15 @@ func (stringCodec) Encode(payload any) ([]byte, error) {
 		return nil, errors.New("expected string")
 	}
 	return []byte(s), nil
+}
+
+func TestDecodeFailureIsLoggedWithoutPayload(t *testing.T) {
+	var line string
+	b := &Bus{logf: func(format string, args ...any) { line = fmt.Sprintf(format, args...) }}
+	b.logDecodeFailure("app.v1.run.t1.r1.started", errors.New("bad frame"))
+	if !strings.Contains(line, "app.v1.run.t1.r1.started") || !strings.Contains(line, "bad frame") || !strings.Contains(line, "terminating") {
+		t.Fatalf("decode log = %q", line)
+	}
 }
 
 func (stringCodec) Decode(data []byte) (any, error) {

--- a/events/catalog.go
+++ b/events/catalog.go
@@ -30,8 +30,17 @@ type (
 	}
 	// RunCanceledEvent marks a run stopped by a cancellation request.
 	RunCanceledEvent struct{}
-	// RunPausedEvent marks a run suspended for a later continuation.
-	RunPausedEvent struct{}
+	// RunPausedEvent marks a run suspended for a later continuation. Committed
+	// reports whether the sink reached a boundary that can promote checkpoints.
+	RunPausedEvent struct {
+		Committed bool `json:"committed"`
+	}
+	// RunPauseRequestedEvent asks the worker owning a running run to stop
+	// extraction, drain accepted records, and acknowledge with RunPaused.
+	RunPauseRequestedEvent struct{}
+	// RunCancelRequestedEvent asks the worker owning a running run to stop and
+	// abort its sink before acknowledging with RunCanceled.
+	RunCancelRequestedEvent struct{}
 	// HeartbeatEvent is the worker liveness and resource usage signal: the
 	// pod's cumulative cgroup CPU time and its current/peak working set.
 	HeartbeatEvent struct {
@@ -112,14 +121,16 @@ type (
 // The event kinds, one per payload type above; each value is the capability
 // to emit or subscribe to that kind.
 var (
-	RunRequested = define[RunRequestedEvent]("run.requested")
-	RunStarted   = define[RunStartedEvent]("run.started")
-	RunCompleted = define[RunCompletedEvent]("run.completed")
-	RunFailed    = define[RunFailedEvent]("run.failed")
-	RunPartial   = define[RunPartialEvent]("run.partial")
-	RunCanceled  = define[RunCanceledEvent]("run.canceled")
-	RunPaused    = define[RunPausedEvent]("run.paused")
-	Heartbeat    = define[HeartbeatEvent]("run.heartbeat")
+	RunRequested       = define[RunRequestedEvent]("run.requested")
+	RunStarted         = define[RunStartedEvent]("run.started")
+	RunCompleted       = define[RunCompletedEvent]("run.completed")
+	RunFailed          = define[RunFailedEvent]("run.failed")
+	RunPartial         = define[RunPartialEvent]("run.partial")
+	RunCanceled        = define[RunCanceledEvent]("run.canceled")
+	RunPaused          = define[RunPausedEvent]("run.paused")
+	RunPauseRequested  = define[RunPauseRequestedEvent]("run.pause_requested")
+	RunCancelRequested = define[RunCancelRequestedEvent]("run.cancel_requested")
+	Heartbeat          = define[HeartbeatEvent]("run.heartbeat")
 
 	ResourceStarted   = define[ResourceStartedEvent]("resource.started")
 	PageFetched       = define[PageFetchedEvent]("resource.page_fetched")

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -57,6 +57,8 @@ func TestRunControlEventsAreCataloged(t *testing.T) {
 	}{
 		{name: RunCanceled.Name(), data: RunCanceledEvent{}},
 		{name: RunPaused.Name(), data: RunPausedEvent{}},
+		{name: RunPauseRequested.Name(), data: RunPauseRequestedEvent{}},
+		{name: RunCancelRequested.Name(), data: RunCancelRequestedEvent{}},
 	} {
 		b, err := Marshal(Fact{Envelope: env(), Name: event.name, Data: event.data})
 		if err != nil {

--- a/infra.go
+++ b/infra.go
@@ -66,7 +66,20 @@ type DataStore interface {
 // the current status. It is separate from DataStore so adapters can reject run
 // signaling explicitly instead of emulating an unsafe LoadRun/SaveRun race.
 type RunTransitionStore interface {
-	TransitionRun(ctx context.Context, id RunID, from []RunStatus, to RunStatus, resetExecution bool) (RunState, error)
+	TransitionRun(
+		ctx context.Context,
+		id RunID,
+		from []RunStatus,
+		to RunStatus,
+		opts RunTransitionOptions,
+	) (RunState, error)
+}
+
+// RunTransitionOptions controls the attempt-local state reset performed by a
+// lifecycle transition.
+type RunTransitionOptions struct {
+	ResetExecution   bool
+	PreserveProgress bool
 }
 
 // ResourceCheckpointKey identifies durable progress shared by runs of one

--- a/infra.go
+++ b/infra.go
@@ -62,6 +62,13 @@ type DataStore interface {
 	Name() string
 }
 
+// RunTransitionStore applies lifecycle commands with a compare-and-swap on
+// the current status. It is separate from DataStore so adapters can reject run
+// signaling explicitly instead of emulating an unsafe LoadRun/SaveRun race.
+type RunTransitionStore interface {
+	TransitionRun(ctx context.Context, id RunID, from []RunStatus, to RunStatus, resetExecution bool) (RunState, error)
+}
+
 // ResourceCheckpointKey identifies durable progress shared by runs of one
 // immutable pipeline route. Resource is deliberately part of the key so each
 // table advances independently.

--- a/internal/modules/dispatch/k8s/client.go
+++ b/internal/modules/dispatch/k8s/client.go
@@ -40,7 +40,19 @@ func restConfig(cfg Config) (*rest.Config, error) {
 
 func (c *client) createJob(ctx context.Context, namespace string, j *batchv1.Job) error {
 	_, err := c.clientset.BatchV1().Jobs(namespace).Create(ctx, j, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if apierrors.IsAlreadyExists(err) {
+		existing, getErr := c.clientset.BatchV1().Jobs(namespace).Get(ctx, j.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("k8sdispatch: inspect existing job %q in %q: %w", j.Name, namespace, getErr)
+		}
+		for _, key := range []string{"filament.galaxy.io/run-id", "filament.galaxy.io/execution-id"} {
+			if existing.Labels[key] != j.Labels[key] {
+				return fmt.Errorf("k8sdispatch: job name collision %q in %q: label %q is %q, want %q", j.Name, namespace, key, existing.Labels[key], j.Labels[key])
+			}
+		}
+		return nil
+	}
+	if err != nil {
 		return fmt.Errorf("k8sdispatch: create job %q in %q: %w", j.Name, namespace, err)
 	}
 	return nil

--- a/internal/modules/dispatch/k8s/handle.go
+++ b/internal/modules/dispatch/k8s/handle.go
@@ -38,7 +38,7 @@ func (h runHandle) Wait(ctx context.Context) (filament.RunResult, error) {
 			return filament.RunResult{}, err
 		}
 		switch state.Status {
-		case filament.RunCompleted, filament.RunFailed, filament.RunCanceled:
+		case filament.RunCompleted, filament.RunFailed, filament.RunCanceled, filament.RunPaused, filament.RunPartial:
 			return filament.RunResult{
 				Status:  state.Status,
 				Records: state.Records,

--- a/internal/modules/dispatch/k8s/helpers.go
+++ b/internal/modules/dispatch/k8s/helpers.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"strconv"
 	"strings"
@@ -8,21 +10,34 @@ import (
 	"github.com/galaxy-io/filament"
 )
 
-func jobName(prefix string, run filament.RunID) string {
+func jobName(prefix string, run filament.RunID, executionID string) string {
 	p := cleanDNS1123(prefix)
 	r := cleanDNS1123(string(run))
-	name := p + "-" + r
+	suffix := ""
+	if executionID != "" {
+		suffix = "-" + executionToken(executionID)
+	}
+	name := p + "-" + r + suffix
 	if len(name) <= 63 {
 		return name
 	}
-	if len(r) > 48 {
-		r = r[:48]
+	maxRun := 63 - len(p) - len(suffix) - 1
+	if maxRun < 1 {
+		maxRun = 1
 	}
-	name = p + "-" + r
+	if len(r) > maxRun {
+		r = r[:maxRun]
+	}
+	name = p + "-" + r + suffix
 	if len(name) > 63 {
 		name = name[:63]
 	}
 	return strings.Trim(name, "-")
+}
+
+func executionToken(executionID string) string {
+	sum := sha256.Sum256([]byte(executionID))
+	return hex.EncodeToString(sum[:6])
 }
 
 func cleanDNS1123(s string) string {

--- a/internal/modules/dispatch/k8s/job.go
+++ b/internal/modules/dispatch/k8s/job.go
@@ -65,12 +65,16 @@ func workerTolerations(in []filament.WorkerToleration) []corev1.Toleration {
 // template share it: when the two were written out separately the pod template
 // lost the tenant label, so a selector that found the Job missed its pods.
 func (m *Module) jobLabels(spec filament.RunSpec) map[string]string {
-	return map[string]string{
+	labels := map[string]string{
 		"app.kubernetes.io/name":      m.appName(),
 		"app.kubernetes.io/component": "worker",
 		"filament.galaxy.io/run-id":   string(spec.Run),
 		"filament.galaxy.io/tenant":   string(spec.Tenant),
 	}
+	if spec.ExecutionID != "" {
+		labels["filament.galaxy.io/execution-id"] = executionToken(spec.ExecutionID)
+	}
+	return labels
 }
 
 // appName is the chart's app name, so Jobs select alongside chart-rendered
@@ -84,7 +88,7 @@ func (m *Module) appName() string {
 }
 
 func (m *Module) jobForSpec(spec filament.RunSpec) (*batchv1.Job, error) {
-	name := jobName(m.cfg.JobNamePrefix, spec.Run)
+	name := jobName(m.cfg.JobNamePrefix, spec.Run, spec.ExecutionID)
 	// All worker configuration arrives through the worker Secret and ConfigMap;
 	// RUN_ID is the only value dispatch itself knows.
 	envFrom := []corev1.EnvFromSource{{

--- a/internal/modules/dispatch/k8s/job_test.go
+++ b/internal/modules/dispatch/k8s/job_test.go
@@ -49,7 +49,7 @@ func TestWorkerResources(t *testing.T) {
 
 func TestJobAndPodLabelsMatch(t *testing.T) {
 	m := &Module{cfg: Config{WorkerImage: "worker:test", WorkerSecretName: "filament-secret", JobNamePrefix: "filament"}}
-	job, err := m.jobForSpec(filament.RunSpec{Tenant: "acme", Run: "run-1"})
+	job, err := m.jobForSpec(filament.RunSpec{Tenant: "acme", Run: "run-1", ExecutionID: "attempt-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,6 +62,24 @@ func TestJobAndPodLabelsMatch(t *testing.T) {
 	}
 	if got := pod["filament.galaxy.io/run-id"]; got != "run-1" {
 		t.Fatalf("pod run-id label = %q, want run-1", got)
+	}
+	if got := pod["filament.galaxy.io/execution-id"]; got != executionToken("attempt-1") {
+		t.Fatalf("pod execution-id label = %q", got)
+	}
+}
+
+func TestJobNameIsStablePerExecutionAndChangesOnResume(t *testing.T) {
+	first := jobName("filament", "run-1", "attempt-1")
+	redelivery := jobName("filament", "run-1", "attempt-1")
+	resumed := jobName("filament", "run-1", "attempt-2")
+	if first != redelivery {
+		t.Fatalf("redelivery name = %q, want %q", redelivery, first)
+	}
+	if first == resumed {
+		t.Fatalf("resumed execution reused job name %q", first)
+	}
+	if !isDNS1123Label(resumed) {
+		t.Fatalf("job name %q is not DNS-1123", resumed)
 	}
 }
 

--- a/internal/modules/dispatch/k8s/module.go
+++ b/internal/modules/dispatch/k8s/module.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/galaxy-io/filament"
 	"github.com/galaxy-io/filament/eventbus/host"
@@ -75,7 +76,9 @@ func (m *Module) onRunRequested(ctx context.Context, ev events.Event[events.RunR
 	if !runner.ShouldRun(state) {
 		return nil
 	}
-	_, err = m.Dispatch(ctx, runner.SpecFromState(state))
+	spec := runner.SpecFromState(state)
+	spec.ExecutionID = ev.At.UTC().Format(time.RFC3339Nano)
+	_, err = m.Dispatch(ctx, spec)
 	return err
 }
 

--- a/internal/modules/tracker/incremental_test.go
+++ b/internal/modules/tracker/incremental_test.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/galaxy-io/filament"
@@ -9,6 +10,19 @@ import (
 	"github.com/galaxy-io/filament/datastore/memory"
 	"github.com/galaxy-io/filament/events"
 )
+
+type failOnceCheckpointStore struct {
+	filament.DataStore
+	failed bool
+}
+
+func (s *failOnceCheckpointStore) SaveResourceCheckpoint(ctx context.Context, state filament.ResourceCheckpointState) error {
+	if !s.failed {
+		s.failed = true
+		return errors.New("checkpoint unavailable")
+	}
+	return s.DataStore.SaveResourceCheckpoint(ctx, state)
+}
 
 func TestWatermarkProgressIsNotPersistedBeforeBatchWrite(t *testing.T) {
 	m := New()
@@ -44,12 +58,16 @@ func TestIncrementalCheckpointBecomesDurableOnlyAfterCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	m.cp[ckKey{run: "run-a", resource: "users"}] = cp
-	m.flushRun(ctx, "run-a", false)
+	if err := m.flushRunFor(ctx, "run-a", false, checkpointReason("flush")); err != nil {
+		t.Fatal(err)
+	}
 	key, _ := request.ResourceCheckpointKey("users")
 	if _, err := store.LoadResourceCheckpoint(ctx, key); err == nil {
 		t.Fatal("partial run persisted a tentative checkpoint")
 	}
-	m.flushRun(ctx, "run-a", true)
+	if err := m.flushRunFor(ctx, "run-a", true, checkpointReason("flush")); err != nil {
+		t.Fatal(err)
+	}
 	stored, err := store.LoadResourceCheckpoint(ctx, key)
 	if err != nil {
 		t.Fatal(err)
@@ -59,6 +77,79 @@ func TestIncrementalCheckpointBecomesDurableOnlyAfterCommit(t *testing.T) {
 	}
 	if got := m.loadCheckpoint(ctx, "run-a", "users"); got == nil || got.String("watermark") == "" {
 		t.Fatalf("loaded checkpoint = %#v", got)
+	}
+}
+
+func TestPausedAcknowledgementCommitsCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+	request := filament.RunRequest{
+		PipelineID: "pipe", PipelineVersionID: "version-3", CheckpointRoute: "route/source/sink",
+		IngestionTypes: map[string]filament.IngestionType{"users": filament.IngestionIncrementalUpsert},
+	}
+	state := filament.RunState{Run: "run-a", Tenant: "tenant", Status: filament.RunRunning, Request: request}
+	if err := store.SaveRun(ctx, state); err != nil {
+		t.Fatal(err)
+	}
+	m := New()
+	m.ds = store
+	cp := filament.NewCheckpoint("users").Set("watermark", "2026-08-04T00:00:00Z")
+	m.cp[ckKey{run: "run-a", resource: "users"}] = cp
+	m.boundary[ckKey{run: "run-a", resource: "users"}] = filament.CheckpointAfterCommit
+	if err := m.apply(ctx, events.NewFact(
+		events.RunPaused,
+		events.Envelope{Tenant: "tenant", Run: "run-a"},
+		events.RunPausedEvent{Committed: true},
+	)); err != nil {
+		t.Fatal(err)
+	}
+	key, _ := request.ResourceCheckpointKey("users")
+	stored, err := store.LoadResourceCheckpoint(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stored.Checkpoint.String("watermark"); got != "2026-08-04T00:00:00Z" {
+		t.Fatalf("paused checkpoint = %q", got)
+	}
+}
+
+func TestPausedAcknowledgementWaitsForCheckpointPromotion(t *testing.T) {
+	ctx := context.Background()
+	base := memory.New()
+	store := &failOnceCheckpointStore{DataStore: base}
+	request := filament.RunRequest{
+		PipelineID: "pipe", PipelineVersionID: "version-3", CheckpointRoute: "route/source/sink",
+		IngestionTypes: map[string]filament.IngestionType{"users": filament.IngestionIncrementalUpsert},
+	}
+	if err := base.SaveRun(ctx, filament.RunState{Run: "run-a", Tenant: "tenant", Status: filament.RunRunning, Request: request}); err != nil {
+		t.Fatal(err)
+	}
+	m := New()
+	m.ds = store
+	cp := filament.NewCheckpoint("users").Set("watermark", "2026-08-04T00:00:00Z")
+	m.cp[ckKey{run: "run-a", resource: "users"}] = cp
+	m.boundary[ckKey{run: "run-a", resource: "users"}] = filament.CheckpointAfterCommit
+	msg := fakeMsg{seq: 7, fact: events.NewFact(
+		events.RunPaused,
+		events.Envelope{Tenant: "tenant", Run: "run-a"},
+		events.RunPausedEvent{Committed: true},
+	)}
+	if err := m.onFact(ctx, msg); err == nil {
+		t.Fatal("pause succeeded despite failed checkpoint promotion")
+	}
+	state, err := base.LoadRun(ctx, "run-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Status != filament.RunRunning {
+		t.Fatalf("status after failed promotion = %v, want running", state.Status)
+	}
+	if err := m.onFact(ctx, msg); err != nil {
+		t.Fatalf("retry pause: %v", err)
+	}
+	state, err = base.LoadRun(ctx, "run-a")
+	if err != nil || state.Status != filament.RunPaused {
+		t.Fatalf("status after retry = %v, %v", state.Status, err)
 	}
 }
 
@@ -76,12 +167,16 @@ func TestCDCCheckpointBecomesDurableOnlyAfterCommit(t *testing.T) {
 	m.ds = store
 	cp := checkpoint.NewStreamDelta("users", "0/16B6C50", 8)
 	m.cp[ckKey{run: "run-a", resource: "users"}] = cp
-	m.flushRun(ctx, "run-a", false)
+	if err := m.flushRunFor(ctx, "run-a", false, checkpointReason("flush")); err != nil {
+		t.Fatal(err)
+	}
 	key, _ := request.ResourceCheckpointKey("users")
 	if _, err := store.LoadResourceCheckpoint(ctx, key); err == nil {
 		t.Fatal("partial CDC run persisted a tentative checkpoint")
 	}
-	m.flushRun(ctx, "run-a", true)
+	if err := m.flushRunFor(ctx, "run-a", true, checkpointReason("flush")); err != nil {
+		t.Fatal(err)
+	}
 	stored, err := store.LoadResourceCheckpoint(ctx, key)
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +218,9 @@ func TestCompletedBackfillPromotesInitialWatermarkAfterRunCommit(t *testing.T) {
 	if !ok || beforePlan.Mode != checkpoint.ModeIncrementalBackfill {
 		t.Fatalf("resource completion promoted checkpoint before commit: %#v", beforeCommit.Checkpoint.Raw())
 	}
-	m.flushRun(ctx, "run-a", true)
+	if err := m.flushRunFor(ctx, "run-a", true, checkpointReason("flush")); err != nil {
+		t.Fatal(err)
+	}
 	stored, err := store.LoadResourceCheckpoint(ctx, key)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/modules/tracker/tracker.go
+++ b/internal/modules/tracker/tracker.go
@@ -144,6 +144,16 @@ func (m *Module) apply(ctx context.Context, f events.Fact) error {
 			r.Error = d.Error
 		})
 
+	case events.RunCanceledEvent:
+		return m.terminal(ctx, env, "canceled", func(r *filament.RunState) {
+			r.Status = filament.RunCanceled
+		})
+
+	case events.RunPausedEvent:
+		return m.terminal(ctx, env, "paused", func(r *filament.RunState) {
+			r.Status = filament.RunPaused
+		})
+
 	case events.ResourceStartedEvent:
 		return m.mutate(ctx, env, func(r *filament.RunState) {
 			rs := resourceRef(r, env.Resource)

--- a/internal/modules/tracker/tracker.go
+++ b/internal/modules/tracker/tracker.go
@@ -183,33 +183,7 @@ func (m *Module) apply(ctx context.Context, f events.Fact) error {
 		})
 
 	case events.BatchWrittenEvent:
-		m.rememberBoundary(env, d.CheckpointPolicy)
-		// Incremental progress: accumulate per-resource and run totals as chunks
-		// land, so observers see counts climb before the run finishes.
-		var pipeline string
-		if err := m.mutate(ctx, env, func(r *filament.RunState) {
-			r.Records += d.Records
-			r.Bytes += d.Bytes
-			rs := resourceRef(r, env.Resource)
-			rs.Records += d.Records
-			rs.Bytes += d.Bytes
-			if rs.Status == filament.RunRequested {
-				rs.Status = filament.RunRunning
-			}
-			pipeline = r.Request.PipelineID
-		}); err != nil {
-			return err
-		}
-		m.observeBatch(env, pipeline, d.Records, d.Bytes)
-		if cp, persist := m.foldCursor(ctx, env, d.Checkpoint); cp != nil && persist {
-			if err := m.saveCheckpoint(ctx, env.Run, cp); err != nil {
-				m.observeCheckpointFailure()
-				if m.log != nil {
-					m.log.Error("tracker: save checkpoint", err, filament.Field{Key: "run", Value: string(env.Run)})
-				}
-			}
-		}
-		return nil
+		return m.applyBatchWritten(ctx, env, d)
 
 	case events.HeartbeatEvent:
 		// Usage counters are cumulative (CPU) or high-water (memory), so max
@@ -231,6 +205,36 @@ func (m *Module) apply(ctx context.Context, f events.Fact) error {
 	default:
 		return nil // facts this module doesn't fold are acked and ignored
 	}
+}
+
+func (m *Module) applyBatchWritten(ctx context.Context, env events.Envelope, d events.BatchWrittenEvent) error {
+	m.rememberBoundary(env, d.CheckpointPolicy)
+	// Incremental progress: accumulate per-resource and run totals as chunks
+	// land, so observers see counts climb before the run finishes.
+	var pipeline string
+	if err := m.mutate(ctx, env, func(r *filament.RunState) {
+		r.Records += d.Records
+		r.Bytes += d.Bytes
+		rs := resourceRef(r, env.Resource)
+		rs.Records += d.Records
+		rs.Bytes += d.Bytes
+		if rs.Status == filament.RunRequested {
+			rs.Status = filament.RunRunning
+		}
+		pipeline = r.Request.PipelineID
+	}); err != nil {
+		return err
+	}
+	m.observeBatch(env, pipeline, d.Records, d.Bytes)
+	if cp, persist := m.foldCursor(ctx, env, d.Checkpoint); cp != nil && persist {
+		if err := m.saveCheckpoint(ctx, env.Run, cp); err != nil {
+			m.observeCheckpointFailure()
+			if m.log != nil {
+				m.log.Error("tracker: save checkpoint", err, filament.Field{Key: "run", Value: string(env.Run)})
+			}
+		}
+	}
+	return nil
 }
 
 // terminal folds a run's terminal fact: apply the status mutation, stamp the

--- a/internal/modules/tracker/tracker.go
+++ b/internal/modules/tracker/tracker.go
@@ -53,6 +53,13 @@ type ckKey struct {
 	resource string
 }
 
+type checkpointReason string
+
+const (
+	checkpointReasonProgress          checkpointReason = "progress"
+	checkpointReasonResourceCompleted checkpointReason = "resource_completed"
+)
+
 // New returns an unmounted tracker. Providers are injected by Mount.
 func New() *Module {
 	return &Module{
@@ -86,8 +93,8 @@ func (m *Module) Mount(_ context.Context, d module.Deps) error {
 	return nil
 }
 
-// onFact de-dups then folds the fact into persisted state. Returning nil acks the
-// message; returning an error naks it for redelivery.
+// onFact folds a fact into persisted state. Returning nil acks the message;
+// returning an error naks it for redelivery.
 //
 // Dedup keys on the bus stream sequence (msg.Seq), not the event's embedded Seq:
 // the stream sequence is broker-assigned and unique per message, so facts from
@@ -99,6 +106,15 @@ func (m *Module) onFact(ctx context.Context, msg eventbus.Message) error {
 	if err != nil {
 		return nil // not a Fact: a foreign publisher on our pattern — skip
 	}
+	// Terminal folds promote checkpoints and are idempotent. Apply them before
+	// advancing the dedup high-water mark so a failed promotion can be retried.
+	if isTerminalFact(f.Data) {
+		if err := m.apply(ctx, f); err != nil {
+			return err
+		}
+		_, err := m.ds.DedupSeen(ctx, string(f.Tenant), f.Run, msg.Seq())
+		return err
+	}
 
 	seen, err := m.ds.DedupSeen(ctx, string(f.Tenant), f.Run, msg.Seq())
 	if err != nil {
@@ -109,6 +125,16 @@ func (m *Module) onFact(ctx context.Context, msg eventbus.Message) error {
 	}
 
 	return m.apply(ctx, f)
+}
+
+func isTerminalFact(data any) bool {
+	switch data.(type) {
+	case events.RunCompletedEvent, events.RunFailedEvent, events.RunPartialEvent,
+		events.RunCanceledEvent, events.RunPausedEvent:
+		return true
+	default:
+		return false
+	}
 }
 
 // apply folds one fact into persisted run/resource/checkpoint state. Facts not
@@ -125,7 +151,7 @@ func (m *Module) apply(ctx context.Context, f events.Fact) error {
 		})
 
 	case events.RunCompletedEvent:
-		return m.terminal(ctx, env, "completed", func(r *filament.RunState) {
+		return m.terminal(ctx, env, "completed", true, func(r *filament.RunState) {
 			r.Status = filament.RunCompleted
 			// The terminal fact carries the engine's authoritative totals.
 			r.Records = d.Records
@@ -133,24 +159,24 @@ func (m *Module) apply(ctx context.Context, f events.Fact) error {
 		})
 
 	case events.RunFailedEvent:
-		return m.terminal(ctx, env, "failed", func(r *filament.RunState) {
+		return m.terminal(ctx, env, "failed", false, func(r *filament.RunState) {
 			r.Status = filament.RunFailed
 			r.Error = d.Error
 		})
 
 	case events.RunPartialEvent:
-		return m.terminal(ctx, env, "partial", func(r *filament.RunState) {
+		return m.terminal(ctx, env, "partial", false, func(r *filament.RunState) {
 			r.Status = filament.RunPartial
 			r.Error = d.Error
 		})
 
 	case events.RunCanceledEvent:
-		return m.terminal(ctx, env, "canceled", func(r *filament.RunState) {
+		return m.terminal(ctx, env, "canceled", false, func(r *filament.RunState) {
 			r.Status = filament.RunCanceled
 		})
 
 	case events.RunPausedEvent:
-		return m.terminal(ctx, env, "paused", func(r *filament.RunState) {
+		return m.terminal(ctx, env, "paused", d.Committed, func(r *filament.RunState) {
 			r.Status = filament.RunPaused
 		})
 
@@ -237,9 +263,18 @@ func (m *Module) applyBatchWritten(ctx context.Context, env events.Envelope, d e
 	return nil
 }
 
-// terminal folds a run's terminal fact: apply the status mutation, stamp the
-// finish time, record the run metrics, and flush the run's cursors.
-func (m *Module) terminal(ctx context.Context, env events.Envelope, status string, fn func(*filament.RunState)) error {
+// terminal folds a run's terminal fact: first make its cursors durable, then
+// apply the status mutation, stamp the finish time, and record run metrics.
+func (m *Module) terminal(
+	ctx context.Context,
+	env events.Envelope,
+	status string,
+	promoteCommitGated bool,
+	fn func(*filament.RunState),
+) error {
+	if err := m.flushRunFor(ctx, env.Run, promoteCommitGated, checkpointReason(status)); err != nil {
+		return err
+	}
 	var labels runLabels
 	if err := m.mutate(ctx, env, func(r *filament.RunState) {
 		fn(r)
@@ -249,7 +284,6 @@ func (m *Module) terminal(ctx context.Context, env events.Envelope, status strin
 		return err
 	}
 	m.observeRun(env, status, labels)
-	m.flushRun(ctx, env.Run, status == "completed")
 	m.evictRun(env.Run)
 	return nil
 }
@@ -421,19 +455,24 @@ func (m *Module) flushResource(ctx context.Context, run filament.RunID, resource
 	m.since[key] = 0
 	m.mu.Unlock()
 	if cp != nil {
-		if err := m.persistCheckpoint(ctx, run, cp, false); err != nil {
+		if _, err := m.persistCheckpoint(ctx, run, cp, false, checkpointReasonResourceCompleted); err != nil {
 			m.observeCheckpointFailure()
 			if m.log != nil {
-				m.log.Error("tracker: flush checkpoint", err, filament.Field{Key: "run", Value: string(run)})
+				m.log.Error("tracker: flush checkpoint", err,
+					filament.Field{Key: "run", Value: string(run)},
+					filament.Field{Key: "resource", Value: resource},
+					filament.Field{Key: "reason", Value: string(checkpointReasonResourceCompleted)},
+				)
 			}
 		}
 	}
 }
 
-// flushRun persists every accumulated cursor for the run. Incremental and CDC
-// cursors become durable only after a successful sink commit; other cursor modes
-// retain their existing attempt-local resume behavior.
-func (m *Module) flushRun(ctx context.Context, run filament.RunID, committed bool) {
+// flushRunFor persists every accumulated cursor for the run. Incremental and CDC
+// cursors become durable only after a terminal fact proves the worker reached a
+// committed pause/completion boundary; other cursor modes retain their existing
+// attempt-local resume behavior.
+func (m *Module) flushRunFor(ctx context.Context, run filament.RunID, promoteCommitGated bool, reason checkpointReason) error {
 	m.mu.Lock()
 	pending := make(map[string]filament.Checkpoint)
 	for key, cp := range m.cp {
@@ -445,14 +484,38 @@ func (m *Module) flushRun(ctx context.Context, run filament.RunID, committed boo
 		}
 	}
 	m.mu.Unlock()
-	for _, cp := range pending {
-		if err := m.persistCheckpoint(ctx, run, cp, committed); err != nil {
+	persisted := 0
+	failed := 0
+	var failures []error
+	for resource, cp := range pending {
+		wrote, err := m.persistCheckpoint(ctx, run, cp, promoteCommitGated, reason)
+		if err != nil {
+			failed++
+			failures = append(failures, err)
 			m.observeCheckpointFailure()
 			if m.log != nil {
-				m.log.Error("tracker: flush checkpoint", err, filament.Field{Key: "run", Value: string(run)})
+				m.log.Error("tracker: flush checkpoint", err,
+					filament.Field{Key: "run", Value: string(run)},
+					filament.Field{Key: "resource", Value: resource},
+					filament.Field{Key: "reason", Value: string(reason)},
+				)
 			}
+		} else if wrote {
+			persisted++
 		}
 	}
+	if m.log != nil {
+		m.log.Info("tracker: checkpoint flush completed",
+			filament.Field{Key: "run", Value: string(run)},
+			filament.Field{Key: "reason", Value: string(reason)},
+			filament.Field{Key: "promote_commit_gated", Value: promoteCommitGated},
+			filament.Field{Key: "pending_checkpoints", Value: len(pending)},
+			filament.Field{Key: "persisted_checkpoints", Value: persisted},
+			filament.Field{Key: "deferred_checkpoints", Value: len(pending) - persisted - failed},
+			filament.Field{Key: "failed_checkpoints", Value: failed},
+		)
+	}
+	return errors.Join(failures...)
 }
 
 // cadence is the run's CheckpointEvery (cached; default when unset).
@@ -471,30 +534,70 @@ func (m *Module) cadence(ctx context.Context, run filament.RunID) int {
 // saveCheckpoint persists attempt-local progress. Cross-run incremental and CDC
 // progress remains tentative until flushRun promotes it after the sink commits.
 func (m *Module) saveCheckpoint(ctx context.Context, run filament.RunID, cp filament.Checkpoint) error {
-	return m.persistCheckpoint(ctx, run, cp, false)
+	_, err := m.persistCheckpoint(ctx, run, cp, false, checkpointReasonProgress)
+	return err
 }
 
-func (m *Module) persistCheckpoint(ctx context.Context, run filament.RunID, cp filament.Checkpoint, committed bool) error {
+func (m *Module) persistCheckpoint(
+	ctx context.Context,
+	run filament.RunID,
+	cp filament.Checkpoint,
+	promoteCommitGated bool,
+	reason checkpointReason,
+) (bool, error) {
 	m.mu.Lock()
 	boundary := m.boundary[ckKey{run: run, resource: cp.Resource()}]
 	m.mu.Unlock()
-	if boundary == filament.CheckpointAfterCommit && !committed {
-		return nil
+	if boundary == filament.CheckpointAfterCommit && !promoteCommitGated {
+		return false, nil
 	}
 	state, err := m.ds.LoadRun(ctx, run)
 	if err != nil {
-		return err
+		return false, err
 	}
 	mode := filament.SourcePolicyForIngestion(filament.TypeFor(state.Request.IngestionTypes, cp.Resource())).Mode
 	if mode == filament.ModeIncremental || mode == filament.ModeCDC {
-		if !committed {
-			return nil
+		if !promoteCommitGated {
+			return false, nil
 		}
 		if key, ok := state.Request.ResourceCheckpointKey(cp.Resource()); ok {
-			return m.ds.SaveResourceCheckpoint(ctx, filament.ResourceCheckpointState{Key: key, Run: run, Checkpoint: cp})
+			if err := m.ds.SaveResourceCheckpoint(ctx, filament.ResourceCheckpointState{Key: key, Run: run, Checkpoint: cp}); err != nil {
+				return false, err
+			}
+			m.logCheckpointPersisted(run, cp, mode, "pipeline", reason)
+			return true, nil
 		}
 	}
-	return m.ds.SaveCheckpoint(ctx, run, cp)
+	if err := m.ds.SaveCheckpoint(ctx, run, cp); err != nil {
+		return false, err
+	}
+	m.logCheckpointPersisted(run, cp, mode, "run", reason)
+	return true, nil
+}
+
+func (m *Module) logCheckpointPersisted(
+	run filament.RunID,
+	cp filament.Checkpoint,
+	mode filament.ReadMode,
+	scope string,
+	reason checkpointReason,
+) {
+	if m.log == nil {
+		return
+	}
+	fields := []filament.Field{
+		{Key: "run", Value: string(run)},
+		{Key: "resource", Value: cp.Resource()},
+		{Key: "checkpoint_scope", Value: scope},
+		{Key: "read_mode", Value: mode.String()},
+		{Key: "checkpoint_kind", Value: filament.CheckpointKind(cp)},
+		{Key: "reason", Value: string(reason)},
+	}
+	if reason == checkpointReasonProgress {
+		m.log.Debug("tracker: checkpoint persisted", fields...)
+		return
+	}
+	m.log.Info("tracker: checkpoint persisted", fields...)
 }
 
 // loadCheckpoint returns the persisted cursor for (run, resource) or nil.

--- a/internal/runs/signals.go
+++ b/internal/runs/signals.go
@@ -88,7 +88,11 @@ func Signal(
 		return err
 	}
 	if command.transition {
-		state, err = store.TransitionRun(ctx, state.Run, command.from, command.to, command.resetExecution)
+		preserveProgress := command.resetExecution && state.Status == filament.RunPaused &&
+			filament.CheckpointCoverageFor(state.Request.Resources, state.Request.IngestionTypes) == filament.CheckpointCoverageAll
+		state, err = store.TransitionRun(ctx, state.Run, command.from, command.to, filament.RunTransitionOptions{
+			ResetExecution: command.resetExecution, PreserveProgress: preserveProgress,
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/runs/signals.go
+++ b/internal/runs/signals.go
@@ -1,0 +1,126 @@
+package runs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/eventbus"
+	"github.com/galaxy-io/filament/events"
+)
+
+var (
+	// ErrWorkerControlUnavailable means the command needs a cooperative worker
+	// drain/stop acknowledgement that is not implemented yet.
+	ErrWorkerControlUnavailable = errors.New("running worker control is unavailable")
+	// ErrSignalTransition means the command is not admitted from the run's
+	// current lifecycle state.
+	ErrSignalTransition = errors.New("run signal is not valid from the current status")
+	// ErrSignalPublish distinguishes a durable transition whose notification
+	// could not be placed on the bus. Retrying the command repairs publication.
+	ErrSignalPublish = errors.New("publish run signal")
+)
+
+type signalCommand struct {
+	from           []filament.RunStatus
+	to             filament.RunStatus
+	resetExecution bool
+	publish        bool
+	transition     bool
+	err            error
+}
+
+type signalKey struct {
+	signal filament.Signal
+	status filament.RunStatus
+}
+
+var signalCommands = map[signalKey]signalCommand{
+	{filament.SignalPause, filament.RunRequested}: {
+		from: []filament.RunStatus{filament.RunRequested}, to: filament.RunPaused,
+		transition: true, publish: true,
+	},
+	{filament.SignalPause, filament.RunPaused}: {},
+	{filament.SignalPause, filament.RunRunning}: {
+		err: fmt.Errorf("%w: pause requires a cooperative drain barrier", ErrWorkerControlUnavailable),
+	},
+	{filament.SignalResume, filament.RunRequested}: {publish: true}, // repair dispatch
+	{filament.SignalResume, filament.RunPaused}: {
+		from: []filament.RunStatus{filament.RunPaused, filament.RunPartial}, to: filament.RunRequested,
+		resetExecution: true, transition: true, publish: true,
+	},
+	{filament.SignalResume, filament.RunPartial}: {
+		from: []filament.RunStatus{filament.RunPaused, filament.RunPartial}, to: filament.RunRequested,
+		resetExecution: true, transition: true, publish: true,
+	},
+	{filament.SignalCancel, filament.RunRequested}: {
+		from: []filament.RunStatus{filament.RunRequested, filament.RunPaused, filament.RunPartial},
+		to:   filament.RunCanceled, transition: true, publish: true,
+	},
+	{filament.SignalCancel, filament.RunPaused}: {
+		from: []filament.RunStatus{filament.RunRequested, filament.RunPaused, filament.RunPartial},
+		to:   filament.RunCanceled, transition: true, publish: true,
+	},
+	{filament.SignalCancel, filament.RunPartial}: {
+		from: []filament.RunStatus{filament.RunRequested, filament.RunPaused, filament.RunPartial},
+		to:   filament.RunCanceled, transition: true, publish: true,
+	},
+	{filament.SignalCancel, filament.RunCanceled}: {},
+	{filament.SignalCancel, filament.RunRunning}: {
+		err: fmt.Errorf("%w: cancel requires a cooperative stop barrier", ErrWorkerControlUnavailable),
+	},
+}
+
+// Signal plans and executes one lifecycle command. Transition policy belongs
+// here rather than in an RPC transport: every caller gets the same idempotency,
+// compare-and-swap, reset, and event publication semantics.
+func Signal(
+	ctx context.Context,
+	bus eventbus.Bus,
+	store filament.RunTransitionStore,
+	state filament.RunState,
+	signal filament.Signal,
+) error {
+	command, err := planSignal(state.Status, signal)
+	if err != nil {
+		return err
+	}
+	if command.transition {
+		state, err = store.TransitionRun(ctx, state.Run, command.from, command.to, command.resetExecution)
+		if err != nil {
+			return err
+		}
+	}
+	if !command.publish {
+		return nil
+	}
+	fact := signalFact(state, signal)
+	if err := events.Publish(ctx, bus, fact); err != nil {
+		return fmt.Errorf("%w: %v", ErrSignalPublish, err)
+	}
+	return nil
+}
+
+func planSignal(status filament.RunStatus, signal filament.Signal) (signalCommand, error) {
+	command, ok := signalCommands[signalKey{signal: signal, status: status}]
+	if !ok {
+		return signalCommand{}, fmt.Errorf("%w: signal %d from status %d", ErrSignalTransition, signal, status)
+	}
+	return command, command.err
+}
+
+func signalFact(state filament.RunState, signal filament.Signal) events.Fact {
+	env := events.Envelope{Tenant: state.Tenant, Run: state.Run, At: time.Now()}
+	switch signal {
+	case filament.SignalPause:
+		return events.NewFact(events.RunPaused, env, events.RunPausedEvent{})
+	case filament.SignalResume:
+		return events.NewFact(events.RunRequested, env, events.RunRequestedEvent{})
+	case filament.SignalCancel:
+		return events.NewFact(events.RunCanceled, env, events.RunCanceledEvent{})
+	default:
+		panic("runs: signalFact called with invalid signal")
+	}
+}

--- a/internal/runs/signals.go
+++ b/internal/runs/signals.go
@@ -29,6 +29,7 @@ type signalCommand struct {
 	resetExecution bool
 	publish        bool
 	transition     bool
+	worker         bool
 	err            error
 }
 
@@ -44,7 +45,7 @@ var signalCommands = map[signalKey]signalCommand{
 	},
 	{filament.SignalPause, filament.RunPaused}: {},
 	{filament.SignalPause, filament.RunRunning}: {
-		err: fmt.Errorf("%w: pause requires a cooperative drain barrier", ErrWorkerControlUnavailable),
+		publish: true, worker: true,
 	},
 	{filament.SignalResume, filament.RunRequested}: {publish: true}, // repair dispatch
 	{filament.SignalResume, filament.RunPaused}: {
@@ -69,7 +70,7 @@ var signalCommands = map[signalKey]signalCommand{
 	},
 	{filament.SignalCancel, filament.RunCanceled}: {},
 	{filament.SignalCancel, filament.RunRunning}: {
-		err: fmt.Errorf("%w: cancel requires a cooperative stop barrier", ErrWorkerControlUnavailable),
+		publish: true, worker: true,
 	},
 }
 
@@ -100,7 +101,7 @@ func Signal(
 	if !command.publish {
 		return nil
 	}
-	fact := signalFact(state, signal)
+	fact := signalFact(state, signal, command.worker)
 	if err := events.Publish(ctx, bus, fact); err != nil {
 		return fmt.Errorf("%w: %v", ErrSignalPublish, err)
 	}
@@ -115,14 +116,20 @@ func planSignal(status filament.RunStatus, signal filament.Signal) (signalComman
 	return command, command.err
 }
 
-func signalFact(state filament.RunState, signal filament.Signal) events.Fact {
+func signalFact(state filament.RunState, signal filament.Signal, worker bool) events.Fact {
 	env := events.Envelope{Tenant: state.Tenant, Run: state.Run, At: time.Now()}
 	switch signal {
 	case filament.SignalPause:
+		if worker {
+			return events.NewFact(events.RunPauseRequested, env, events.RunPauseRequestedEvent{})
+		}
 		return events.NewFact(events.RunPaused, env, events.RunPausedEvent{})
 	case filament.SignalResume:
 		return events.NewFact(events.RunRequested, env, events.RunRequestedEvent{})
 	case filament.SignalCancel:
+		if worker {
+			return events.NewFact(events.RunCancelRequested, env, events.RunCancelRequestedEvent{})
+		}
 		return events.NewFact(events.RunCanceled, env, events.RunCanceledEvent{})
 	default:
 		panic("runs: signalFact called with invalid signal")

--- a/internal/runs/signals.go
+++ b/internal/runs/signals.go
@@ -12,9 +12,6 @@ import (
 )
 
 var (
-	// ErrWorkerControlUnavailable means the command needs a cooperative worker
-	// drain/stop acknowledgement that is not implemented yet.
-	ErrWorkerControlUnavailable = errors.New("running worker control is unavailable")
 	// ErrSignalTransition means the command is not admitted from the run's
 	// current lifecycle state.
 	ErrSignalTransition = errors.New("run signal is not valid from the current status")
@@ -31,6 +28,11 @@ type signalCommand struct {
 	transition     bool
 	worker         bool
 	err            error
+}
+
+// SignalResult describes work that remains after a command is published.
+type SignalResult struct {
+	WorkerAcknowledgement bool
 }
 
 type signalKey struct {
@@ -83,10 +85,14 @@ func Signal(
 	store filament.RunTransitionStore,
 	state filament.RunState,
 	signal filament.Signal,
-) error {
+) (SignalResult, error) {
 	command, err := planSignal(state.Status, signal)
 	if err != nil {
-		return err
+		return SignalResult{}, err
+	}
+	if command.worker && signal == filament.SignalPause &&
+		filament.CheckpointCoverageFor(state.Request.Resources, state.Request.IngestionTypes) == filament.CheckpointCoverageSome {
+		return SignalResult{}, fmt.Errorf("%w: pause requires either all or no resources to be checkpointable", ErrSignalTransition)
 	}
 	if command.transition {
 		preserveProgress := command.resetExecution && state.Status == filament.RunPaused &&
@@ -95,17 +101,17 @@ func Signal(
 			ResetExecution: command.resetExecution, PreserveProgress: preserveProgress,
 		})
 		if err != nil {
-			return err
+			return SignalResult{}, err
 		}
 	}
 	if !command.publish {
-		return nil
+		return SignalResult{WorkerAcknowledgement: command.worker}, nil
 	}
 	fact := signalFact(state, signal, command.worker)
 	if err := events.Publish(ctx, bus, fact); err != nil {
-		return fmt.Errorf("%w: %v", ErrSignalPublish, err)
+		return SignalResult{}, fmt.Errorf("%w: %v", ErrSignalPublish, err)
 	}
-	return nil
+	return SignalResult{WorkerAcknowledgement: command.worker}, nil
 }
 
 func planSignal(status filament.RunStatus, signal filament.Signal) (signalCommand, error) {

--- a/internal/runs/signals_test.go
+++ b/internal/runs/signals_test.go
@@ -15,16 +15,18 @@ func TestPlanSignal(t *testing.T) {
 		to         filament.RunStatus
 		transition bool
 		publish    bool
+		worker     bool
 		wantErr    error
 	}{
 		{name: "pause requested", status: filament.RunRequested, signal: filament.SignalPause, to: filament.RunPaused, transition: true, publish: true},
 		{name: "pause idempotent", status: filament.RunPaused, signal: filament.SignalPause},
-		{name: "pause running unsupported", status: filament.RunRunning, signal: filament.SignalPause, wantErr: ErrWorkerControlUnavailable},
+		{name: "pause running", status: filament.RunRunning, signal: filament.SignalPause, publish: true, worker: true},
 		{name: "resume paused", status: filament.RunPaused, signal: filament.SignalResume, to: filament.RunRequested, transition: true, publish: true},
 		{name: "resume partial", status: filament.RunPartial, signal: filament.SignalResume, to: filament.RunRequested, transition: true, publish: true},
 		{name: "resume requested repairs dispatch", status: filament.RunRequested, signal: filament.SignalResume, publish: true},
 		{name: "cancel requested", status: filament.RunRequested, signal: filament.SignalCancel, to: filament.RunCanceled, transition: true, publish: true},
 		{name: "cancel idempotent", status: filament.RunCanceled, signal: filament.SignalCancel},
+		{name: "cancel running", status: filament.RunRunning, signal: filament.SignalCancel, publish: true, worker: true},
 		{name: "resume completed rejected", status: filament.RunCompleted, signal: filament.SignalResume, wantErr: ErrSignalTransition},
 	}
 	for _, tt := range tests {
@@ -36,7 +38,7 @@ func TestPlanSignal(t *testing.T) {
 			if tt.wantErr != nil {
 				return
 			}
-			if got.to != tt.to || got.transition != tt.transition || got.publish != tt.publish {
+			if got.to != tt.to || got.transition != tt.transition || got.publish != tt.publish || got.worker != tt.worker {
 				t.Fatalf("command = %#v", got)
 			}
 		})

--- a/internal/runs/signals_test.go
+++ b/internal/runs/signals_test.go
@@ -1,0 +1,44 @@
+package runs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/galaxy-io/filament"
+)
+
+func TestPlanSignal(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     filament.RunStatus
+		signal     filament.Signal
+		to         filament.RunStatus
+		transition bool
+		publish    bool
+		wantErr    error
+	}{
+		{name: "pause requested", status: filament.RunRequested, signal: filament.SignalPause, to: filament.RunPaused, transition: true, publish: true},
+		{name: "pause idempotent", status: filament.RunPaused, signal: filament.SignalPause},
+		{name: "pause running unsupported", status: filament.RunRunning, signal: filament.SignalPause, wantErr: ErrWorkerControlUnavailable},
+		{name: "resume paused", status: filament.RunPaused, signal: filament.SignalResume, to: filament.RunRequested, transition: true, publish: true},
+		{name: "resume partial", status: filament.RunPartial, signal: filament.SignalResume, to: filament.RunRequested, transition: true, publish: true},
+		{name: "resume requested repairs dispatch", status: filament.RunRequested, signal: filament.SignalResume, publish: true},
+		{name: "cancel requested", status: filament.RunRequested, signal: filament.SignalCancel, to: filament.RunCanceled, transition: true, publish: true},
+		{name: "cancel idempotent", status: filament.RunCanceled, signal: filament.SignalCancel},
+		{name: "resume completed rejected", status: filament.RunCompleted, signal: filament.SignalResume, wantErr: ErrSignalTransition},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := planSignal(tt.status, tt.signal)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr != nil {
+				return
+			}
+			if got.to != tt.to || got.transition != tt.transition || got.publish != tt.publish {
+				t.Fatalf("command = %#v", got)
+			}
+		})
+	}
+}

--- a/internal/runs/signals_test.go
+++ b/internal/runs/signals_test.go
@@ -1,10 +1,13 @@
 package runs
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/datastore/memory"
+	"github.com/galaxy-io/filament/eventbus/inproc"
 )
 
 func TestPlanSignal(t *testing.T) {
@@ -42,5 +45,61 @@ func TestPlanSignal(t *testing.T) {
 				t.Fatalf("command = %#v", got)
 			}
 		})
+	}
+}
+
+func TestResumePreservesOnlyCheckpointedProgress(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      filament.RunStatus
+		ingestion   filament.IngestionType
+		wantRecords int64
+	}{
+		{name: "paused resumable", status: filament.RunPaused, ingestion: filament.IngestionFullUpsert, wantRecords: 125},
+		{name: "paused restart", status: filament.RunPaused, ingestion: filament.IngestionFullReplace, wantRecords: 0},
+		{name: "partial progress is attempt-local", status: filament.RunPartial, ingestion: filament.IngestionFullUpsert, wantRecords: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := memory.New()
+			state := filament.RunState{
+				Run: "run", Tenant: "tenant", Status: tt.status, Records: 125, Bytes: 500,
+				Request: filament.RunRequest{
+					Resources:      []string{"users"},
+					IngestionTypes: map[string]filament.IngestionType{"users": tt.ingestion},
+				},
+				Resources: []filament.ResourceState{{Resource: "users", Status: filament.RunRunning, Records: 125, Bytes: 500}},
+			}
+			if err := store.SaveRun(ctx, state); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Signal(ctx, inproc.New(), store, state, filament.SignalResume); err != nil {
+				t.Fatal(err)
+			}
+			got, err := store.LoadRun(ctx, state.Run)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Records != tt.wantRecords || got.Resources[0].Records != tt.wantRecords {
+				t.Fatalf("resume records = run %d, resource %d; want %d", got.Records, got.Resources[0].Records, tt.wantRecords)
+			}
+		})
+	}
+}
+
+func TestPauseRejectsMixedCheckpointCoverage(t *testing.T) {
+	state := filament.RunState{
+		Run: "run", Tenant: "tenant", Status: filament.RunRunning,
+		Request: filament.RunRequest{
+			Resources: []string{"users", "audit"},
+			IngestionTypes: map[string]filament.IngestionType{
+				"users": filament.IngestionFullUpsert,
+				"audit": filament.IngestionFullAppend,
+			},
+		},
+	}
+	if _, err := Signal(context.Background(), inproc.New(), memory.New(), state, filament.SignalPause); !errors.Is(err, ErrSignalTransition) {
+		t.Fatalf("mixed pause error = %v, want transition error", err)
 	}
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -54,6 +54,25 @@ func TestValidateReplication(t *testing.T) {
 	}
 }
 
+func TestCheckpointCoverageFor(t *testing.T) {
+	resources := []string{"users", "audit"}
+	if got := CheckpointCoverageFor(resources, map[string]IngestionType{
+		"users": IngestionFullUpsert,
+		"audit": IngestionFullAppend,
+	}); got != CheckpointCoverageSome {
+		t.Fatalf("mixed coverage = %v, want some", got)
+	}
+	if got := CheckpointCoverageFor(resources, map[string]IngestionType{
+		"users": IngestionFullUpsert,
+		"audit": IngestionIncrementalUpsert,
+	}); got != CheckpointCoverageAll {
+		t.Fatalf("resumable coverage = %v, want all", got)
+	}
+	if got := CheckpointCoverageFor(resources, nil); got != CheckpointCoverageNone {
+		t.Fatalf("default coverage = %v, want none", got)
+	}
+}
+
 type replicationSource struct{ Source }
 
 func (replicationSource) Replication(cfg Config) ReplicationMode {

--- a/record.go
+++ b/record.go
@@ -174,6 +174,17 @@ func (c *CheckpointData) Set(key string, v any) Checkpoint {
 // Raw exposes the underlying cursor map for persistence.
 func (c *CheckpointData) Raw() map[string]any { return c.Cursor }
 
+// CheckpointKind describes a cursor's shape without exposing its value.
+func CheckpointKind(cp Checkpoint) string {
+	if cp == nil {
+		return "none"
+	}
+	if mode, ok := cp.Raw()["mode"].(string); ok && mode != "" {
+		return mode
+	}
+	return "cursor"
+}
+
 // crcTable uses the Castagnoli polynomial, which has hardware acceleration on
 // both ARM64 (CRC32 instructions) and x86 (SSE4.2).
 var crcTable = crc32.MakeTable(crc32.Castagnoli)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -15,183 +15,179 @@ import (
 // ErrUnknownProvider is returned by Resolve when no factory is registered.
 var ErrUnknownProvider = errors.New("registry: unknown provider")
 
-// Sources is the source-provider registry.
-type Sources struct {
-	mu        sync.RWMutex
-	factories map[string]sourceRegistration
-}
-
-type sourceRegistration struct {
-	factory  filament.SourceFactory
+type registration[P any] struct {
+	factory  func() P
 	maturity filament.ConnectorMaturity
 }
 
-// NewSources returns an empty source registry.
-func NewSources() *Sources { return &Sources{factories: map[string]sourceRegistration{}} }
-
-var _ filament.SourceRegistry = (*Sources)(nil)
-
-// Register adds a factory under name. It panics on a nil factory or a duplicate
-func (r *Sources) Register(name string, f filament.SourceFactory) {
-	r.RegisterWithMaturity(name, filament.MaturityAlpha, f)
+type providerRegistry[P, S any] struct {
+	kind        string
+	mu          sync.RWMutex
+	factories   map[string]registration[P]
+	specOf      func(P) S
+	setMaturity func(*S, filament.ConnectorMaturity)
 }
 
-// RegisterWithMaturity adds a source factory and its catalog maturity under
-// name. It panics on an invalid maturity, a nil factory, or a duplicate name.
-func (r *Sources) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, f filament.SourceFactory) {
+func newProviderRegistry[P, S any](
+	kind string,
+	specOf func(P) S,
+	setMaturity func(*S, filament.ConnectorMaturity),
+) *providerRegistry[P, S] {
+	return &providerRegistry[P, S]{
+		kind:        kind,
+		factories:   make(map[string]registration[P]),
+		specOf:      specOf,
+		setMaturity: setMaturity,
+	}
+}
+
+func (r *providerRegistry[P, S]) register(name string, maturity filament.ConnectorMaturity, factory func() P) {
 	switch maturity {
 	case filament.MaturityAlpha, filament.MaturityBeta, filament.MaturityStable:
 	default:
-		panic("registry: invalid source maturity for " + name + ": " + string(maturity))
+		panic("registry: invalid " + r.kind + " maturity for " + name + ": " + string(maturity))
 	}
-	if f == nil {
-		panic("registry: nil source factory for " + name)
+	if factory == nil {
+		panic("registry: nil " + r.kind + " factory for " + name)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, dup := r.factories[name]; dup {
-		panic("registry: source already registered: " + name)
+		panic("registry: " + r.kind + " already registered: " + name)
 	}
-	r.factories[name] = sourceRegistration{factory: f, maturity: maturity}
+	r.factories[name] = registration[P]{factory: factory, maturity: maturity}
 }
 
-// Resolve constructs a fresh source instance for name.
-func (r *Sources) Resolve(name string) (filament.Source, error) {
+func (r *providerRegistry[P, S]) resolve(name string) (P, error) {
 	r.mu.RLock()
 	registration, ok := r.factories[name]
 	r.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("%w: source %q", ErrUnknownProvider, name)
+		var zero P
+		return zero, fmt.Errorf("%w: %s %q", ErrUnknownProvider, r.kind, name)
 	}
 	return registration.factory(), nil
 }
 
-// Spec returns one registered source's catalog spec with its maturity marker.
-func (r *Sources) Spec(name string) (filament.ConnectorSpec, error) {
+func (r *providerRegistry[P, S]) spec(name string) (S, error) {
 	r.mu.RLock()
 	registration, ok := r.factories[name]
 	r.mu.RUnlock()
 	if !ok {
-		return filament.ConnectorSpec{}, fmt.Errorf("%w: source %q", ErrUnknownProvider, name)
+		var zero S
+		return zero, fmt.Errorf("%w: %s %q", ErrUnknownProvider, r.kind, name)
 	}
-	spec := registration.factory().Spec()
-	spec.Maturity = registration.maturity
+	spec := r.specOf(registration.factory())
+	r.setMaturity(&spec, registration.maturity)
 	return spec, nil
+}
+
+func (r *providerRegistry[P, S]) specs() []S {
+	registrations := r.snapshot()
+	out := make([]S, len(registrations))
+	for i, registration := range registrations {
+		out[i] = r.specOf(registration.factory())
+		r.setMaturity(&out[i], registration.maturity)
+	}
+	return out
+}
+
+func (r *providerRegistry[P, S]) snapshot() []registration[P] {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.factories))
+	for n := range r.factories {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]registration[P], len(names))
+	for i, n := range names {
+		out[i] = r.factories[n]
+	}
+	return out
+}
+
+// Sources is the source-provider registry.
+type Sources struct {
+	providers *providerRegistry[filament.Source, filament.ConnectorSpec]
+}
+
+// NewSources returns an empty source registry.
+func NewSources() *Sources {
+	return &Sources{providers: newProviderRegistry(
+		"source",
+		func(source filament.Source) filament.ConnectorSpec { return source.Spec() },
+		func(spec *filament.ConnectorSpec, maturity filament.ConnectorMaturity) { spec.Maturity = maturity },
+	)}
+}
+
+var _ filament.SourceRegistry = (*Sources)(nil)
+
+// Register adds a factory under name. It panics on a nil factory or a duplicate
+func (r *Sources) Register(name string, factory filament.SourceFactory) {
+	r.RegisterWithMaturity(name, filament.MaturityAlpha, factory)
+}
+
+// RegisterWithMaturity adds a source factory and its catalog maturity under
+// name. It panics on an invalid maturity, a nil factory, or a duplicate name.
+func (r *Sources) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, factory filament.SourceFactory) {
+	r.providers.register(name, maturity, factory)
+}
+
+// Resolve constructs a fresh source instance for name.
+func (r *Sources) Resolve(name string) (filament.Source, error) {
+	return r.providers.resolve(name)
+}
+
+// Spec returns one registered source's catalog spec with its maturity marker.
+func (r *Sources) Spec(name string) (filament.ConnectorSpec, error) {
+	return r.providers.spec(name)
 }
 
 // Specs returns every registered source's spec, sorted by name. Powers the
 // DiscoveryService catalog.
 func (r *Sources) Specs() []filament.ConnectorSpec {
-	registrations := r.snapshot()
-	out := make([]filament.ConnectorSpec, len(registrations))
-	for i, registration := range registrations {
-		out[i] = registration.factory().Spec()
-		out[i].Maturity = registration.maturity
-	}
-	return out
-}
-
-func (r *Sources) snapshot() []sourceRegistration {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.factories))
-	for n := range r.factories {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	out := make([]sourceRegistration, len(names))
-	for i, n := range names {
-		out[i] = r.factories[n]
-	}
-	return out
+	return r.providers.specs()
 }
 
 // Sinks is the sink-provider registry.
 type Sinks struct {
-	mu        sync.RWMutex
-	factories map[string]sinkRegistration
-}
-
-type sinkRegistration struct {
-	factory  filament.SinkFactory
-	maturity filament.ConnectorMaturity
+	providers *providerRegistry[filament.Sink, filament.SinkSpec]
 }
 
 // NewSinks returns an empty sink registry.
-func NewSinks() *Sinks { return &Sinks{factories: map[string]sinkRegistration{}} }
+func NewSinks() *Sinks {
+	return &Sinks{providers: newProviderRegistry(
+		"sink",
+		func(sink filament.Sink) filament.SinkSpec { return sink.Spec() },
+		func(spec *filament.SinkSpec, maturity filament.ConnectorMaturity) { spec.Maturity = maturity },
+	)}
+}
 
 var _ filament.SinkRegistry = (*Sinks)(nil)
 
 // Register adds a factory under name. Panics on nil factory or duplicate name.
-func (r *Sinks) Register(name string, f filament.SinkFactory) {
-	r.RegisterWithMaturity(name, filament.MaturityAlpha, f)
+func (r *Sinks) Register(name string, factory filament.SinkFactory) {
+	r.RegisterWithMaturity(name, filament.MaturityAlpha, factory)
 }
 
 // RegisterWithMaturity adds a sink factory and its catalog maturity under name.
 // It panics on an invalid maturity, a nil factory, or a duplicate name.
-func (r *Sinks) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, f filament.SinkFactory) {
-	switch maturity {
-	case filament.MaturityAlpha, filament.MaturityBeta, filament.MaturityStable:
-	default:
-		panic("registry: invalid sink maturity for " + name + ": " + string(maturity))
-	}
-	if f == nil {
-		panic("registry: nil sink factory for " + name)
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, dup := r.factories[name]; dup {
-		panic("registry: sink already registered: " + name)
-	}
-	r.factories[name] = sinkRegistration{factory: f, maturity: maturity}
+func (r *Sinks) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, factory filament.SinkFactory) {
+	r.providers.register(name, maturity, factory)
 }
 
 // Resolve constructs a fresh sink instance for name.
 func (r *Sinks) Resolve(name string) (filament.Sink, error) {
-	r.mu.RLock()
-	registration, ok := r.factories[name]
-	r.mu.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("%w: sink %q", ErrUnknownProvider, name)
-	}
-	return registration.factory(), nil
+	return r.providers.resolve(name)
 }
 
 // Spec returns one registered sink's catalog spec with its maturity marker.
 func (r *Sinks) Spec(name string) (filament.SinkSpec, error) {
-	r.mu.RLock()
-	registration, ok := r.factories[name]
-	r.mu.RUnlock()
-	if !ok {
-		return filament.SinkSpec{}, fmt.Errorf("%w: sink %q", ErrUnknownProvider, name)
-	}
-	spec := registration.factory().Spec()
-	spec.Maturity = registration.maturity
-	return spec, nil
+	return r.providers.spec(name)
 }
 
 // Specs returns every registered sink's spec, sorted by name.
 func (r *Sinks) Specs() []filament.SinkSpec {
-	registrations := r.snapshot()
-	out := make([]filament.SinkSpec, len(registrations))
-	for i, registration := range registrations {
-		out[i] = registration.factory().Spec()
-		out[i].Maturity = registration.maturity
-	}
-	return out
-}
-
-func (r *Sinks) snapshot() []sinkRegistration {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.factories))
-	for n := range r.factories {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	out := make([]sinkRegistration, len(names))
-	for i, n := range names {
-		out[i] = r.factories[n]
-	}
-	return out
+	return r.providers.specs()
 }

--- a/run.go
+++ b/run.go
@@ -27,7 +27,6 @@ type RunSpec struct {
 	// IngestionTypes maps each resource to its ingestion type; the "" entry is
 	// the route default for resources not explicitly listed.
 	IngestionTypes map[string]IngestionType
-	Checkpoint     *CheckpointData
 	Options        RunOptions
 	WritePolicies  map[string]WritePolicy
 	// WorkerConfiguration is the already-resolved worker shape for this run: the
@@ -283,7 +282,6 @@ type RunFilter struct {
 	Tenant            TenantID
 	PipelineID        string
 	PipelineVersionID *string
-	Source            string
 	Status            []RunStatus
 	Schedule          ScheduleID
 	Since             time.Time

--- a/run.go
+++ b/run.go
@@ -651,3 +651,41 @@ func SourcePolicyForIngestion(t IngestionType) SourcePolicy {
 		}
 	}
 }
+
+// CheckpointCoverage describes whether none, some, or all selected resources
+// can resume from a durable source cursor.
+type CheckpointCoverage uint8
+
+const (
+	CheckpointCoverageNone CheckpointCoverage = iota
+	CheckpointCoverageSome
+	CheckpointCoverageAll
+)
+
+// CheckpointCoverageFor returns the read-side checkpoint coverage for a run.
+func CheckpointCoverageFor(resources []string, types map[string]IngestionType) CheckpointCoverage {
+	total, checkpointed := 0, 0
+	if len(resources) > 0 {
+		for _, resource := range resources {
+			total++
+			if SourcePolicyForIngestion(TypeFor(types, resource)).Checkpointing != CheckpointNone {
+				checkpointed++
+			}
+		}
+	} else {
+		for _, ingestionType := range types {
+			total++
+			if SourcePolicyForIngestion(ingestionType).Checkpointing != CheckpointNone {
+				checkpointed++
+			}
+		}
+	}
+	switch {
+	case checkpointed == 0:
+		return CheckpointCoverageNone
+	case checkpointed == total:
+		return CheckpointCoverageAll
+	default:
+		return CheckpointCoverageSome
+	}
+}

--- a/run.go
+++ b/run.go
@@ -10,8 +10,12 @@ import (
 // RunSpec is the fully resolved execution plan for one run — what a Runtime
 // receives after the engine has bound refs, ingestion type, and options.
 type RunSpec struct {
-	Tenant            TenantID
-	Run               RunID
+	Tenant TenantID
+	Run    RunID
+	// ExecutionID identifies one dispatch attempt of a logical run. Dispatchers
+	// derive it from the run.requested fact so redelivery is idempotent while a
+	// later resume creates fresh worker infrastructure.
+	ExecutionID       string
 	PipelineID        string
 	PipelineVersionID string
 	CheckpointRoute   string

--- a/run.go
+++ b/run.go
@@ -657,8 +657,11 @@ func SourcePolicyForIngestion(t IngestionType) SourcePolicy {
 type CheckpointCoverage uint8
 
 const (
+	// CheckpointCoverageNone means no selected resource has a resumable cursor.
 	CheckpointCoverageNone CheckpointCoverage = iota
+	// CheckpointCoverageSome means only some selected resources have resumable cursors.
 	CheckpointCoverageSome
+	// CheckpointCoverageAll means every selected resource has a resumable cursor.
 	CheckpointCoverageAll
 )
 
@@ -680,10 +683,10 @@ func CheckpointCoverageFor(resources []string, types map[string]IngestionType) C
 			}
 		}
 	}
-	switch {
-	case checkpointed == 0:
+	switch checkpointed {
+	case 0:
 		return CheckpointCoverageNone
-	case checkpointed == total:
+	case total:
 		return CheckpointCoverageAll
 	default:
 		return CheckpointCoverageSome

--- a/runner/control.go
+++ b/runner/control.go
@@ -1,0 +1,141 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/eventbus"
+	"github.com/galaxy-io/filament/events"
+)
+
+type controlSignal int32
+
+const (
+	controlNone controlSignal = iota
+	controlPause
+	controlCancel
+)
+
+// runControl tails commands addressed to one active run. The subscription is
+// established before run.started is published, so once the API can observe a
+// running run there is always a worker ready to receive its command.
+type runControl struct {
+	tenant filament.TenantID
+	run    filament.RunID
+	log    filament.Logger
+
+	mu            sync.Mutex
+	signal        controlSignal
+	sealed        bool
+	cancelExtract context.CancelFunc
+	subs          []eventbus.Subscription
+	wg            sync.WaitGroup
+}
+
+func newRunControl(
+	ctx context.Context,
+	bus eventbus.Bus,
+	log filament.Logger,
+	tenant filament.TenantID,
+	run filament.RunID,
+) (context.Context, *runControl, error) {
+	if bus == nil {
+		return nil, nil, fmt.Errorf("runner: run control requires an event bus")
+	}
+	extractCtx, cancelExtract := context.WithCancel(ctx)
+	control := &runControl{tenant: tenant, run: run, log: log, cancelExtract: cancelExtract}
+	commands := []struct {
+		name    string
+		subject string
+		signal  controlSignal
+	}{
+		{events.RunPauseRequested.Name(), events.Subject(events.RunPauseRequested, tenant, run), controlPause},
+		{events.RunCancelRequested.Name(), events.Subject(events.RunCancelRequested, tenant, run), controlCancel},
+	}
+	for _, command := range commands {
+		sub, err := bus.Subscribe(command.subject, eventbus.SubOpts{})
+		if err != nil {
+			control.close()
+			return nil, nil, fmt.Errorf("runner: subscribe to %s: %w", command.name, err)
+		}
+		control.subs = append(control.subs, sub)
+		control.wg.Add(1)
+		go control.pump(ctx, sub, command.name, command.signal)
+	}
+	return extractCtx, control, nil
+}
+
+func (c *runControl) pump(ctx context.Context, sub eventbus.Subscription, name string, signal controlSignal) {
+	defer c.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-sub.C():
+			if !ok {
+				return
+			}
+			fact, err := events.Decode(msg)
+			if err == nil && fact.Name == name && fact.Tenant == c.tenant && fact.Run == c.run && c.request(signal) && c.log != nil {
+				c.log.Info("runner: control requested",
+					filament.Field{Key: "run", Value: string(c.run)},
+					filament.Field{Key: "control", Value: signal.String()},
+				)
+			}
+			_ = msg.Ack()
+		}
+	}
+}
+
+func (c *runControl) request(signal controlSignal) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sealed {
+		return false
+	}
+	previous := c.signal
+	switch signal {
+	case controlCancel:
+		c.signal = controlCancel
+	case controlPause:
+		if c.signal == controlNone {
+			c.signal = controlPause
+		}
+	}
+	c.cancelExtract()
+	return c.signal != previous
+}
+
+func (s controlSignal) String() string {
+	switch s {
+	case controlPause:
+		return "pause"
+	case controlCancel:
+		return "cancel"
+	default:
+		return "none"
+	}
+}
+
+func (c *runControl) requested() controlSignal {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.signal
+}
+
+func (c *runControl) seal() controlSignal {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sealed = true
+	return c.signal
+}
+
+func (c *runControl) close() {
+	c.cancelExtract()
+	for _, sub := range c.subs {
+		_ = sub.Close()
+	}
+	c.wg.Wait()
+}

--- a/runner/emitter.go
+++ b/runner/emitter.go
@@ -41,6 +41,32 @@ func newEmitter(ctx context.Context, bus eventbus.Bus, log filament.Logger, tena
 	return &emitter{ctx: ctx, bus: bus, log: log, tenant: tenant, run: run, res: map[string]*tally{}}
 }
 
+// seedProgress carries durable progress from a prior paused attempt into this
+// attempt's terminal totals. Checkpoint-free resumes reset these counters in the
+// datastore, so they naturally start from zero.
+func (e *emitter) seedProgress(state filament.RunState) {
+	e.mu.Lock()
+	e.runRecords = state.Records
+	e.runBytes = state.Bytes
+	progressedResources := 0
+	for _, resource := range state.Resources {
+		if resource.Records == 0 && resource.Bytes == 0 {
+			continue
+		}
+		e.res[resource.Resource] = &tally{records: resource.Records, bytes: resource.Bytes}
+		progressedResources++
+	}
+	e.mu.Unlock()
+	if e.log != nil && (state.Records > 0 || state.Bytes > 0) {
+		e.log.Info("runner: progress restored",
+			filament.Field{Key: "run", Value: string(e.run)},
+			filament.Field{Key: "records", Value: state.Records},
+			filament.Field{Key: "bytes", Value: state.Bytes},
+			filament.Field{Key: "progressed_resources", Value: progressedResources},
+		)
+	}
+}
+
 // next returns the run's next fact sequence. Shared with the pipeline so run
 // lifecycle facts and pipeline facts never collide on (tenant, run, seq).
 func (e *emitter) next() uint64 { return e.seq.Add(1) }
@@ -80,12 +106,16 @@ func (e *emitter) publish(f events.Fact) {
 		e.mu.Unlock()
 	}
 	if e.log != nil {
-		records, bytes, errMsg := factProgress(f)
+		records, bytes, errMsg, hasProgress := factProgress(f)
 		fields := []filament.Field{
 			{Key: "run", Value: string(f.Run)},
 			{Key: "resource", Value: f.Resource},
-			{Key: "records", Value: records},
-			{Key: "bytes", Value: bytes},
+		}
+		if hasProgress {
+			fields = append(fields,
+				filament.Field{Key: "records", Value: records},
+				filament.Field{Key: "bytes", Value: bytes},
+			)
 		}
 		if errMsg != "" {
 			fields = append(fields, filament.Field{Key: "error", Value: errMsg})
@@ -105,28 +135,28 @@ func (e *emitter) publish(f events.Fact) {
 }
 
 // factProgress flattens a typed payload's progress counters and error for logging.
-func factProgress(f events.Fact) (records, bytes int64, errMsg string) {
+func factProgress(f events.Fact) (records, bytes int64, errMsg string, hasProgress bool) {
 	switch d := f.Data.(type) {
 	case events.BatchBufferedEvent:
-		return d.Records, d.Bytes, ""
+		return d.Records, d.Bytes, "", true
 	case events.BatchWrittenEvent:
-		return d.Records, d.Bytes, ""
+		return d.Records, d.Bytes, "", true
 	case events.PageFetchedEvent:
-		return d.Records, d.Bytes, ""
+		return d.Records, d.Bytes, "", true
 	case events.ResourceCompletedEvent:
-		return d.Records, d.Bytes, ""
+		return d.Records, d.Bytes, "", true
 	case events.RunCompletedEvent:
-		return d.Records, d.Bytes, ""
+		return d.Records, d.Bytes, "", true
 	case events.ResourceFailedEvent:
-		return 0, 0, d.Error
+		return 0, 0, d.Error, false
 	case events.RunFailedEvent:
-		return 0, 0, d.Error
+		return 0, 0, d.Error, false
 	case events.RunPartialEvent:
-		return 0, 0, d.Error
+		return 0, 0, d.Error, false
 	case events.RetryExhaustedEvent:
-		return 0, 0, d.Error
+		return 0, 0, d.Error, false
 	default:
-		return 0, 0, ""
+		return 0, 0, "", false
 	}
 }
 
@@ -208,6 +238,29 @@ func (e *emitter) completed(resources []string) {
 	}
 	records, bytes := e.runTotals()
 	emit(e, events.RunCompleted, "", events.RunCompletedEvent{Records: records, Bytes: bytes})
+}
+
+func (e *emitter) controlled(signal controlSignal) bool {
+	switch signal {
+	case controlPause:
+		e.paused(false)
+		return true
+	case controlCancel:
+		e.canceled()
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *emitter) paused(committed bool) {
+	defer e.finish()()
+	emit(e, events.RunPaused, "", events.RunPausedEvent{Committed: committed})
+}
+
+func (e *emitter) canceled() {
+	defer e.finish()()
+	emit(e, events.RunCanceled, "", events.RunCanceledEvent{})
 }
 
 func (e *emitter) fail(err error) {

--- a/runner/extractor.go
+++ b/runner/extractor.go
@@ -19,7 +19,7 @@ type extractorFunc func(context.Context, filament.RecordSink, filament.ExtractOp
 // carry no plan entry, which sources read whole. Seeding those cursors is the
 // one place a run writes durable state itself; every other transition is
 // folded from facts by the tracker.
-func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.Source, spec filament.RunSpec, plan filament.IngestionPlan) (extractorFunc, error) {
+func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.Source, spec filament.RunSpec, plan filament.IngestionPlan, log filament.Logger) (extractorFunc, error) {
 	if plan.RequiresCDC {
 		changes, ok := src.(filament.ChangeSource)
 		if !ok {
@@ -29,7 +29,9 @@ func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.S
 		if err != nil {
 			return nil, err
 		}
+		logLoadedCheckpoints(log, spec, checkpoints)
 		return func(ctx context.Context, sink filament.RecordSink, opts filament.ExtractOpts) error {
+			logExtractionStart(log, spec, "cdc", len(checkpoints), len(checkpoints))
 			return changes.ExtractChanges(ctx, sink, filament.ChangeExtractOpts{
 				Resources:   opts.Resources,
 				Checkpoints: checkpoints,
@@ -41,6 +43,7 @@ func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.S
 	incremental, checkpointed := partitionCheckpointing(spec)
 	if len(incremental) == 0 && len(checkpointed) == 0 {
 		return func(ctx context.Context, sink filament.RecordSink, opts filament.ExtractOpts) error {
+			logExtractionStart(log, spec, "full", 0, 0)
 			return src.Extract(ctx, sink, opts)
 		}, nil
 	}
@@ -49,6 +52,7 @@ func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.S
 		return nil, fmt.Errorf("source %q does not support resumable extraction", spec.Source.Provider)
 	}
 	resumePlan := map[string]filament.Checkpoint{}
+	loaded := 0
 	if len(incremental) > 0 {
 		planner, ok := src.(filament.IncrementalPlanner)
 		if !ok {
@@ -63,6 +67,7 @@ func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.S
 			state, err := ds.LoadResourceCheckpoint(ctx, key)
 			if err == nil {
 				prev[resource] = state.Checkpoint
+				noteLoadedCheckpoint(log, spec, resource, "pipeline", state.Checkpoint, &loaded)
 			} else if !errors.Is(err, filament.ErrNotFound) {
 				return nil, fmt.Errorf("load checkpoint %q: %w", resource, err)
 			}
@@ -92,6 +97,7 @@ func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.S
 			cp, err := ds.LoadCheckpoint(ctx, spec.Run, resource)
 			if err == nil {
 				prev[resource] = cp
+				noteLoadedCheckpoint(log, spec, resource, "run", cp, &loaded)
 			} else if !errors.Is(err, filament.ErrNotFound) {
 				return nil, fmt.Errorf("load checkpoint %q: %w", resource, err)
 			}
@@ -111,8 +117,67 @@ func resolveExtractor(ctx context.Context, ds filament.DataStore, src filament.S
 		}
 	}
 	return func(ctx context.Context, sink filament.RecordSink, opts filament.ExtractOpts) error {
+		logExtractionStart(log, spec, "resumable", len(resumePlan), loaded)
 		return resumable.ExtractFrom(ctx, sink, opts, resumePlan)
 	}, nil
+}
+
+// Checkpoint logs intentionally describe cursor shape and scope without logging
+// raw cursor values, which may contain database positions, URLs, or opaque tokens.
+func logCheckpointLoaded(log filament.Logger, spec filament.RunSpec, resource, scope string, cp filament.Checkpoint) {
+	if log == nil {
+		return
+	}
+	mode := filament.SourcePolicyForIngestion(filament.TypeFor(spec.IngestionTypes, resource)).Mode.String()
+	log.Info("runner: checkpoint loaded",
+		filament.Field{Key: "run", Value: string(spec.Run)},
+		filament.Field{Key: "resource", Value: resource},
+		filament.Field{Key: "checkpoint_scope", Value: scope},
+		filament.Field{Key: "read_mode", Value: mode},
+		filament.Field{Key: "checkpoint_kind", Value: filament.CheckpointKind(cp)},
+	)
+}
+
+func logLoadedCheckpoints(log filament.Logger, spec filament.RunSpec, checkpoints map[string]filament.Checkpoint) {
+	for _, resource := range spec.Resources {
+		if cp := checkpoints[resource]; cp != nil {
+			logCheckpointLoaded(log, spec, resource, checkpointScope(spec, resource), cp)
+		}
+	}
+}
+
+func noteLoadedCheckpoint(
+	log filament.Logger,
+	spec filament.RunSpec,
+	resource, scope string,
+	cp filament.Checkpoint,
+	loaded *int,
+) {
+	if cp == nil {
+		return
+	}
+	(*loaded)++
+	logCheckpointLoaded(log, spec, resource, scope, cp)
+}
+
+func logExtractionStart(log filament.Logger, spec filament.RunSpec, strategy string, checkpointResources, loadedCheckpoints int) {
+	if log == nil {
+		return
+	}
+	log.Info("runner: extraction starting",
+		filament.Field{Key: "run", Value: string(spec.Run)},
+		filament.Field{Key: "strategy", Value: strategy},
+		filament.Field{Key: "resources", Value: len(spec.Resources)},
+		filament.Field{Key: "checkpoint_resources", Value: checkpointResources},
+		filament.Field{Key: "loaded_checkpoints", Value: loadedCheckpoints},
+	)
+}
+
+func checkpointScope(spec filament.RunSpec, resource string) string {
+	if _, ok := spec.ResourceCheckpointKey(resource); ok {
+		return "pipeline"
+	}
+	return "run"
 }
 
 // partitionCheckpointing splits the run's resources by their type's read-side
@@ -158,21 +223,25 @@ func loadChangeCheckpoints(ctx context.Context, ds filament.DataStore, spec fila
 	return out, nil
 }
 
-// isResumableRun reports whether a failure can leave progress that is safe to
-// replay into the sink. Append writes preserve already-applied rows, so retrying
-// an incremental append would duplicate them even when the source resumes from
-// its last checkpoint.
+// isResumableRun reports whether every resource has progress that is durable
+// before Commit and safe to replay. Commit-gated and append progress cannot be
+// resumed after a failed attempt without losing or duplicating rows.
 func isResumableRun(spec filament.RunSpec, plan filament.IngestionPlan) bool {
 	if plan.RequiresCDC {
 		return false
 	}
+	if filament.CheckpointCoverageFor(spec.Resources, spec.IngestionTypes) != filament.CheckpointCoverageAll {
+		return false
+	}
 	incremental, checkpointed := partitionCheckpointing(spec)
-	for _, resource := range incremental {
+	resumeResources := append(append([]string(nil), incremental...), checkpointed...)
+	for _, resource := range resumeResources {
 		policy, ok := plan.WritePolicies[resource]
 		if !ok {
 			policy, ok = plan.WritePolicies[""]
 		}
-		if !ok || policy.Capability.Mode == filament.WriteAppend {
+		if !ok || policy.Checkpoint == filament.CheckpointAfterCommit ||
+			policy.Capability.Mode == filament.WriteAppend {
 			return false
 		}
 	}

--- a/runner/incremental_test.go
+++ b/runner/incremental_test.go
@@ -109,7 +109,7 @@ func TestResolveExtractorCarriesCheckpointAcrossRuns(t *testing.T) {
 		CursorConfigs:  map[string]filament.ResourceCursorConfig{"users": {Field: "updated_at", LookbackSeconds: 300}},
 	}
 	first := &incrementalTestSource{}
-	if _, err := resolveExtractor(ctx, store, first, base, plan); err != nil {
+	if _, err := resolveExtractor(ctx, store, first, base, plan, nil); err != nil {
 		t.Fatal(err)
 	}
 	key, _ := base.ResourceCheckpointKey("users")
@@ -125,7 +125,7 @@ func TestResolveExtractorCarriesCheckpointAcrossRuns(t *testing.T) {
 	secondSpec := base
 	secondSpec.Run = "run-b"
 	second := &incrementalTestSource{}
-	if _, err := resolveExtractor(ctx, store, second, secondSpec, plan); err != nil {
+	if _, err := resolveExtractor(ctx, store, second, secondSpec, plan, nil); err != nil {
 		t.Fatal(err)
 	}
 	if second.previous["users"].String("position") != "next-run" {
@@ -180,5 +180,12 @@ func TestIncrementalAppendFailureIsNotResumable(t *testing.T) {
 	plan.WritePolicies["users"] = filament.WritePolicyForIngestion(filament.IngestionIncrementalUpsert)
 	if !isResumableRun(spec, plan) {
 		t.Fatal("incremental upsert should remain resumable")
+	}
+
+	policy := plan.WritePolicies["users"]
+	policy.Checkpoint = filament.CheckpointAfterCommit
+	plan.WritePolicies["users"] = policy
+	if isResumableRun(spec, plan) {
+		t.Fatal("commit-gated progress must fail instead of resuming before commit")
 	}
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -11,6 +11,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -71,7 +72,7 @@ func ShouldRun(state filament.RunState) bool {
 // RunOne executes a single extraction end-to-end: resolve providers, open the
 // sink, drive the pipeline with the source, then commit or abort. It publishes
 // run.started first and exactly one terminal fact (run.completed | run.failed |
-// run.partial).
+// run.partial | run.paused | run.canceled).
 //
 //nolint:funlen // the run lifecycle reads best as one sequence
 func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
@@ -87,9 +88,22 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 
 	em := newEmitter(ctx, deps.Bus, deps.Log, spec.Tenant, spec.Run)
 	em.span = span
+	if err := seedEmitterProgress(ctx, deps.DataStore, spec.Run, em); err != nil {
+		em.failed(fmt.Errorf("restore run progress: %w", err), nil, false)
+		return
+	}
+	extractCtx, control, err := newRunControl(ctx, deps.Bus, deps.Log, spec.Tenant, spec.Run)
+	if err != nil {
+		em.failed(err, nil, false)
+		return
+	}
+	defer control.close()
 	emit(em, events.RunStarted, "", events.RunStartedEvent{})
 
-	if err := ResolveConfigRefs(ctx, deps.Secrets, &spec); err != nil {
+	if err := ResolveConfigRefs(extractCtx, deps.Secrets, &spec); err != nil {
+		if emitControlledIfStopped(extractCtx, err, control, em) {
+			return
+		}
 		em.failed(err, nil, false)
 		return
 	}
@@ -99,13 +113,19 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 		em.failed(fmt.Errorf("resolve source %q: %w", spec.Source.Provider, err), nil, false)
 		return
 	}
-	if err := src.Configure(ctx, filament.NewConfig(spec.Source.Config)); err != nil {
+	if err := src.Configure(extractCtx, filament.NewConfig(spec.Source.Config)); err != nil {
+		if emitControlledIfStopped(extractCtx, err, control, em) {
+			return
+		}
 		em.failed(fmt.Errorf("configure source %q: %w", spec.Source.Provider, err), nil, false)
 		return
 	}
 	defer func() { _ = src.Teardown(ctx) }()
-	plannedResources, err := PlanResources(ctx, src, spec.Resources, spec.Selectors)
+	plannedResources, err := PlanResources(extractCtx, src, spec.Resources, spec.Selectors)
 	if err != nil {
+		if emitControlledIfStopped(extractCtx, err, control, em) {
+			return
+		}
 		em.failed(fmt.Errorf("plan resources: %w", err), nil, false)
 		return
 	}
@@ -116,8 +136,11 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 		em.failed(fmt.Errorf("resolve sink %q: %w", spec.Sink.Provider, err), nil, false)
 		return
 	}
-	plan, err := filament.ResolveIngestionPlan(ctx, src, snk, spec)
+	plan, err := filament.ResolveIngestionPlan(extractCtx, src, snk, spec)
 	if err != nil {
+		if emitControlledIfStopped(extractCtx, err, control, em) {
+			return
+		}
 		em.failed(err, nil, false)
 		return
 	}
@@ -128,7 +151,10 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	if incremental, checkpointed := partitionCheckpointing(spec); plan.RequiresCDC || len(incremental) > 0 || len(checkpointed) > 0 {
 		spec.Options.SnapshotParallelism = 1
 	}
-	if err := snk.Open(ctx, spec); err != nil {
+	if err := snk.Open(extractCtx, spec); err != nil {
+		if emitControlledIfStopped(extractCtx, err, control, em) {
+			return
+		}
 		em.failed(fmt.Errorf("open sink %q: %w", spec.Sink.Provider, err), nil, false)
 		return
 	}
@@ -136,9 +162,10 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	// A schema-aware sink needs typed DDL before any write. When the source can
 	// supply per-resource schemas, ensure each one up front so a Schematized sink
 	// (e.g. iceberg, postgres) creates/evolves its tables before extraction.
-	if err := ensureSchemas(ctx, src, snk, spec); err != nil {
-		if aerr := snk.Abort(ctx); aerr != nil && deps.Log != nil {
-			deps.Log.Error("runner: sink abort", aerr, filament.Field{Key: "run", Value: string(spec.Run)})
+	if err := ensureSchemas(extractCtx, src, snk, spec); err != nil {
+		abortSink(ctx, deps, spec, snk)
+		if emitControlledIfStopped(extractCtx, err, control, em) {
+			return
 		}
 		em.failed(fmt.Errorf("ensure schema: %w", err), nil, false)
 		return
@@ -149,10 +176,11 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 		emit(em, events.ResourceStarted, res, events.ResourceStartedEvent{})
 	}
 
-	extractor, err := resolveExtractor(ctx, deps.DataStore, src, spec, plan)
+	extractor, err := resolveExtractor(extractCtx, deps.DataStore, src, spec, plan, deps.Log)
 	if err != nil {
-		if aerr := snk.Abort(ctx); aerr != nil && deps.Log != nil {
-			deps.Log.Error("runner: sink abort", aerr, filament.Field{Key: "run", Value: string(spec.Run)})
+		abortSink(ctx, deps, spec, snk)
+		if emitControlledIfStopped(extractCtx, err, control, em) {
+			return
 		}
 		em.failed(err, spec.Resources, false)
 		return
@@ -176,7 +204,7 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	extractErrCh := make(chan error, 1)
 	go func() {
 		extractErrCh <- safeCall(func() error {
-			return extractor(ctx, p.Records(), filament.ExtractOpts{
+			return extractor(extractCtx, p.Records(), filament.ExtractOpts{
 				Resources:   spec.Resources,
 				Selectors:   spec.Selectors,
 				Parallelism: spec.Options.SnapshotParallelism,
@@ -198,6 +226,10 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	}
 
 	resources := resolveResources(spec.Resources, em.seenResources())
+	if waitErr == nil && stoppedByControl(extractCtx, extractErr, control.requested()) {
+		finishControlled(ctx, deps, spec, plan, snk, em, resources, control.seal())
+		return
+	}
 
 	if runErr != nil {
 		resumable := isResumableRun(spec, plan)
@@ -208,22 +240,114 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 		// Abort after the obituary, on its own detached context: cleanup must
 		// not eat the terminal publish window, and a slow sink must not strand
 		// the row in RunRunning.
-		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), abortWait)
-		defer cancel()
-		if err := snk.Abort(abortCtx); err != nil && deps.Log != nil {
-			deps.Log.Error("runner: sink abort", err, filament.Field{Key: "run", Value: string(spec.Run)})
-		}
+		abortSink(ctx, deps, spec, snk)
 		return
 	}
 
+	if signal := control.seal(); signal != controlNone {
+		finishControlled(ctx, deps, spec, plan, snk, em, resources, signal)
+		return
+	}
 	if err := snk.Commit(ctx); err != nil {
 		em.failed(fmt.Errorf("commit sink %q: %w", spec.Sink.Provider, err), resources, false)
-		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), abortWait)
-		defer cancel()
-		if aerr := snk.Abort(abortCtx); aerr != nil && deps.Log != nil {
-			deps.Log.Error("runner: sink abort", aerr, filament.Field{Key: "run", Value: string(spec.Run)})
-		}
+		abortSink(ctx, deps, spec, snk)
 		return
 	}
 	em.completed(resources)
+}
+
+func seedEmitterProgress(ctx context.Context, ds filament.DataStore, run filament.RunID, em *emitter) error {
+	if ds == nil {
+		return nil
+	}
+	state, err := ds.LoadRun(ctx, run)
+	if errors.Is(err, filament.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if state.Status == filament.RunPartial {
+		return nil
+	}
+	em.seedProgress(state)
+	return nil
+}
+
+func emitControlledIfStopped(ctx context.Context, err error, control *runControl, em *emitter) bool {
+	signal := control.requested()
+	return stoppedByControl(ctx, err, signal) && em.controlled(signal)
+}
+
+func stoppedByControl(ctx context.Context, err error, signal controlSignal) bool {
+	if signal == controlNone || ctx.Err() == nil {
+		return false
+	}
+	return err == nil || errors.Is(err, context.Canceled)
+}
+
+func finishControlled(
+	ctx context.Context,
+	deps Deps,
+	spec filament.RunSpec,
+	plan filament.IngestionPlan,
+	sink filament.Sink,
+	em *emitter,
+	resources []string,
+	signal controlSignal,
+) {
+	if signal == controlCancel {
+		abortSink(ctx, deps, spec, sink)
+		logControlBoundary(deps.Log, spec.Run, "cancel", "abort", em, 0)
+		em.canceled()
+		return
+	}
+	incremental, checkpointed := partitionCheckpointing(spec)
+	checkpointResources := len(incremental) + len(checkpointed)
+	checkpointCoverage := filament.CheckpointCoverageFor(spec.Resources, spec.IngestionTypes)
+	action := "abort_and_restart"
+	committed := plan.RequiresCDC || checkpointCoverage == filament.CheckpointCoverageAll
+	if committed {
+		if err := sink.Commit(ctx); err != nil {
+			em.failed(fmt.Errorf("commit paused sink %q: %w", spec.Sink.Provider, err), resources, false)
+			abortSink(ctx, deps, spec, sink)
+			return
+		}
+		action = "commit_for_resume"
+	} else {
+		// A checkpoint-free read cannot resume from a partial sink, so discard it;
+		// resume will safely restart the resource from the beginning.
+		abortSink(ctx, deps, spec, sink)
+	}
+	logControlBoundary(deps.Log, spec.Run, "pause", action, em, checkpointResources)
+	em.paused(committed)
+}
+
+func logControlBoundary(
+	log filament.Logger,
+	run filament.RunID,
+	control, action string,
+	em *emitter,
+	checkpointResources int,
+) {
+	if log == nil {
+		return
+	}
+	records, bytes := em.runTotals()
+	log.Info("runner: control boundary reached",
+		filament.Field{Key: "run", Value: string(run)},
+		filament.Field{Key: "control", Value: control},
+		filament.Field{Key: "sink_action", Value: action},
+		filament.Field{Key: "checkpoint_resources", Value: checkpointResources},
+		filament.Field{Key: "records", Value: records},
+		filament.Field{Key: "bytes", Value: bytes},
+	)
+}
+
+func abortSink(ctx context.Context, deps Deps, spec filament.RunSpec, sink filament.Sink) {
+	abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), abortWait)
+	defer cancel()
+	if err := sink.Abort(abortCtx); err != nil && deps.Log != nil {
+		deps.Log.Error("runner: sink abort", err, filament.Field{Key: "run", Value: string(spec.Run)})
+	}
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -88,11 +88,7 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 
 	em := newEmitter(ctx, deps.Bus, deps.Log, spec.Tenant, spec.Run)
 	em.span = span
-	if err := seedEmitterProgress(ctx, deps.DataStore, spec.Run, em); err != nil {
-		em.failed(fmt.Errorf("restore run progress: %w", err), nil, false)
-		return
-	}
-	extractCtx, control, err := newRunControl(ctx, deps.Bus, deps.Log, spec.Tenant, spec.Run)
+	extractCtx, control, err := prepareRunExecution(ctx, deps, spec, em)
 	if err != nil {
 		em.failed(err, nil, false)
 		return
@@ -254,6 +250,18 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 		return
 	}
 	em.completed(resources)
+}
+
+func prepareRunExecution(
+	ctx context.Context,
+	deps Deps,
+	spec filament.RunSpec,
+	em *emitter,
+) (context.Context, *runControl, error) {
+	if err := seedEmitterProgress(ctx, deps.DataStore, spec.Run, em); err != nil {
+		return nil, nil, fmt.Errorf("restore run progress: %w", err)
+	}
+	return newRunControl(ctx, deps.Bus, deps.Log, spec.Tenant, spec.Run)
 }
 
 func seedEmitterProgress(ctx context.Context, ds filament.DataStore, run filament.RunID, em *emitter) error {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -31,6 +31,60 @@ type commitFailSink struct {
 func (s *commitFailSink) Commit(context.Context) error { return errors.New("commit boom") }
 func (s *commitFailSink) Abort(context.Context) error  { s.aborts.Add(1); return nil }
 
+type controlledTestSource struct {
+	commitTestSource
+	started chan struct{}
+}
+
+func (s *controlledTestSource) wait(ctx context.Context) error {
+	close(s.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *controlledTestSource) Extract(ctx context.Context, _ filament.RecordSink, _ filament.ExtractOpts) error {
+	return s.wait(ctx)
+}
+
+func (s *controlledTestSource) ExtractFrom(
+	ctx context.Context,
+	_ filament.RecordSink,
+	_ filament.ExtractOpts,
+	_ map[string]filament.Checkpoint,
+) error {
+	return s.wait(ctx)
+}
+
+type controlledTestSink struct {
+	incrementalTestSink
+	commits atomic.Int32
+	aborts  atomic.Int32
+}
+
+func (s *controlledTestSink) Commit(context.Context) error { s.commits.Add(1); return nil }
+func (s *controlledTestSink) Abort(context.Context) error  { s.aborts.Add(1); return nil }
+
+type progressLoadErrorStore struct {
+	filament.DataStore
+}
+
+func (progressLoadErrorStore) LoadRun(context.Context, filament.RunID) (filament.RunState, error) {
+	return filament.RunState{}, errors.New("database unavailable")
+}
+
+func TestRunOneFailsWhenProgressCannotBeRestored(t *testing.T) {
+	bus := inproc.New()
+	facts, err := bus.Subscribe(events.AllPattern(), eventbus.SubOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = facts.Close() }()
+	RunOne(context.Background(), Deps{
+		Bus: bus, DataStore: progressLoadErrorStore{DataStore: memory.New()},
+	}, filament.RunSpec{Tenant: "tenant", Run: "run"})
+	waitForFact(t, facts, events.RunFailed.Name())
+}
+
 func TestRunOneCommitFailureAborts(t *testing.T) {
 	bus := inproc.New()
 	facts, err := bus.Subscribe(events.AllPattern(), eventbus.SubOpts{})
@@ -96,5 +150,136 @@ func TestRunOneCommitFailureAborts(t *testing.T) {
 	}
 	if got := sink.aborts.Load(); got != 1 {
 		t.Fatalf("Abort calls = %d, want 1", got)
+	}
+}
+
+func TestRunOneCooperativeControl(t *testing.T) {
+	tests := []struct {
+		name        string
+		cancel      bool
+		ingestion   filament.IngestionType
+		terminal    string
+		wantCommits int32
+		wantAborts  int32
+	}{
+		{
+			name:      "pause checkpointed run commits drained progress",
+			ingestion: filament.IngestionFullUpsert, terminal: events.RunPaused.Name(), wantCommits: 1,
+		},
+		{
+			name:      "pause checkpoint-free run aborts partial output",
+			ingestion: filament.IngestionFullReplace, terminal: events.RunPaused.Name(), wantAborts: 1,
+		},
+		{
+			name: "cancel aborts", cancel: true,
+			ingestion: filament.IngestionFullUpsert, terminal: events.RunCanceled.Name(), wantAborts: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bus := inproc.New()
+			facts, err := bus.Subscribe(events.AllPattern(), eventbus.SubOpts{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = facts.Close() }()
+
+			source := &controlledTestSource{started: make(chan struct{})}
+			sink := &controlledTestSink{}
+			sources := registry.NewSources()
+			sources.Register("test", func() filament.Source { return source })
+			sinks := registry.NewSinks()
+			sinks.Register("test-sink", func() filament.Sink { return sink })
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				RunOne(context.Background(), Deps{
+					Bus: bus, DataStore: memory.New(), Sources: sources, Sinks: sinks,
+				}, filament.RunSpec{
+					Tenant: "t1", Run: "r1", Source: filament.Ref{Provider: "test"}, Sink: filament.Ref{Provider: "test-sink"},
+					Resources: []string{"users"}, IngestionTypes: map[string]filament.IngestionType{"users": tt.ingestion},
+				})
+			}()
+
+			select {
+			case <-source.started:
+			case <-time.After(5 * time.Second):
+				t.Fatal("source did not start")
+			}
+			env := events.Envelope{Tenant: "t1", Run: "r1", At: time.Now()}
+			if tt.cancel {
+				err = events.Emit(context.Background(), bus, events.RunCancelRequested, env, events.RunCancelRequestedEvent{})
+			} else {
+				err = events.Emit(context.Background(), bus, events.RunPauseRequested, env, events.RunPauseRequestedEvent{})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			waitForFact(t, facts, tt.terminal)
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("controlled run did not stop")
+			}
+			if got := sink.commits.Load(); got != tt.wantCommits {
+				t.Fatalf("Commit calls = %d, want %d", got, tt.wantCommits)
+			}
+			if got := sink.aborts.Load(); got != tt.wantAborts {
+				t.Fatalf("Abort calls = %d, want %d", got, tt.wantAborts)
+			}
+		})
+	}
+}
+
+func waitForFact(t *testing.T, sub eventbus.Subscription, name string) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case msg := <-sub.C():
+			fact, err := events.Decode(msg)
+			_ = msg.Ack()
+			if err != nil {
+				continue
+			}
+			if fact.Name == name {
+				return
+			}
+			if _, failed := fact.Data.(events.RunFailedEvent); failed {
+				t.Fatalf("run failed while waiting for %s: %#v", name, fact.Data)
+			}
+		case <-deadline:
+			t.Fatalf("no %s fact published", name)
+		}
+	}
+}
+
+func TestEmitterSeedsResumedProgress(t *testing.T) {
+	em := newEmitter(context.Background(), inproc.New(), nil, "tenant", "run")
+	em.seedProgress(filament.RunState{
+		Run: "run", Records: 125, Bytes: 500,
+		Resources: []filament.ResourceState{{Resource: "users", Records: 125, Bytes: 500}},
+	})
+	if records, bytes := em.runTotals(); records != 125 || bytes != 500 {
+		t.Fatalf("run totals = %d/%d, want 125/500", records, bytes)
+	}
+	if records, bytes := em.resourceTally("users"); records != 125 || bytes != 500 {
+		t.Fatalf("resource totals = %d/%d, want 125/500", records, bytes)
+	}
+}
+
+func TestSeedEmitterProgressIgnoresPartialAttemptCounters(t *testing.T) {
+	store := memory.New()
+	state := filament.RunState{Run: "run", Status: filament.RunPartial, Records: 125, Bytes: 500}
+	if err := store.SaveRun(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	em := newEmitter(context.Background(), inproc.New(), nil, "tenant", "run")
+	if err := seedEmitterProgress(context.Background(), store, state.Run, em); err != nil {
+		t.Fatal(err)
+	}
+	if records, bytes := em.runTotals(); records != 0 || bytes != 0 {
+		t.Fatalf("partial totals = %d/%d, want 0/0", records, bytes)
 	}
 }

--- a/server/convert.go
+++ b/server/convert.go
@@ -253,6 +253,19 @@ func runStatusesFromProto(statuses []ingestionv1.RunStatus) []filament.RunStatus
 	return out
 }
 
+func runSignalFromProto(signal ingestionv1.RunSignal) (filament.Signal, error) {
+	switch signal {
+	case ingestionv1.RunSignal_RUN_SIGNAL_PAUSE:
+		return filament.SignalPause, nil
+	case ingestionv1.RunSignal_RUN_SIGNAL_RESUME:
+		return filament.SignalResume, nil
+	case ingestionv1.RunSignal_RUN_SIGNAL_CANCEL:
+		return filament.SignalCancel, nil
+	default:
+		return 0, fmt.Errorf("signal is required")
+	}
+}
+
 func resourcesToProto(resources []filament.Resource) *ingestionv1.DiscoverResourcesResponse {
 	out := make([]*ingestionv1.Resource, 0, len(resources))
 	for _, resource := range resources {
@@ -389,7 +402,7 @@ func runSnapshotEvent(state filament.RunState, replay bool) *ingestionv1.RunEven
 
 func runStatusTerminal(status filament.RunStatus) bool {
 	switch status {
-	case filament.RunCompleted, filament.RunFailed, filament.RunCanceled, filament.RunPartial:
+	case filament.RunCompleted, filament.RunFailed, filament.RunCanceled, filament.RunPaused, filament.RunPartial:
 		return true
 	default:
 		return false

--- a/server/runs.go
+++ b/server/runs.go
@@ -106,16 +106,96 @@ func (a *Server) SignalRun(ctx context.Context, req *connect.Request[ingestionv1
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-	if err := runcommands.Signal(ctx, a.bus, transitions, state, signal); err != nil {
+	var ack eventbus.Subscription
+	if state.Status == filament.RunRunning && (signal == filament.SignalPause || signal == filament.SignalCancel) {
+		ack, err = a.bus.Subscribe(events.RunPattern(state.Tenant, state.Run), eventbus.SubOpts{})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeUnavailable, err)
+		}
+		defer func() { _ = ack.Close() }()
+	}
+	result, err := runcommands.Signal(ctx, a.bus, transitions, state, signal)
+	if err != nil {
 		return nil, signalRunError(err)
+	}
+	if result.WorkerAcknowledgement {
+		if ack == nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("worker acknowledgement subscription is missing"))
+		}
+		if err := awaitWorkerAcknowledgement(ctx, ack, a.store, state.Run, signal); err != nil {
+			return nil, signalRunError(err)
+		}
 	}
 	return connect.NewResponse(&ingestionv1.SignalRunResponse{}), nil
 }
 
+func awaitWorkerAcknowledgement(
+	ctx context.Context,
+	sub eventbus.Subscription,
+	store filament.DataStore,
+	run filament.RunID,
+	signal filament.Signal,
+) error {
+	want := events.RunPaused.Name()
+	wantStatus := filament.RunPaused
+	if signal == filament.SignalCancel {
+		want = events.RunCanceled.Name()
+		wantStatus = filament.RunCanceled
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg, ok := <-sub.C():
+			if !ok {
+				return fmt.Errorf("%w: worker acknowledgement stream closed", runcommands.ErrSignalPublish)
+			}
+			fact, err := events.Decode(msg)
+			_ = msg.Ack()
+			if err != nil {
+				continue
+			}
+			if fact.Name == want {
+				return awaitRunStatus(ctx, store, run, wantStatus)
+			}
+			switch fact.Data.(type) {
+			case events.RunCompletedEvent, events.RunFailedEvent, events.RunPartialEvent,
+				events.RunPausedEvent, events.RunCanceledEvent:
+				return fmt.Errorf("%w: worker finished with %s before %s", runcommands.ErrSignalTransition, fact.Name, want)
+			}
+		}
+	}
+}
+
+func awaitRunStatus(ctx context.Context, store filament.DataStore, run filament.RunID, want filament.RunStatus) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		state, err := store.LoadRun(ctx, run)
+		if err != nil {
+			return err
+		}
+		if state.Status == want {
+			return nil
+		}
+		if runStatusTerminal(state.Status) {
+			return fmt.Errorf("%w: run reached %v before %v", runcommands.ErrSignalTransition, state.Status, want)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 func signalRunError(err error) error {
 	switch {
-	case errors.Is(err, runcommands.ErrWorkerControlUnavailable),
-		errors.Is(err, runcommands.ErrSignalTransition),
+	case errors.Is(err, context.Canceled):
+		return connect.NewError(connect.CodeCanceled, err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return connect.NewError(connect.CodeDeadlineExceeded, err)
+	case errors.Is(err, runcommands.ErrSignalTransition),
 		errors.Is(err, filament.ErrVersionConflict):
 		return connect.NewError(connect.CodeFailedPrecondition, err)
 	case errors.Is(err, runcommands.ErrSignalPublish):
@@ -182,7 +262,7 @@ func (a *Server) TailRun(ctx context.Context, req *connect.Request[ingestionv1.T
 				return err
 			}
 			switch f.Data.(type) {
-			case events.RunCompletedEvent, events.RunFailedEvent:
+			case events.RunCompletedEvent, events.RunFailedEvent, events.RunPausedEvent, events.RunCanceledEvent:
 				return nil
 			}
 		}

--- a/server/runs.go
+++ b/server/runs.go
@@ -12,6 +12,7 @@ import (
 	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
 	"github.com/galaxy-io/filament/eventbus"
 	"github.com/galaxy-io/filament/events"
+	runcommands "github.com/galaxy-io/filament/internal/runs"
 )
 
 // ListRuns returns runs matching the request's tenant, pipeline, version,
@@ -77,12 +78,51 @@ func (a *Server) GetRun(ctx context.Context, req *connect.Request[ingestionv1.Ge
 	return connect.NewResponse(&ingestionv1.GetRunResponse{Snapshot: &ingestionv1.RunSnapshot{Run: runInfoToProto(state), Resources: resources}}), nil
 }
 
-// SignalRun rejects the request; run signals are not configured in this binary.
-func (a *Server) SignalRun(_ context.Context, req *connect.Request[ingestionv1.SignalRunRequest]) (*connect.Response[ingestionv1.SignalRunResponse], error) {
+// SignalRun validates transport concerns and delegates lifecycle policy to the
+// shared run command layer.
+func (a *Server) SignalRun(ctx context.Context, req *connect.Request[ingestionv1.SignalRunRequest]) (*connect.Response[ingestionv1.SignalRunResponse], error) {
 	if req.Msg.GetRunId() == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("run_id is required"))
 	}
-	return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("run signals are not configured in this ingestion binary"))
+	if a.bus == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("event bus is not configured"))
+	}
+	transitions, ok := a.store.(filament.RunTransitionStore)
+	if !ok {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("datastore does not support atomic run transitions"))
+	}
+	run := filament.RunID(req.Msg.GetRunId())
+	state, err := a.store.LoadRun(ctx, run)
+	if errors.Is(err, filament.ErrNotFound) {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	if tenant := req.Msg.GetTenantId(); tenant != "" && tenant != string(state.Tenant) {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("run %q was not found for tenant", run))
+	}
+	signal, err := runSignalFromProto(req.Msg.GetSignal())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := runcommands.Signal(ctx, a.bus, transitions, state, signal); err != nil {
+		return nil, signalRunError(err)
+	}
+	return connect.NewResponse(&ingestionv1.SignalRunResponse{}), nil
+}
+
+func signalRunError(err error) error {
+	switch {
+	case errors.Is(err, runcommands.ErrWorkerControlUnavailable),
+		errors.Is(err, runcommands.ErrSignalTransition),
+		errors.Is(err, filament.ErrVersionConflict):
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	case errors.Is(err, runcommands.ErrSignalPublish):
+		return connect.NewError(connect.CodeUnavailable, err)
+	default:
+		return connect.NewError(connect.CodeInternal, err)
+	}
 }
 
 // TailRun streams run progress facts to the client, optionally replaying

--- a/server/runs_test.go
+++ b/server/runs_test.go
@@ -4,14 +4,83 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
+
+	"connectrpc.com/connect"
 
 	"github.com/galaxy-io/filament"
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
 	"github.com/galaxy-io/filament/datastore/memory"
+	"github.com/galaxy-io/filament/eventbus/inproc"
 )
 
 type loadRunErrorStore struct {
 	filament.DataStore
 	err error
+}
+
+func TestSignalRunPauseResumeAndCancelStateMachine(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+	api := &Server{store: store, bus: inproc.New()}
+	ended := time.Now()
+	state := filament.RunState{
+		Run: "run-1", Tenant: "tenant-1", Status: filament.RunRequested,
+		StartedAt: time.Now().Add(-time.Minute), EndedAt: &ended, Records: 9, Bytes: 90,
+		Resources: []filament.ResourceState{{Resource: "users", Status: filament.RunCompleted, Records: 9, Bytes: 90, Error: "old"}},
+	}
+	if err := store.SaveRun(ctx, state); err != nil {
+		t.Fatal(err)
+	}
+
+	signal := func(value ingestionv1.RunSignal) error {
+		_, err := api.SignalRun(ctx, connect.NewRequest(&ingestionv1.SignalRunRequest{
+			TenantId: "tenant-1", RunId: "run-1", Signal: value,
+		}))
+		return err
+	}
+	if err := signal(ingestionv1.RunSignal_RUN_SIGNAL_PAUSE); err != nil {
+		t.Fatalf("pause requested run: %v", err)
+	}
+	paused, _ := store.LoadRun(ctx, "run-1")
+	if paused.Status != filament.RunPaused {
+		t.Fatalf("status after pause = %v", paused.Status)
+	}
+	if err := signal(ingestionv1.RunSignal_RUN_SIGNAL_RESUME); err != nil {
+		t.Fatalf("resume paused run: %v", err)
+	}
+	resumed, _ := store.LoadRun(ctx, "run-1")
+	if resumed.Status != filament.RunRequested || !resumed.StartedAt.IsZero() || resumed.EndedAt != nil || resumed.Records != 0 || resumed.Error != "" {
+		t.Fatalf("resumed state was not reset: %#v", resumed)
+	}
+	if len(resumed.Resources) != 1 || resumed.Resources[0].Status != filament.RunRequested || resumed.Resources[0].Records != 0 || resumed.Resources[0].Error != "" {
+		t.Fatalf("resumed resources were not reset: %#v", resumed.Resources)
+	}
+	if err := signal(ingestionv1.RunSignal_RUN_SIGNAL_CANCEL); err != nil {
+		t.Fatalf("cancel requested run: %v", err)
+	}
+	canceled, _ := store.LoadRun(ctx, "run-1")
+	if canceled.Status != filament.RunCanceled {
+		t.Fatalf("status after cancel = %v", canceled.Status)
+	}
+}
+
+func TestSignalRunRejectsUnsafeRunningWorkerCommands(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+	if err := store.SaveRun(ctx, filament.RunState{Run: "run-1", Tenant: "tenant-1", Status: filament.RunRunning}); err != nil {
+		t.Fatal(err)
+	}
+	api := &Server{store: store, bus: inproc.New()}
+	for _, signal := range []ingestionv1.RunSignal{
+		ingestionv1.RunSignal_RUN_SIGNAL_PAUSE,
+		ingestionv1.RunSignal_RUN_SIGNAL_CANCEL,
+	} {
+		_, err := api.SignalRun(ctx, connect.NewRequest(&ingestionv1.SignalRunRequest{RunId: "run-1", Signal: signal}))
+		if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+			t.Fatalf("signal %v error = %v, want failed precondition", signal, err)
+		}
+	}
 }
 
 func (s loadRunErrorStore) LoadRun(context.Context, filament.RunID) (filament.RunState, error) {

--- a/server/runs_test.go
+++ b/server/runs_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/galaxy-io/filament"
 	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
 	"github.com/galaxy-io/filament/datastore/memory"
+	"github.com/galaxy-io/filament/eventbus"
 	"github.com/galaxy-io/filament/eventbus/inproc"
+	"github.com/galaxy-io/filament/events"
 )
 
 type loadRunErrorStore struct {
@@ -65,21 +67,117 @@ func TestSignalRunPauseResumeAndCancelStateMachine(t *testing.T) {
 	}
 }
 
-func TestSignalRunRejectsUnsafeRunningWorkerCommands(t *testing.T) {
+func TestSignalRunPublishesRunningWorkerCommands(t *testing.T) {
 	ctx := context.Background()
 	store := memory.New()
 	if err := store.SaveRun(ctx, filament.RunState{Run: "run-1", Tenant: "tenant-1", Status: filament.RunRunning}); err != nil {
 		t.Fatal(err)
 	}
-	api := &Server{store: store, bus: inproc.New()}
-	for _, signal := range []ingestionv1.RunSignal{
-		ingestionv1.RunSignal_RUN_SIGNAL_PAUSE,
-		ingestionv1.RunSignal_RUN_SIGNAL_CANCEL,
-	} {
-		_, err := api.SignalRun(ctx, connect.NewRequest(&ingestionv1.SignalRunRequest{RunId: "run-1", Signal: signal}))
-		if connect.CodeOf(err) != connect.CodeFailedPrecondition {
-			t.Fatalf("signal %v error = %v, want failed precondition", signal, err)
+	bus := inproc.New()
+	sub, err := bus.Subscribe("ingestion.v1.run.tenant-1.run-1.*", eventbus.SubOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sub.Close() }()
+	api := &Server{store: store, bus: bus}
+	setStatus := func(status filament.RunStatus) error {
+		state, err := store.LoadRun(ctx, "run-1")
+		if err != nil {
+			return err
 		}
+		state.Status = status
+		return store.SaveRun(ctx, state)
+	}
+	for _, test := range []struct {
+		signal ingestionv1.RunSignal
+		want   string
+		ack    func() error
+	}{
+		{ingestionv1.RunSignal_RUN_SIGNAL_PAUSE, "run.pause_requested", func() error {
+			if err := setStatus(filament.RunPaused); err != nil {
+				return err
+			}
+			return events.Emit(ctx, bus, events.RunPaused, events.Envelope{
+				Tenant: "tenant-1", Run: "run-1", At: time.Now(),
+			}, events.RunPausedEvent{})
+		}},
+		{ingestionv1.RunSignal_RUN_SIGNAL_CANCEL, "run.cancel_requested", func() error {
+			if err := setStatus(filament.RunCanceled); err != nil {
+				return err
+			}
+			return events.Emit(ctx, bus, events.RunCanceled, events.Envelope{
+				Tenant: "tenant-1", Run: "run-1", At: time.Now(),
+			}, events.RunCanceledEvent{})
+		}},
+	} {
+		if err := setStatus(filament.RunRunning); err != nil {
+			t.Fatal(err)
+		}
+		errCh := make(chan error, 1)
+		go func() {
+			_, signalErr := api.SignalRun(ctx, connect.NewRequest(&ingestionv1.SignalRunRequest{RunId: "run-1", Signal: test.signal}))
+			errCh <- signalErr
+		}()
+		deadline := time.After(time.Second)
+		published := false
+		for !published {
+			select {
+			case msg := <-sub.C():
+				fact, decodeErr := events.Decode(msg)
+				_ = msg.Ack()
+				if decodeErr == nil && fact.Name == test.want {
+					if err := test.ack(); err != nil {
+						t.Fatal(err)
+					}
+					published = true
+				}
+			case <-deadline:
+				t.Fatalf("signal %v did not publish %q", test.signal, test.want)
+			}
+		}
+		if err := <-errCh; err != nil {
+			t.Fatalf("signal %v: %v", test.signal, err)
+		}
+	}
+	state, err := store.LoadRun(ctx, "run-1")
+	if err != nil || state.Status != filament.RunCanceled {
+		t.Fatalf("worker acknowledgement was not persisted: %#v, %v", state, err)
+	}
+}
+
+func TestSignalRunReportsWhenWorkerAlreadyFinished(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+	state := filament.RunState{Run: "run-1", Tenant: "tenant-1", Status: filament.RunRunning}
+	if err := store.SaveRun(ctx, state); err != nil {
+		t.Fatal(err)
+	}
+	bus := inproc.New()
+	commands, err := bus.Subscribe(events.Subject(events.RunCancelRequested, state.Tenant, state.Run), eventbus.SubOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = commands.Close() }()
+	api := &Server{store: store, bus: bus}
+	errCh := make(chan error, 1)
+	go func() {
+		_, signalErr := api.SignalRun(ctx, connect.NewRequest(&ingestionv1.SignalRunRequest{
+			RunId: "run-1", Signal: ingestionv1.RunSignal_RUN_SIGNAL_CANCEL,
+		}))
+		errCh <- signalErr
+	}()
+	select {
+	case msg := <-commands.C():
+		_ = msg.Ack()
+	case <-time.After(time.Second):
+		t.Fatal("cancel command was not published")
+	}
+	if err := events.Emit(ctx, bus, events.RunCompleted,
+		events.Envelope{Tenant: state.Tenant, Run: state.Run, At: time.Now()}, events.RunCompletedEvent{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errCh; connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("signal error = %v, want failed precondition", err)
 	}
 }
 


### PR DESCRIPTION
Implements core pause/resume wiring

Adds events to the engine and their reactions to it everywhere

Adds database queries and golang state machines to allow for transitions between states

Adds a unified mechanism for pausing/resuming/logging across inproc and k8s workers 

Adds worker ack handling for these signals

Untested on deployed pods

## Slop

This pull request introduces a robust, atomic mechanism for transitioning the lifecycle state of a "run" in both the in-memory and Postgres-backed datastores. It adds a new interface for safe run state transitions, implements compare-and-swap semantics to prevent race conditions, and ensures proper reset and progress preservation on run resumption. Additionally, it enhances Kubernetes job naming and labeling to disambiguate executions and improve traceability, and expands event cataloging for run control. The most important changes are grouped below.

### Run Lifecycle Management & Atomic Transitions

* Introduced the `RunTransitionStore` interface and `RunTransitionOptions` struct to provide atomic, compare-and-swap lifecycle transitions for runs, including options for resetting execution state and preserving progress.
* Implemented the `TransitionRun` method for both in-memory (`memory.go`) and Postgres (`store.go`) datastores, ensuring that state transitions only occur if the run is in an expected status, and handling resets of execution and resource state as needed. [[1]](diffhunk://#diff-239fdc3dc73570f5e1869a4739b5a5eab8d174be0a37d23f27d23c679365d379R200-R249) [[2]](diffhunk://#diff-457e2f0ceb99c9f39a2f71ed5418e67e65bd80d2eaa69f7f89e793f473c88049R107-R164)
* Added SQL queries and Go wrappers for atomic status locking, state transitions, and execution/resource resets in Postgres (`runs.sql`, `run_resource_states.sql`, and generated Go code). [[1]](diffhunk://#diff-f3b06eae44e707695e8747617e80dc236027be5d52a3b297e55aecd370d843f6R54-R73) [[2]](diffhunk://#diff-e151a0145ac1119f389e2b99c47321887a7274463c5cb3fed234550838cb8d3aR15-R23) [[3]](diffhunk://#diff-5faa9c820fbbd569203cb4dad8fedb3aae739a9fcd09b645d9b641a3d6e058acR160-R196) [[4]](diffhunk://#diff-5faa9c820fbbd569203cb4dad8fedb3aae739a9fcd09b645d9b641a3d6e058acR263-R276) [[5]](diffhunk://#diff-adbb2290da8d3c1891f4e182a097424485fe09610ea6e6dc8a0c9d467ab6774fR55-R75)

### Kubernetes Job Execution & Traceability

* Modified job naming to include a hash of the execution ID, ensuring job names are stable per execution and change on resume, preventing name collisions and improving traceability. [[1]](diffhunk://#diff-b6c26a16464969db7071d5a209e2127462a359f79b27403d612f5b3b1e308476R4-R42) [[2]](diffhunk://#diff-6965e494c30f306c156aeede82e1668caa840e4807eb181ee896d49ddd4770ddL87-R91) [[3]](diffhunk://#diff-e20f50f1ac703335b2fcd5d11a9d4bdb0368dbd6a01fff5f07f639e1b082b119L52-R52) [[4]](diffhunk://#diff-e20f50f1ac703335b2fcd5d11a9d4bdb0368dbd6a01fff5f07f639e1b082b119R66-R83)
* Updated job and pod labeling to include the execution ID, and improved collision detection logic when creating jobs in Kubernetes. [[1]](diffhunk://#diff-6965e494c30f306c156aeede82e1668caa840e4807eb181ee896d49ddd4770ddL68-R77) [[2]](diffhunk://#diff-80b115d70676f892f47185300f11a189eea31ba50794231c36080a3f5ffc99a2L43-R55)

### Event Cataloging & Control

* Expanded the event catalog to include `RunPauseRequestedEvent` and `RunCancelRequestedEvent`, and updated tests to ensure these events are properly cataloged. [[1]](diffhunk://#diff-9c5eeb50f74c6937d65dc9634610682bc28bdb324ba0fdc18228416c1f44f4bfL33-R43) [[2]](diffhunk://#diff-9c5eeb50f74c6937d65dc9634610682bc28bdb324ba0fdc18228416c1f44f4bfR131-R132) [[3]](diffhunk://#diff-7d6f1f4a23a259359913950c7576cbb70f0c8a370ec12a1003f41a2d6cf02453R60-R61)

### Minor Improvements & Testing

* Added a test double (`failOnceCheckpointStore`) for simulating checkpoint failures in incremental tracker tests. [[1]](diffhunk://#diff-b774f1b96eb40375f8f884844d712b1ba88468c324fc484aa438dc2b9dc0acfcR5) [[2]](diffhunk://#diff-b774f1b96eb40375f8f884844d712b1ba88468c324fc484aa438dc2b9dc0acfcR14-R26)
* Allowed `Wait` on a run handle to return for additional terminal states (`RunPaused`, `RunPartial`).

These changes collectively improve the safety, observability, and reliability of run management and execution in the system. 