### PR TITLE
Atterpac/cleanup

### DIFF
--- a/datastore/memory/memory.go
+++ b/datastore/memory/memory.go
@@ -488,10 +488,5 @@ func matchRun(r filament.RunState, f filament.RunFilter) bool {
 	if len(f.Status) > 0 && !slices.Contains(f.Status, r.Status) {
 		return false
 	}
-	if f.Source != "" &&
-		r.Request.Source.ConfigRef != f.Source &&
-		r.Request.Source.Provider != f.Source {
-		return false
-	}
 	return true
 }

--- a/datastore/postgres/store.go
+++ b/datastore/postgres/store.go
@@ -275,9 +275,6 @@ func (s *Store) ListRuns(ctx context.Context, f filament.RunFilter) ([]filament.
 	if f.Schedule != "" {
 		q += " AND schedule_id = " + arg(string(f.Schedule))
 	}
-	if f.Source != "" {
-		q += " AND (request->'Source'->>'Provider' = " + arg(f.Source) + " OR request->'Source'->>'ConfigRef' = " + arg(f.Source) + ")"
-	}
 	if !f.Since.IsZero() {
 		q += " AND started_at >= " + arg(f.Since)
 	}

--- a/eventbus/nats/nats.go
+++ b/eventbus/nats/nats.go
@@ -457,6 +457,7 @@ func (s *subscription) pump() {
 				}
 				payload, derr := s.bus.codec.Decode(msg.Data())
 				if derr != nil {
+					s.bus.logDecodeFailure(msg.Subject(), derr)
 					_ = msg.Term()
 					continue
 				}
@@ -495,6 +496,13 @@ func (s *subscription) pump() {
 		case <-time.After(defaultFetchWait):
 		}
 	}
+}
+
+func (b *Bus) logDecodeFailure(subject string, err error) {
+	if b.logf == nil {
+		return
+	}
+	b.logf("eventbus/nats: decode %q: %v; terminating poison message", subject, err)
 }
 
 type message struct {

--- a/eventbus/nats/nats_test.go
+++ b/eventbus/nats/nats_test.go
@@ -3,6 +3,8 @@ package nats
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/galaxy-io/filament/eventbus"
@@ -16,6 +18,15 @@ func (stringCodec) Encode(payload any) ([]byte, error) {
 		return nil, errors.New("expected string")
 	}
 	return []byte(s), nil
+}
+
+func TestDecodeFailureIsLoggedWithoutPayload(t *testing.T) {
+	var line string
+	b := &Bus{logf: func(format string, args ...any) { line = fmt.Sprintf(format, args...) }}
+	b.logDecodeFailure("app.v1.run.t1.r1.started", errors.New("bad frame"))
+	if !strings.Contains(line, "app.v1.run.t1.r1.started") || !strings.Contains(line, "bad frame") || !strings.Contains(line, "terminating") {
+		t.Fatalf("decode log = %q", line)
+	}
 }
 
 func (stringCodec) Decode(data []byte) (any, error) {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -15,183 +15,179 @@ import (
 // ErrUnknownProvider is returned by Resolve when no factory is registered.
 var ErrUnknownProvider = errors.New("registry: unknown provider")
 
-// Sources is the source-provider registry.
-type Sources struct {
-	mu        sync.RWMutex
-	factories map[string]sourceRegistration
-}
-
-type sourceRegistration struct {
-	factory  filament.SourceFactory
+type registration[P any] struct {
+	factory  func() P
 	maturity filament.ConnectorMaturity
 }
 
-// NewSources returns an empty source registry.
-func NewSources() *Sources { return &Sources{factories: map[string]sourceRegistration{}} }
-
-var _ filament.SourceRegistry = (*Sources)(nil)
-
-// Register adds a factory under name. It panics on a nil factory or a duplicate
-func (r *Sources) Register(name string, f filament.SourceFactory) {
-	r.RegisterWithMaturity(name, filament.MaturityAlpha, f)
+type providerRegistry[P, S any] struct {
+	kind        string
+	mu          sync.RWMutex
+	factories   map[string]registration[P]
+	specOf      func(P) S
+	setMaturity func(*S, filament.ConnectorMaturity)
 }
 
-// RegisterWithMaturity adds a source factory and its catalog maturity under
-// name. It panics on an invalid maturity, a nil factory, or a duplicate name.
-func (r *Sources) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, f filament.SourceFactory) {
+func newProviderRegistry[P, S any](
+	kind string,
+	specOf func(P) S,
+	setMaturity func(*S, filament.ConnectorMaturity),
+) *providerRegistry[P, S] {
+	return &providerRegistry[P, S]{
+		kind:        kind,
+		factories:   make(map[string]registration[P]),
+		specOf:      specOf,
+		setMaturity: setMaturity,
+	}
+}
+
+func (r *providerRegistry[P, S]) register(name string, maturity filament.ConnectorMaturity, factory func() P) {
 	switch maturity {
 	case filament.MaturityAlpha, filament.MaturityBeta, filament.MaturityStable:
 	default:
-		panic("registry: invalid source maturity for " + name + ": " + string(maturity))
+		panic("registry: invalid " + r.kind + " maturity for " + name + ": " + string(maturity))
 	}
-	if f == nil {
-		panic("registry: nil source factory for " + name)
+	if factory == nil {
+		panic("registry: nil " + r.kind + " factory for " + name)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, dup := r.factories[name]; dup {
-		panic("registry: source already registered: " + name)
+		panic("registry: " + r.kind + " already registered: " + name)
 	}
-	r.factories[name] = sourceRegistration{factory: f, maturity: maturity}
+	r.factories[name] = registration[P]{factory: factory, maturity: maturity}
 }
 
-// Resolve constructs a fresh source instance for name.
-func (r *Sources) Resolve(name string) (filament.Source, error) {
+func (r *providerRegistry[P, S]) resolve(name string) (P, error) {
 	r.mu.RLock()
 	registration, ok := r.factories[name]
 	r.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("%w: source %q", ErrUnknownProvider, name)
+		var zero P
+		return zero, fmt.Errorf("%w: %s %q", ErrUnknownProvider, r.kind, name)
 	}
 	return registration.factory(), nil
 }
 
-// Spec returns one registered source's catalog spec with its maturity marker.
-func (r *Sources) Spec(name string) (filament.ConnectorSpec, error) {
+func (r *providerRegistry[P, S]) spec(name string) (S, error) {
 	r.mu.RLock()
 	registration, ok := r.factories[name]
 	r.mu.RUnlock()
 	if !ok {
-		return filament.ConnectorSpec{}, fmt.Errorf("%w: source %q", ErrUnknownProvider, name)
+		var zero S
+		return zero, fmt.Errorf("%w: %s %q", ErrUnknownProvider, r.kind, name)
 	}
-	spec := registration.factory().Spec()
-	spec.Maturity = registration.maturity
+	spec := r.specOf(registration.factory())
+	r.setMaturity(&spec, registration.maturity)
 	return spec, nil
+}
+
+func (r *providerRegistry[P, S]) specs() []S {
+	registrations := r.snapshot()
+	out := make([]S, len(registrations))
+	for i, registration := range registrations {
+		out[i] = r.specOf(registration.factory())
+		r.setMaturity(&out[i], registration.maturity)
+	}
+	return out
+}
+
+func (r *providerRegistry[P, S]) snapshot() []registration[P] {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.factories))
+	for n := range r.factories {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]registration[P], len(names))
+	for i, n := range names {
+		out[i] = r.factories[n]
+	}
+	return out
+}
+
+// Sources is the source-provider registry.
+type Sources struct {
+	providers *providerRegistry[filament.Source, filament.ConnectorSpec]
+}
+
+// NewSources returns an empty source registry.
+func NewSources() *Sources {
+	return &Sources{providers: newProviderRegistry(
+		"source",
+		func(source filament.Source) filament.ConnectorSpec { return source.Spec() },
+		func(spec *filament.ConnectorSpec, maturity filament.ConnectorMaturity) { spec.Maturity = maturity },
+	)}
+}
+
+var _ filament.SourceRegistry = (*Sources)(nil)
+
+// Register adds a factory under name. It panics on a nil factory or a duplicate
+func (r *Sources) Register(name string, factory filament.SourceFactory) {
+	r.RegisterWithMaturity(name, filament.MaturityAlpha, factory)
+}
+
+// RegisterWithMaturity adds a source factory and its catalog maturity under
+// name. It panics on an invalid maturity, a nil factory, or a duplicate name.
+func (r *Sources) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, factory filament.SourceFactory) {
+	r.providers.register(name, maturity, factory)
+}
+
+// Resolve constructs a fresh source instance for name.
+func (r *Sources) Resolve(name string) (filament.Source, error) {
+	return r.providers.resolve(name)
+}
+
+// Spec returns one registered source's catalog spec with its maturity marker.
+func (r *Sources) Spec(name string) (filament.ConnectorSpec, error) {
+	return r.providers.spec(name)
 }
 
 // Specs returns every registered source's spec, sorted by name. Powers the
 // DiscoveryService catalog.
 func (r *Sources) Specs() []filament.ConnectorSpec {
-	registrations := r.snapshot()
-	out := make([]filament.ConnectorSpec, len(registrations))
-	for i, registration := range registrations {
-		out[i] = registration.factory().Spec()
-		out[i].Maturity = registration.maturity
-	}
-	return out
-}
-
-func (r *Sources) snapshot() []sourceRegistration {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.factories))
-	for n := range r.factories {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	out := make([]sourceRegistration, len(names))
-	for i, n := range names {
-		out[i] = r.factories[n]
-	}
-	return out
+	return r.providers.specs()
 }
 
 // Sinks is the sink-provider registry.
 type Sinks struct {
-	mu        sync.RWMutex
-	factories map[string]sinkRegistration
-}
-
-type sinkRegistration struct {
-	factory  filament.SinkFactory
-	maturity filament.ConnectorMaturity
+	providers *providerRegistry[filament.Sink, filament.SinkSpec]
 }
 
 // NewSinks returns an empty sink registry.
-func NewSinks() *Sinks { return &Sinks{factories: map[string]sinkRegistration{}} }
+func NewSinks() *Sinks {
+	return &Sinks{providers: newProviderRegistry(
+		"sink",
+		func(sink filament.Sink) filament.SinkSpec { return sink.Spec() },
+		func(spec *filament.SinkSpec, maturity filament.ConnectorMaturity) { spec.Maturity = maturity },
+	)}
+}
 
 var _ filament.SinkRegistry = (*Sinks)(nil)
 
 // Register adds a factory under name. Panics on nil factory or duplicate name.
-func (r *Sinks) Register(name string, f filament.SinkFactory) {
-	r.RegisterWithMaturity(name, filament.MaturityAlpha, f)
+func (r *Sinks) Register(name string, factory filament.SinkFactory) {
+	r.RegisterWithMaturity(name, filament.MaturityAlpha, factory)
 }
 
 // RegisterWithMaturity adds a sink factory and its catalog maturity under name.
 // It panics on an invalid maturity, a nil factory, or a duplicate name.
-func (r *Sinks) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, f filament.SinkFactory) {
-	switch maturity {
-	case filament.MaturityAlpha, filament.MaturityBeta, filament.MaturityStable:
-	default:
-		panic("registry: invalid sink maturity for " + name + ": " + string(maturity))
-	}
-	if f == nil {
-		panic("registry: nil sink factory for " + name)
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, dup := r.factories[name]; dup {
-		panic("registry: sink already registered: " + name)
-	}
-	r.factories[name] = sinkRegistration{factory: f, maturity: maturity}
+func (r *Sinks) RegisterWithMaturity(name string, maturity filament.ConnectorMaturity, factory filament.SinkFactory) {
+	r.providers.register(name, maturity, factory)
 }
 
 // Resolve constructs a fresh sink instance for name.
 func (r *Sinks) Resolve(name string) (filament.Sink, error) {
-	r.mu.RLock()
-	registration, ok := r.factories[name]
-	r.mu.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("%w: sink %q", ErrUnknownProvider, name)
-	}
-	return registration.factory(), nil
+	return r.providers.resolve(name)
 }
 
 // Spec returns one registered sink's catalog spec with its maturity marker.
 func (r *Sinks) Spec(name string) (filament.SinkSpec, error) {
-	r.mu.RLock()
-	registration, ok := r.factories[name]
-	r.mu.RUnlock()
-	if !ok {
-		return filament.SinkSpec{}, fmt.Errorf("%w: sink %q", ErrUnknownProvider, name)
-	}
-	spec := registration.factory().Spec()
-	spec.Maturity = registration.maturity
-	return spec, nil
+	return r.providers.spec(name)
 }
 
 // Specs returns every registered sink's spec, sorted by name.
 func (r *Sinks) Specs() []filament.SinkSpec {
-	registrations := r.snapshot()
-	out := make([]filament.SinkSpec, len(registrations))
-	for i, registration := range registrations {
-		out[i] = registration.factory().Spec()
-		out[i].Maturity = registration.maturity
-	}
-	return out
-}
-
-func (r *Sinks) snapshot() []sinkRegistration {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.factories))
-	for n := range r.factories {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	out := make([]sinkRegistration, len(names))
-	for i, n := range names {
-		out[i] = r.factories[n]
-	}
-	return out
+	return r.providers.specs()
 }

--- a/run.go
+++ b/run.go
@@ -27,7 +27,6 @@ type RunSpec struct {
 	// IngestionTypes maps each resource to its ingestion type; the "" entry is
 	// the route default for resources not explicitly listed.
 	IngestionTypes map[string]IngestionType
-	Checkpoint     *CheckpointData
 	Options        RunOptions
 	WritePolicies  map[string]WritePolicy
 	// WorkerConfiguration is the already-resolved worker shape for this run: the
@@ -283,7 +282,6 @@ type RunFilter struct {
 	Tenant            TenantID
 	PipelineID        string
 	PipelineVersionID *string
-	Source            string
 	Status            []RunStatus
 	Schedule          ScheduleID
 	Since             time.Time


### PR DESCRIPTION
General cleanup/small tix

Reduce duplicated logic between source/sink registries with a generic registry and small layer on top of it for each source/sink individual needs

Fix nats decoding error terming the stream

Cleans unused code

## Slop

This pull request introduces several improvements and refactorings across the codebase, focusing on simplifying provider registries, enhancing error logging in the event bus, and cleaning up unused or redundant fields and filters. The main themes are registry code generalization, improved observability, and removal of unused filtering logic.

### Registry Refactoring and Simplification

* Refactored the provider registry logic for sources and sinks in `registry/registry.go`, introducing a generic `providerRegistry` type to reduce code duplication and improve maintainability. The `Sources` and `Sinks` registries now delegate to this generic provider, making the code more extensible and less error-prone.

### Observability and Logging

* Added a `logDecodeFailure` method to the NATS event bus (`eventbus/nats/nats.go`) to log decoding errors with context, improving visibility into message handling issues. Also added a unit test to verify that decode failures are logged as expected. [[1]](diffhunk://#diff-e69cddc425abbd75f0bba6a35bd295be994ef747a0751c7df51829aa487d38bcR460) [[2]](diffhunk://#diff-e69cddc425abbd75f0bba6a35bd295be994ef747a0751c7df51829aa487d38bcR501-R507) [[3]](diffhunk://#diff-1c45c3b555c6b29c78c83cde2320de8f3e99726f68a11dd60d7258ce2c450b35R6-R7) [[4]](diffhunk://#diff-1c45c3b555c6b29c78c83cde2320de8f3e99726f68a11dd60d7258ce2c450b35R23-R31)

### Filtering and Data Model Cleanup

* Removed the `Source` field from `filament.RunFilter` and eliminated related filtering logic from both the in-memory and Postgres run listing implementations, reflecting that this filter is no longer needed or supported. [[1]](diffhunk://#diff-05d67ab64d2cc3aeb2a3d4b1b1de5b145c06a2371ddf94660d326f5aa265ab6dL287) [[2]](diffhunk://#diff-239fdc3dc73570f5e1869a4739b5a5eab8d174be0a37d23f27d23c679365d379L461-L465) [[3]](diffhunk://#diff-457e2f0ceb99c9f39a2f71ed5418e67e65bd80d2eaa69f7f89e793f473c88049L282-L284)

* Removed the unused `Checkpoint` field from `RunSpec` in `run.go`, simplifying the data model.