### PR TITLE
CDC WAL advance / retention bug and harden run admission

### DIFF
--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -82,13 +82,14 @@ func run(ctx context.Context) error {
 	sched := scheduler.New(scheduleStore)
 	mods := []module.Module{tracker.New(), dispatcher, sched}
 	// The reaper mounts only under kubernetes dispatch: staleness means death
-	// only where heartbeats exist, and inproc runs don't emit them. The Alive
-	// probe holds kills for workers that are up but silent.
+	// only where heartbeats exist, and inproc runs don't emit them. The
+	// workload probe holds kills for workers that are up but silent and for
+	// Requested runs that were never dispatched.
 	var reap *reaper.Module
-	if alive, ok := dispatcher.(interface {
-		Alive(context.Context, filament.RunID) (bool, error)
+	if prober, ok := dispatcher.(interface {
+		Workload(context.Context, filament.RunID) (filament.Workload, error)
 	}); ok {
-		reap = reaper.NewFromEnv(reaper.WithAliveCheck(alive.Alive))
+		reap = reaper.NewFromEnv(reaper.WithWorkloadProbe(prober.Workload))
 		mods = append(mods, reap)
 	}
 	h, err := boot.Mount(ctx, deps, bus, mods...)

--- a/cmd/filament/run.go
+++ b/cmd/filament/run.go
@@ -255,12 +255,14 @@ func executeLocalRun(ctx context.Context, spec filament.RunSpec) (runResult, err
 		return runResult{}, err
 	}
 
-	runner.RunOne(ctx, runner.Deps{
+	if err := runner.RunOne(ctx, runner.Deps{
 		Bus:       bus,
 		DataStore: memory.New(),
 		Sources:   registry.DefaultSources,
 		Sinks:     registry.DefaultSinks,
-	}, spec)
+	}, spec); err != nil {
+		return runResult{}, err
+	}
 
 	select {
 	case message := <-completed.C():

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -75,7 +75,7 @@ func run(ctx context.Context) error {
 	}
 	stopHeartbeat := hb.start(ctx, heartbeatInterval())
 
-	runner.RunOne(ctx, runner.Deps{
+	err = runner.RunOne(ctx, runner.Deps{
 		Bus:       bus,
 		DataStore: deps.Store,
 		Log:       deps.Log,
@@ -85,5 +85,5 @@ func run(ctx context.Context) error {
 		Tracer:    deps.Tracer,
 	}, runner.SpecFromState(state))
 	stopHeartbeat()
-	return nil
+	return err
 }

--- a/connectors/postgres/source/cdc.go
+++ b/connectors/postgres/source/cdc.go
@@ -233,10 +233,10 @@ func (s *Source) ExtractChanges(ctx context.Context, sink arrowbatch.Inlet, opts
 	}); err != nil {
 		return fmt.Errorf("postgres cdc: start slot %q at %s: %w", s.slotName, start, err)
 	}
-	// Only acknowledge the cursor which was durable before this extraction began.
-	// The final watermark is acknowledged by the next cycle, after the sink and
-	// tracker have committed it.
-	if err := pglogrepl.SendStandbyStatusUpdate(ctx, repl, pglogrepl.StandbyStatusUpdate{WALWritePosition: start}); err != nil {
+	// Standby replies confirm the slot's own position, a no-op that keeps the
+	// walsender satisfied. The slot advances in exactly one place,
+	// AcknowledgeChanges, once the runner has proven the cursors durable.
+	if err := pglogrepl.SendStandbyStatusUpdate(ctx, repl, pglogrepl.StandbyStatusUpdate{WALWritePosition: slot.start}); err != nil {
 		return fmt.Errorf("postgres cdc: acknowledge start %s: %w", start, err)
 	}
 
@@ -252,7 +252,7 @@ func (s *Source) ExtractChanges(ctx context.Context, sink arrowbatch.Inlet, opts
 		cancel()
 		if recvErr != nil {
 			if pgconn.Timeout(recvErr) {
-				if err := pglogrepl.SendStandbyStatusUpdate(ctx, repl, pglogrepl.StandbyStatusUpdate{WALWritePosition: start}); err != nil {
+				if err := pglogrepl.SendStandbyStatusUpdate(ctx, repl, pglogrepl.StandbyStatusUpdate{WALWritePosition: slot.start}); err != nil {
 					return fmt.Errorf("postgres cdc: standby status: %w", err)
 				}
 				nextStatus = time.Now().Add(standbyStatusInterval)
@@ -274,7 +274,7 @@ func (s *Source) ExtractChanges(ctx context.Context, sink arrowbatch.Inlet, opts
 					return fmt.Errorf("postgres cdc: keepalive: %w", err)
 				}
 				if keepalive.ReplyRequested {
-					if err := pglogrepl.SendStandbyStatusUpdate(ctx, repl, pglogrepl.StandbyStatusUpdate{WALWritePosition: start}); err != nil {
+					if err := pglogrepl.SendStandbyStatusUpdate(ctx, repl, pglogrepl.StandbyStatusUpdate{WALWritePosition: slot.start}); err != nil {
 						return fmt.Errorf("postgres cdc: keepalive reply: %w", err)
 					}
 					nextStatus = time.Now().Add(standbyStatusInterval)

--- a/connectors/postgres/source/cdc.go
+++ b/connectors/postgres/source/cdc.go
@@ -11,6 +11,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -29,6 +30,42 @@ import (
 )
 
 const standbyStatusInterval = 10 * time.Second
+
+// slotReleaseWait bounds how long a cycle waits for a peer to let go of the
+// slot: the previous cycle's walsender still exiting after Close, or its
+// pg_replication_slot_advance still decoding toward the acknowledged cursor.
+const (
+	slotReleaseWait = 10 * time.Second
+	slotReleasePoll = 100 * time.Millisecond
+)
+
+// errSlotHeld marks a slot operation refused because another backend holds
+// the slot right now; untilSlotReleased retries such operations.
+var errSlotHeld = errors.New("slot is held by another backend")
+
+// slotHeldByPeer reports whether a server error is PostgreSQL refusing to
+// acquire an active slot (SQLSTATE 55006, object_in_use).
+func slotHeldByPeer(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "55006"
+}
+
+// untilSlotReleased runs op until it stops reporting errSlotHeld or
+// slotReleaseWait elapses, returning op's last error.
+func untilSlotReleased(ctx context.Context, op func() error) error {
+	deadline := time.Now().Add(slotReleaseWait)
+	for {
+		err := op()
+		if !errors.Is(err, errSlotHeld) || time.Now().After(deadline) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(slotReleasePoll):
+		}
+	}
+}
 
 var replicationNameRE = regexp.MustCompile(`^[a-z_][a-z0-9_]{0,62}$`)
 
@@ -376,9 +413,21 @@ func (s *Source) replicationConn(ctx context.Context) (*pgconn.PgConn, error) {
 func (s *Source) ensureReplicationSlot(ctx context.Context, conn *pgconn.PgConn) (replicationSlotState, error) {
 	var plugin, database string
 	var confirmed, restart *string
-	var active bool
-	err := s.pool.QueryRow(ctx, `SELECT plugin, database, active, confirmed_flush_lsn::text, restart_lsn::text
-		FROM pg_replication_slots WHERE slot_name=$1`, s.slotName).Scan(&plugin, &database, &active, &confirmed, &restart)
+	err := untilSlotReleased(ctx, func() error {
+		var active bool
+		err := s.pool.QueryRow(ctx, `SELECT plugin, database, active, confirmed_flush_lsn::text, restart_lsn::text
+			FROM pg_replication_slots WHERE slot_name=$1`, s.slotName).Scan(&plugin, &database, &active, &confirmed, &restart)
+		if err != nil {
+			return err
+		}
+		if active {
+			return fmt.Errorf("postgres cdc: slot %q is already active; use a unique slot per pipeline (%w)", s.slotName, errSlotHeld)
+		}
+		return nil
+	})
+	if errors.Is(err, errSlotHeld) {
+		return replicationSlotState{}, err
+	}
 	if err != nil && err != pgx.ErrNoRows {
 		return replicationSlotState{}, fmt.Errorf("postgres cdc: inspect slot %q: %w", s.slotName, err)
 	}
@@ -403,9 +452,6 @@ func (s *Source) ensureReplicationSlot(ctx context.Context, conn *pgconn.PgConn)
 	if database != currentDB {
 		return replicationSlotState{}, fmt.Errorf("postgres cdc: slot %q belongs to database %q, want %q", s.slotName, database, currentDB)
 	}
-	if active {
-		return replicationSlotState{}, fmt.Errorf("postgres cdc: slot %q is already active; use a unique slot per pipeline", s.slotName)
-	}
 	position := confirmed
 	if position == nil || *position == "" {
 		position = restart
@@ -418,6 +464,33 @@ func (s *Source) ensureReplicationSlot(ctx context.Context, conn *pgconn.PgConn)
 		return replicationSlotState{}, fmt.Errorf("postgres cdc: slot position %q: %w", *position, err)
 	}
 	return replicationSlotState{start: lsn}, nil
+}
+
+// AcknowledgeChanges advances the logical slot to the oldest checkpoint the
+// runner has verified durable after sink commit. ExtractChanges cannot do this
+// itself: at extraction return time the sink and tracker may still fail. The
+// standby replies sent while streaming only confirm a flush position; advancing
+// decodes the retained WAL so restart_lsn moves and the server can recycle it.
+func (s *Source) AcknowledgeChanges(ctx context.Context, checkpoints map[string]filament.Checkpoint) error {
+	target, _, found, err := startPostgresLSN(checkpoints)
+	if err != nil || !found {
+		return err
+	}
+	// GREATEST keeps the call monotonic: a target behind confirmed_flush_lsn
+	// is a no-op rather than an error.
+	err = untilSlotReleased(ctx, func() error {
+		var endLSN string
+		err := s.pool.QueryRow(ctx, `SELECT (pg_replication_slot_advance(slot_name, GREATEST(confirmed_flush_lsn, $2::pg_lsn))).end_lsn::text
+			FROM pg_replication_slots WHERE slot_name=$1`, s.slotName, target.String()).Scan(&endLSN)
+		if slotHeldByPeer(err) {
+			return fmt.Errorf("%w: %w", errSlotHeld, err)
+		}
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("postgres cdc: advance slot %q to %s: %w", s.slotName, target, err)
+	}
+	return nil
 }
 
 // importSnapshot opens a read-only transaction over the snapshot exported by

--- a/connectors/postgres/source/postgres.go
+++ b/connectors/postgres/source/postgres.go
@@ -106,6 +106,7 @@ var (
 	_ filament.IncrementalPlanner   = (*Source)(nil)
 	_ filament.CursorColumnProvider = (*Source)(nil)
 	_ filament.ChangeSource         = (*Source)(nil)
+	_ filament.ChangeAcknowledger   = (*Source)(nil)
 )
 
 // Spec describes the source's config fields, modes, and write policies.

--- a/datastore/memory/memory.go
+++ b/datastore/memory/memory.go
@@ -472,6 +472,26 @@ func (s *Store) LoadResourceCheckpoint(ctx context.Context, key filament.Resourc
 	return state, nil
 }
 
+// ListResourceCheckpoints returns every durable cursor under one route,
+// ordered by resource.
+func (s *Store) ListResourceCheckpoints(ctx context.Context, route filament.ResourceCheckpointRoute) ([]filament.ResourceCheckpointState, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	var states []filament.ResourceCheckpointState
+	for key, state := range s.resourceCheckpoints {
+		if key.PipelineID == route.PipelineID && key.PipelineVersionID == route.PipelineVersionID && key.Route == route.Route {
+			states = append(states, state)
+		}
+	}
+	s.mu.RUnlock()
+	slices.SortFunc(states, func(a, b filament.ResourceCheckpointState) int {
+		return strings.Compare(a.Key.Resource, b.Key.Resource)
+	})
+	return states, nil
+}
+
 // DeleteResourceCheckpoint clears durable progress so the next run starts a
 // fresh backfill.
 func (s *Store) DeleteResourceCheckpoint(ctx context.Context, key filament.ResourceCheckpointKey) error {

--- a/datastore/postgres/queries/pipeline_resource_checkpoints.sql
+++ b/datastore/postgres/queries/pipeline_resource_checkpoints.sql
@@ -16,6 +16,14 @@ WHERE pipeline_id = @pipeline_id
   AND route_key = @route_key
   AND resource_name = @resource_name;
 
+-- name: ListResourceCheckpoints :many
+SELECT resource_name, cursor, last_run_id, updated_at
+FROM pipeline_resource_checkpoints
+WHERE pipeline_id = @pipeline_id
+  AND pipeline_version_id = @pipeline_version_id
+  AND route_key = @route_key
+ORDER BY resource_name;
+
 -- name: DeleteResourceCheckpoint :exec
 DELETE FROM pipeline_resource_checkpoints
 WHERE pipeline_id = @pipeline_id

--- a/datastore/postgres/sqlcgen/pipeline_resource_checkpoints.sql.go
+++ b/datastore/postgres/sqlcgen/pipeline_resource_checkpoints.sql.go
@@ -36,6 +36,53 @@ func (q *Queries) DeleteResourceCheckpoint(ctx context.Context, arg DeleteResour
 	return err
 }
 
+const listResourceCheckpoints = `-- name: ListResourceCheckpoints :many
+SELECT resource_name, cursor, last_run_id, updated_at
+FROM pipeline_resource_checkpoints
+WHERE pipeline_id = $1
+  AND pipeline_version_id = $2
+  AND route_key = $3
+ORDER BY resource_name
+`
+
+type ListResourceCheckpointsParams struct {
+	PipelineID        string
+	PipelineVersionID string
+	RouteKey          string
+}
+
+type ListResourceCheckpointsRow struct {
+	ResourceName string
+	Cursor       []byte
+	LastRunID    string
+	UpdatedAt    pgtype.Timestamptz
+}
+
+func (q *Queries) ListResourceCheckpoints(ctx context.Context, arg ListResourceCheckpointsParams) ([]*ListResourceCheckpointsRow, error) {
+	rows, err := q.db.Query(ctx, listResourceCheckpoints, arg.PipelineID, arg.PipelineVersionID, arg.RouteKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListResourceCheckpointsRow
+	for rows.Next() {
+		var i ListResourceCheckpointsRow
+		if err := rows.Scan(
+			&i.ResourceName,
+			&i.Cursor,
+			&i.LastRunID,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const loadResourceCheckpoint = `-- name: LoadResourceCheckpoint :one
 SELECT cursor, last_run_id, updated_at
 FROM pipeline_resource_checkpoints

--- a/datastore/postgres/store.go
+++ b/datastore/postgres/store.go
@@ -566,6 +566,33 @@ func (s *Store) LoadResourceCheckpoint(ctx context.Context, key filament.Resourc
 	}, nil
 }
 
+// ListResourceCheckpoints returns every durable cursor under one route,
+// ordered by resource.
+func (s *Store) ListResourceCheckpoints(ctx context.Context, route filament.ResourceCheckpointRoute) ([]filament.ResourceCheckpointState, error) {
+	rows, err := s.q.ListResourceCheckpoints(ctx, sqlcgen.ListResourceCheckpointsParams{
+		PipelineID: route.PipelineID, PipelineVersionID: route.PipelineVersionID, RouteKey: route.Route,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("datastore/postgres: list resource checkpoints: %w", err)
+	}
+	states := make([]filament.ResourceCheckpointState, 0, len(rows))
+	for _, row := range rows {
+		var raw map[string]any
+		if err := json.Unmarshal(row.Cursor, &raw); err != nil {
+			return nil, fmt.Errorf("datastore/postgres: unmarshal resource checkpoint: %w", err)
+		}
+		key := filament.ResourceCheckpointKey{
+			PipelineID: route.PipelineID, PipelineVersionID: route.PipelineVersionID,
+			Route: route.Route, Resource: row.ResourceName,
+		}
+		states = append(states, filament.ResourceCheckpointState{
+			Key: key, Run: filament.RunID(row.LastRunID), UpdatedAt: row.UpdatedAt.Time,
+			Checkpoint: &filament.CheckpointData{ResourceName: row.ResourceName, Cursor: raw},
+		})
+	}
+	return states, nil
+}
+
 // DeleteResourceCheckpoint resets durable progress for one route/resource.
 func (s *Store) DeleteResourceCheckpoint(ctx context.Context, key filament.ResourceCheckpointKey) error {
 	err := s.q.DeleteResourceCheckpoint(ctx, sqlcgen.DeleteResourceCheckpointParams{

--- a/eventbus/nats/nats.go
+++ b/eventbus/nats/nats.go
@@ -24,6 +24,11 @@ const (
 	defaultFetchWait   = 250 * time.Millisecond
 	defaultRequestWait = 5 * time.Second
 
+	// nakRedeliveryDelay spaces redeliveries of a nak'd message. A plain NAK
+	// redelivers immediately and the consumer BackOff schedule applies only to
+	// AckWait expiry, so without it a handler failing on a broken dependency
+	// spins the consumer.
+	nakRedeliveryDelay = time.Second
 	// ephemeralInactiveThreshold lets the server garbage-collect ephemeral
 	// consumers abandoned by a crashed process; live ones stay active by
 	// fetching and clean ones are deleted explicitly on Close.
@@ -424,6 +429,15 @@ func (s *subscription) consumer() jetstream.Consumer {
 	return s.cons
 }
 
+func (s *subscription) stopped() bool {
+	select {
+	case <-s.done:
+		return true
+	default:
+		return false
+	}
+}
+
 // recreate rebuilds the server-side consumer after it disappeared. A durable
 // recreated this way resumes per its deliver policy (DeliverAll replays and
 // relies on the consumer's dedup; DeliverNew tails).
@@ -444,10 +458,8 @@ func (s *subscription) pump() {
 	defer s.wg.Done()
 	var lastErr string
 	for {
-		select {
-		case <-s.done:
+		if s.stopped() {
 			return
-		default:
 		}
 
 		batch, err := s.consumer().Fetch(s.batch, jetstream.FetchMaxWait(defaultFetchWait))
@@ -481,6 +493,9 @@ func (s *subscription) pump() {
 			}
 		}
 
+		if s.stopped() {
+			return
+		}
 		if err.Error() != lastErr {
 			lastErr = err.Error()
 			s.bus.logf("eventbus/nats: fetch %q (durable %q): %v", s.route.Target, s.cfg.Durable, err)
@@ -520,7 +535,7 @@ func (m *message) Subject() string { return m.subject }
 func (m *message) Payload() any    { return m.payload }
 func (m *message) Seq() uint64     { return m.seq }
 func (m *message) Ack() error      { return m.msg.Ack() }
-func (m *message) Nak() error      { return m.msg.Nak() }
+func (m *message) Nak() error      { return m.msg.NakWithDelay(nakRedeliveryDelay) }
 
 func maxInFlight(opt, fallback int) int {
 	if opt > 0 {

--- a/infra.go
+++ b/infra.go
@@ -41,6 +41,7 @@ type DataStore interface {
 	LoadCheckpoint(ctx context.Context, id RunID, resource string) (Checkpoint, error)
 	SaveResourceCheckpoint(ctx context.Context, state ResourceCheckpointState) error
 	LoadResourceCheckpoint(ctx context.Context, key ResourceCheckpointKey) (ResourceCheckpointState, error)
+	ListResourceCheckpoints(ctx context.Context, route ResourceCheckpointRoute) ([]ResourceCheckpointState, error)
 	DeleteResourceCheckpoint(ctx context.Context, key ResourceCheckpointKey) error
 
 	DedupSeen(ctx context.Context, tenant string, run RunID, seq uint64) (bool, error)
@@ -92,6 +93,14 @@ type ResourceCheckpointKey struct {
 	PipelineVersionID string
 	Route             string
 	Resource          string
+}
+
+// ResourceCheckpointRoute identifies every resource cursor one pipeline
+// version keeps for one source-to-sink route.
+type ResourceCheckpointRoute struct {
+	PipelineID        string
+	PipelineVersionID string
+	Route             string
 }
 
 // ResourceCheckpointState is the durable cursor plus its most recent writer.

--- a/internal/modules/dispatch/k8s/helpers.go
+++ b/internal/modules/dispatch/k8s/helpers.go
@@ -7,6 +7,10 @@ import (
 	"strconv"
 	"strings"
 
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+
 	"github.com/galaxy-io/filament"
 )
 
@@ -38,6 +42,30 @@ func jobName(prefix string, run filament.RunID, executionID string) string {
 func executionToken(executionID string) string {
 	sum := sha256.Sum256([]byte(executionID))
 	return hex.EncodeToString(sum[:6])
+}
+
+// jobFinished reports whether the Job controller has stamped a terminal
+// condition. Pod counters can read zero mid-reconcile, so this is the boundary
+// the reaper's Alive probe trusts.
+func jobFinished(j *batchv1.Job) bool {
+	for _, condition := range j.Status.Conditions {
+		if condition.Status != corev1.ConditionTrue {
+			continue
+		}
+		if condition.Type == batchv1.JobComplete || condition.Type == batchv1.JobFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// k8sLabelValue returns value when it is a valid label value, else a stable
+// token derived from it.
+func k8sLabelValue(value string) string {
+	if len(validation.IsValidLabelValue(value)) == 0 {
+		return value
+	}
+	return executionToken(value)
 }
 
 func cleanDNS1123(s string) string {

--- a/internal/modules/dispatch/k8s/job.go
+++ b/internal/modules/dispatch/k8s/job.go
@@ -74,6 +74,12 @@ func (m *Module) jobLabels(spec filament.RunSpec) map[string]string {
 	if spec.ExecutionID != "" {
 		labels["filament.galaxy.io/execution-id"] = executionToken(spec.ExecutionID)
 	}
+	if spec.SourceConnectionID != "" {
+		labels["filament.galaxy.io/source-connection-id"] = k8sLabelValue(spec.SourceConnectionID)
+	}
+	if spec.SinkConnectionID != "" {
+		labels["filament.galaxy.io/sink-connection-id"] = k8sLabelValue(spec.SinkConnectionID)
+	}
 	return labels
 }
 

--- a/internal/modules/dispatch/k8s/job_test.go
+++ b/internal/modules/dispatch/k8s/job_test.go
@@ -5,10 +5,31 @@ import (
 	"reflect"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/galaxy-io/filament"
 )
+
+func TestJobFinishedRequiresTerminalCondition(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		job  batchv1.Job
+		want bool
+	}{
+		{name: "controller gap", job: batchv1.Job{}, want: false},
+		{name: "active", job: batchv1.Job{Status: batchv1.JobStatus{Active: 1}}, want: false},
+		{name: "complete", job: batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()}}}}, want: true},
+		{name: "failed", job: batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()}}}}, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jobFinished(&tt.job); got != tt.want {
+				t.Fatalf("jobFinished() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 // The Job is the entire contract between dispatch and the worker, so an unset
 // map must be absent rather than empty: an empty request list is still a
@@ -49,7 +70,10 @@ func TestWorkerResources(t *testing.T) {
 
 func TestJobAndPodLabelsMatch(t *testing.T) {
 	m := &Module{cfg: Config{WorkerImage: "worker:test", WorkerSecretName: "filament-secret", JobNamePrefix: "filament"}}
-	job, err := m.jobForSpec(filament.RunSpec{Tenant: "acme", Run: "run-1", ExecutionID: "attempt-1"})
+	job, err := m.jobForSpec(filament.RunSpec{
+		Tenant: "acme", Run: "run-1", ExecutionID: "attempt-1",
+		SourceConnectionID: "source-connection", SinkConnectionID: "sink-connection",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,6 +89,20 @@ func TestJobAndPodLabelsMatch(t *testing.T) {
 	}
 	if got := pod["filament.galaxy.io/execution-id"]; got != executionToken("attempt-1") {
 		t.Fatalf("pod execution-id label = %q", got)
+	}
+	if got := pod["filament.galaxy.io/source-connection-id"]; got != "source-connection" {
+		t.Fatalf("pod source connection label = %q", got)
+	}
+	if got := pod["filament.galaxy.io/sink-connection-id"]; got != "sink-connection" {
+		t.Fatalf("pod sink connection label = %q", got)
+	}
+}
+
+func TestInvalidConnectionIDUsesStableLabelToken(t *testing.T) {
+	value := "connection/id/that/is/not/a/kubernetes/label/value"
+	got := k8sLabelValue(value)
+	if got != executionToken(value) {
+		t.Fatalf("label value = %q, want stable token", got)
 	}
 }
 

--- a/internal/modules/dispatch/k8s/module.go
+++ b/internal/modules/dispatch/k8s/module.go
@@ -110,9 +110,10 @@ func (m *Module) Dispatch(ctx context.Context, spec filament.RunSpec) (filament.
 	return runHandle{run: spec.Run, ds: m.ds}, nil
 }
 
-// Alive reports whether the run's worker Job still has active pods. The reaper
-// consults it before killing a stale run: an active Job means the worker may
-// be alive but silent (heartbeats lost, not the worker), so the kill is held.
+// Alive reports whether Kubernetes still considers any Job for the run
+// unfinished. Job status can briefly report zero active pods while the
+// controller is reconciling, so absence of a terminal condition—not the active
+// counter—is the safe boundary for the reaper.
 func (m *Module) Alive(ctx context.Context, run filament.RunID) (bool, error) {
 	if m.client == nil {
 		return false, errors.New("k8sdispatch: module is not mounted")
@@ -122,7 +123,7 @@ func (m *Module) Alive(ctx context.Context, run filament.RunID) (bool, error) {
 		return false, err
 	}
 	for _, j := range jobs {
-		if j.Status.Active > 0 {
+		if !jobFinished(&j) {
 			return true, nil
 		}
 	}

--- a/internal/modules/dispatch/k8s/module.go
+++ b/internal/modules/dispatch/k8s/module.go
@@ -110,22 +110,24 @@ func (m *Module) Dispatch(ctx context.Context, spec filament.RunSpec) (filament.
 	return runHandle{run: spec.Run, ds: m.ds}, nil
 }
 
-// Alive reports whether Kubernetes still considers any Job for the run
-// unfinished. Job status can briefly report zero active pods while the
-// controller is reconciling, so absence of a terminal condition—not the active
-// counter—is the safe boundary for the reaper.
-func (m *Module) Alive(ctx context.Context, run filament.RunID) (bool, error) {
+// Workload reports the run's Job state for the reaper. A Job without a
+// terminal condition is Active even when its pod counter reads zero, which
+// happens briefly while the controller reconciles; a Job with one is Finished;
+// no Job at all is Absent.
+func (m *Module) Workload(ctx context.Context, run filament.RunID) (filament.Workload, error) {
 	if m.client == nil {
-		return false, errors.New("k8sdispatch: module is not mounted")
+		return filament.WorkloadAbsent, errors.New("k8sdispatch: module is not mounted")
 	}
 	jobs, err := m.client.listJobs(ctx, m.cfg.Namespace, "filament.galaxy.io/run-id="+string(run))
 	if err != nil {
-		return false, err
+		return filament.WorkloadAbsent, err
 	}
+	workload := filament.WorkloadAbsent
 	for _, j := range jobs {
 		if !jobFinished(&j) {
-			return true, nil
+			return filament.WorkloadActive, nil
 		}
+		workload = filament.WorkloadFinished
 	}
-	return false, nil
+	return workload, nil
 }

--- a/internal/modules/engine/engine.go
+++ b/internal/modules/engine/engine.go
@@ -66,6 +66,5 @@ func (m *Module) onRunRequested(ctx context.Context, ev events.Event[events.RunR
 	if !runner.ShouldRun(state) {
 		return nil // already running or finished — ack and ignore
 	}
-	runner.RunOne(ctx, m.deps, runner.SpecFromState(state))
-	return nil
+	return runner.RunOne(ctx, m.deps, runner.SpecFromState(state))
 }

--- a/internal/modules/reaper/reaper.go
+++ b/internal/modules/reaper/reaper.go
@@ -26,8 +26,8 @@ const (
 	defaultStaleAfter = 5 * time.Minute
 )
 
-// AliveCheck reports whether the dispatched workload for a run still exists.
-type AliveCheck func(ctx context.Context, run filament.RunID) (bool, error)
+// WorkloadProbe reports what the dispatcher can prove about a run's worker.
+type WorkloadProbe func(ctx context.Context, run filament.RunID) (filament.Workload, error)
 
 // Module is the staleness sweep over the run store.
 type Module struct {
@@ -35,7 +35,7 @@ type Module struct {
 	bus   eventbus.Bus
 	log   filament.Logger
 	mx    filament.Metrics
-	alive AliveCheck
+	probe WorkloadProbe
 
 	interval   time.Duration
 	staleAfter time.Duration
@@ -51,10 +51,12 @@ func WithInterval(d time.Duration) Option { return func(m *Module) { m.interval 
 // is declared dead (default 5m).
 func WithStaleAfter(d time.Duration) Option { return func(m *Module) { m.staleAfter = d } }
 
-// WithAliveCheck sets a dispatcher probe consulted before each kill: a stale
-// run whose workload is still up is held, since the worker may be alive with
-// its heartbeats lost. Without one, staleness alone decides.
-func WithAliveCheck(f AliveCheck) Option { return func(m *Module) { m.alive = f } }
+// WithWorkloadProbe sets the dispatcher probe consulted before each kill. A
+// stale run whose workload is still up is held, since the worker may be alive
+// with its heartbeats lost, and a Requested run is only judged dead once the
+// probe proves its workload ran and finished. Without one, staleness alone
+// decides and only Running runs are swept.
+func WithWorkloadProbe(f WorkloadProbe) Option { return func(m *Module) { m.probe = f } }
 
 // New returns an unmounted reaper; providers are injected by Mount and the
 // timer is launched by Start.
@@ -124,40 +126,45 @@ func (m *Module) Start(ctx context.Context) {
 	}()
 }
 
-// reap fails every Requested or Running run with no write inside the staleness
-// window. Requested covers a run whose worker exhausted its attempts before
-// publishing run.started; nothing else re-dispatches it, and while it sits
-// there it counts as active for the scheduler. The kill travels the bus as an
-// ordinary run.failed fact, so the tracker remains the only writer of terminal
-// state. One run's emit failure doesn't stop the sweep; the next tick retries
-// anything still stale.
+// reap fails every stale run the workload evidence says is dead. The kill
+// travels the bus as an ordinary run.failed fact, so the tracker remains the
+// only writer of terminal state. One run's emit failure doesn't stop the
+// sweep; the next tick retries anything still stale.
 func (m *Module) reap(ctx context.Context, now time.Time) error {
+	statuses := []filament.RunStatus{filament.RunRunning}
+	if m.probe != nil {
+		// A Requested run can only be judged with dispatch evidence.
+		statuses = append(statuses, filament.RunRequested)
+	}
 	stale, _, err := m.ds.ListRuns(ctx, filament.RunFilter{
-		Status:        []filament.RunStatus{filament.RunRequested, filament.RunRunning},
+		Status:        statuses,
 		UpdatedBefore: now.Add(-m.staleAfter),
 	})
 	if err != nil {
 		return err
 	}
 	for _, r := range stale {
-		if m.alive != nil {
-			alive, err := m.alive(ctx, r.Run)
+		workload := filament.WorkloadAbsent
+		if m.probe != nil {
+			workload, err = m.probe(ctx, r.Run)
 			if err != nil {
 				// Can't prove the workload is gone — hold the kill and let the
 				// next tick retry rather than fail a run that may still be live.
 				if m.log != nil {
-					m.log.Error("reaper: alive check", err, filament.Field{Key: "run", Value: string(r.Run)})
+					m.log.Error("reaper: workload probe", err, filament.Field{Key: "run", Value: string(r.Run)})
 				}
 				continue
 			}
-			if alive {
-				if m.log != nil {
-					m.log.Info("reaper: stale run's workload still up; holding",
-						filament.Field{Key: "run", Value: string(r.Run)},
-						filament.Field{Key: "stale_since", Value: r.UpdatedAt.UTC().Format(time.RFC3339)})
-				}
-				continue
+		}
+		if !dead(r.Status, workload) {
+			if m.log != nil {
+				m.log.Info("reaper: stale run held",
+					filament.Field{Key: "run", Value: string(r.Run)},
+					filament.Field{Key: "status", Value: int(r.Status)},
+					filament.Field{Key: "workload", Value: workload.String()},
+					filament.Field{Key: "stale_since", Value: r.UpdatedAt.UTC().Format(time.RFC3339)})
 			}
+			continue
 		}
 		err := events.Emit(ctx, m.bus, events.RunFailed,
 			events.Envelope{Tenant: r.Tenant, Run: r.Run, At: now},
@@ -179,4 +186,20 @@ func (m *Module) reap(ctx context.Context, now time.Time) error {
 		}
 	}
 	return nil
+}
+
+// dead decides whether a stale run's workload evidence warrants the kill.
+// Running dies unless its workload is provably still up; Absent there means
+// the platform already collected it. Requested dies only once the workload
+// provably ran and finished, because Absent may simply mean not dispatched
+// yet.
+func dead(status filament.RunStatus, workload filament.Workload) bool {
+	switch status {
+	case filament.RunRunning:
+		return workload != filament.WorkloadActive
+	case filament.RunRequested:
+		return workload == filament.WorkloadFinished
+	default:
+		return false
+	}
 }

--- a/internal/modules/reaper/reaper.go
+++ b/internal/modules/reaper/reaper.go
@@ -1,8 +1,9 @@
 // Package reaper is the zombie-run janitor: on each tick it finds runs stuck
-// in Running whose heartbeats stopped — a lost pod, an OOM-killed worker, a
-// crashed engine — and emits run.failed so the tracker folds them terminal.
-// Disaster recovery only; it plays no part in the normal lifecycle. Partial
-// runs are left alone: they hold resumable checkpoints.
+// in Requested or Running with no write in the staleness window — a worker
+// that never got admitted, a lost pod, an OOM-killed worker, a crashed engine
+// — and emits run.failed so the tracker folds them terminal. Disaster recovery
+// only; it plays no part in the normal lifecycle. Partial runs are left alone:
+// they hold resumable checkpoints.
 package reaper
 
 import (
@@ -123,13 +124,16 @@ func (m *Module) Start(ctx context.Context) {
 	}()
 }
 
-// reap fails every Running run with no write inside the staleness window. The
-// kill travels the bus as an ordinary run.failed fact, so the tracker remains
-// the only writer of terminal state. One run's emit failure doesn't stop the
-// sweep; the next tick retries anything still stale.
+// reap fails every Requested or Running run with no write inside the staleness
+// window. Requested covers a run whose worker exhausted its attempts before
+// publishing run.started; nothing else re-dispatches it, and while it sits
+// there it counts as active for the scheduler. The kill travels the bus as an
+// ordinary run.failed fact, so the tracker remains the only writer of terminal
+// state. One run's emit failure doesn't stop the sweep; the next tick retries
+// anything still stale.
 func (m *Module) reap(ctx context.Context, now time.Time) error {
 	stale, _, err := m.ds.ListRuns(ctx, filament.RunFilter{
-		Status:        []filament.RunStatus{filament.RunRunning},
+		Status:        []filament.RunStatus{filament.RunRequested, filament.RunRunning},
 		UpdatedBefore: now.Add(-m.staleAfter),
 	})
 	if err != nil {

--- a/internal/modules/reaper/reaper_test.go
+++ b/internal/modules/reaper/reaper_test.go
@@ -1,0 +1,27 @@
+package reaper
+
+import (
+	"testing"
+
+	"github.com/galaxy-io/filament"
+)
+
+func TestDeadNeedsDispatchEvidenceForRequested(t *testing.T) {
+	for _, tt := range []struct {
+		status   filament.RunStatus
+		workload filament.Workload
+		want     bool
+	}{
+		{filament.RunRunning, filament.WorkloadAbsent, true},
+		{filament.RunRunning, filament.WorkloadActive, false},
+		{filament.RunRunning, filament.WorkloadFinished, true},
+		{filament.RunRequested, filament.WorkloadAbsent, false},
+		{filament.RunRequested, filament.WorkloadActive, false},
+		{filament.RunRequested, filament.WorkloadFinished, true},
+		{filament.RunPartial, filament.WorkloadFinished, false},
+	} {
+		if got := dead(tt.status, tt.workload); got != tt.want {
+			t.Errorf("dead(%v, %v) = %v, want %v", tt.status, tt.workload, got, tt.want)
+		}
+	}
+}

--- a/run.go
+++ b/run.go
@@ -20,15 +20,17 @@ type RunSpec struct {
 	// ExecutionID identifies one dispatch attempt of a logical run. Dispatchers
 	// derive it from the run.requested fact so redelivery is idempotent while a
 	// later resume creates fresh worker infrastructure.
-	ExecutionID       string
-	PipelineID        string
-	PipelineVersionID string
-	CheckpointRoute   string
-	CursorConfigs     map[string]ResourceCursorConfig
-	Source            Ref
-	Sink              Ref
-	Resources         []string
-	Selectors         []string
+	ExecutionID        string
+	PipelineID         string
+	PipelineVersionID  string
+	SourceConnectionID string
+	SinkConnectionID   string
+	CheckpointRoute    string
+	CursorConfigs      map[string]ResourceCursorConfig
+	Source             Ref
+	Sink               Ref
+	Resources          []string
+	Selectors          []string
 	// IngestionTypes maps each resource to its ingestion type; the "" entry is
 	// the route default for resources not explicitly listed.
 	IngestionTypes map[string]IngestionType

--- a/run.go
+++ b/run.go
@@ -281,6 +281,34 @@ const (
 	RunScheduled
 )
 
+// Workload is what a dispatcher can prove about the worker it launched for a
+// run. The reaper reads it to tell a dead run from one that is slow to start
+// or alive but silent.
+type Workload int
+
+// Workload states, from least to most evidence of a completed attempt.
+const (
+	// WorkloadAbsent means no workload exists for the run: it was never
+	// dispatched, or the platform has already garbage-collected it.
+	WorkloadAbsent Workload = iota
+	// WorkloadActive means the workload exists and has not finished.
+	WorkloadActive
+	// WorkloadFinished means the workload ran to a terminal outcome.
+	WorkloadFinished
+)
+
+func (w Workload) String() string {
+	switch w {
+	case WorkloadAbsent:
+		return "absent"
+	case WorkloadActive:
+		return "active"
+	case WorkloadFinished:
+		return "finished"
+	}
+	return "unknown"
+}
+
 // RunResult is the terminal outcome of a run as reported by a RunHandle.
 type RunResult struct {
 	Status  RunStatus

--- a/runner/ack.go
+++ b/runner/ack.go
@@ -1,0 +1,92 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/checkpoint"
+)
+
+const durableChangeAckWait = 5 * time.Second
+
+// acknowledgeDurableChanges releases source-side stream retention once the
+// tracker has promoted every final cursor into the cross-run checkpoint store.
+// Failure is deliberately non-terminal: the sink is already committed, and the
+// next CDC cycle retries the acknowledgement. Detached from run cancellation so
+// shutdown cannot skip it, bounded so a lagging tracker cannot hang the worker.
+func acknowledgeDurableChanges(
+	ctx context.Context,
+	deps Deps,
+	spec filament.RunSpec,
+	src filament.Source,
+	targets map[string]filament.Checkpoint,
+) {
+	ack, ok := src.(filament.ChangeAcknowledger)
+	if !ok || deps.DataStore == nil || len(targets) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), durableChangeAckWait)
+	defer cancel()
+	durable, err := waitForDurableStreamCheckpoints(ctx, deps.DataStore, spec, targets)
+	if err == nil {
+		err = ack.AcknowledgeChanges(ctx, durable)
+	}
+	if err != nil && deps.Log != nil {
+		deps.Log.Warn("runner: acknowledge durable change checkpoint",
+			filament.Field{Key: "run", Value: string(spec.Run)},
+			filament.Field{Key: "error", Value: err.Error()})
+	}
+}
+
+func waitForDurableStreamCheckpoints(
+	ctx context.Context,
+	ds filament.DataStore,
+	spec filament.RunSpec,
+	targets map[string]filament.Checkpoint,
+) (map[string]filament.Checkpoint, error) {
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		durable := make(map[string]filament.Checkpoint, len(targets))
+		ready := true
+		for resource, target := range targets {
+			key, ok := spec.ResourceCheckpointKey(resource)
+			if !ok {
+				return nil, fmt.Errorf("CDC resource %q has no durable checkpoint route", resource)
+			}
+			state, err := ds.LoadResourceCheckpoint(ctx, key)
+			if err != nil {
+				if errors.Is(err, filament.ErrNotFound) {
+					ready = false
+					break
+				}
+				return nil, err
+			}
+			if !streamCheckpointReached(state.Checkpoint, target) {
+				ready = false
+				break
+			}
+			durable[resource] = state.Checkpoint
+		}
+		if ready {
+			return durable, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func streamCheckpointReached(durable, target filament.Checkpoint) bool {
+	durableLSN, durableSeq, durableOK := checkpoint.ParseStream(durable)
+	targetLSN, targetSeq, targetOK := checkpoint.ParseStream(target)
+	if !durableOK || !targetOK || durableSeq < targetSeq {
+		return false
+	}
+	return durableSeq > targetSeq || durableLSN == targetLSN
+}

--- a/runner/ack.go
+++ b/runner/ack.go
@@ -10,13 +10,22 @@ import (
 	"github.com/galaxy-io/filament/checkpoint"
 )
 
-const durableChangeAckWait = 5 * time.Second
+// durableChangeAckWait bounds one acknowledgement. It must outlast both a
+// lagging tracker promotion and the source's own wait for a peer to release
+// the stream.
+const durableChangeAckWait = 30 * time.Second
 
-// acknowledgeDurableChanges releases source-side stream retention once the
-// tracker has promoted every final cursor into the cross-run checkpoint store.
-// Failure is deliberately non-terminal: the sink is already committed, and the
-// next CDC cycle retries the acknowledgement. Detached from run cancellation so
-// shutdown cannot skip it, bounded so a lagging tracker cannot hang the worker.
+// acknowledgeDurableChanges releases source-side stream retention up to the
+// route floor: the oldest durable cursor of every resource under the run's
+// checkpoint route, not only this run's. A run covering a subset of the
+// route's resources must never advance past the ones it left out.
+//
+// Called at run start, when everything in the store is already durable, and
+// at run end once the tracker has promoted this run's final cursors (targets).
+// An acknowledgement skipped at the end of one run is therefore repeated at
+// the start of the next. Failure is non-terminal: the sink is already
+// committed. Detached from run cancellation so shutdown cannot skip it,
+// bounded so a lagging tracker cannot hang the worker.
 func acknowledgeDurableChanges(
 	ctx context.Context,
 	deps Deps,
@@ -25,14 +34,18 @@ func acknowledgeDurableChanges(
 	targets map[string]filament.Checkpoint,
 ) {
 	ack, ok := src.(filament.ChangeAcknowledger)
-	if !ok || deps.DataStore == nil || len(targets) == 0 {
+	if !ok || deps.DataStore == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), durableChangeAckWait)
 	defer cancel()
-	durable, err := waitForDurableStreamCheckpoints(ctx, deps.DataStore, spec, targets)
+	err := waitForDurableStreamCheckpoints(ctx, deps.DataStore, spec, targets)
+	var floor map[string]filament.Checkpoint
 	if err == nil {
-		err = ack.AcknowledgeChanges(ctx, durable)
+		floor, err = routeStreamCheckpoints(ctx, deps.DataStore, spec)
+	}
+	if err == nil && len(floor) > 0 {
+		err = ack.AcknowledgeChanges(ctx, floor)
 	}
 	if err != nil && deps.Log != nil {
 		deps.Log.Warn("runner: acknowledge durable change checkpoint",
@@ -41,45 +54,66 @@ func acknowledgeDurableChanges(
 	}
 }
 
+// waitForDurableStreamCheckpoints blocks until the store holds a cursor at or
+// beyond each target, i.e. until the tracker has promoted this run's progress.
 func waitForDurableStreamCheckpoints(
 	ctx context.Context,
 	ds filament.DataStore,
 	spec filament.RunSpec,
 	targets map[string]filament.Checkpoint,
-) (map[string]filament.Checkpoint, error) {
+) error {
+	if len(targets) == 0 {
+		return nil
+	}
 	ticker := time.NewTicker(25 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		durable := make(map[string]filament.Checkpoint, len(targets))
 		ready := true
 		for resource, target := range targets {
 			key, ok := spec.ResourceCheckpointKey(resource)
 			if !ok {
-				return nil, fmt.Errorf("CDC resource %q has no durable checkpoint route", resource)
+				return fmt.Errorf("CDC resource %q has no durable checkpoint route", resource)
 			}
 			state, err := ds.LoadResourceCheckpoint(ctx, key)
-			if err != nil {
-				if errors.Is(err, filament.ErrNotFound) {
-					ready = false
-					break
-				}
-				return nil, err
-			}
-			if !streamCheckpointReached(state.Checkpoint, target) {
+			if errors.Is(err, filament.ErrNotFound) || (err == nil && !streamCheckpointReached(state.Checkpoint, target)) {
 				ready = false
 				break
 			}
-			durable[resource] = state.Checkpoint
+			if err != nil {
+				return err
+			}
 		}
 		if ready {
-			return durable, nil
+			return nil
 		}
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return ctx.Err()
 		case <-ticker.C:
 		}
 	}
+}
+
+// routeStreamCheckpoints returns every durable stream cursor under the run's
+// checkpoint route, keyed by resource. Cursors of other shapes (incremental
+// columns) share the route but not the stream and are left out.
+func routeStreamCheckpoints(ctx context.Context, ds filament.DataStore, spec filament.RunSpec) (map[string]filament.Checkpoint, error) {
+	if spec.PipelineID == "" || spec.PipelineVersionID == "" || spec.CheckpointRoute == "" {
+		return nil, nil
+	}
+	states, err := ds.ListResourceCheckpoints(ctx, filament.ResourceCheckpointRoute{
+		PipelineID: spec.PipelineID, PipelineVersionID: spec.PipelineVersionID, Route: spec.CheckpointRoute,
+	})
+	if err != nil {
+		return nil, err
+	}
+	floor := make(map[string]filament.Checkpoint, len(states))
+	for _, state := range states {
+		if _, _, ok := checkpoint.ParseStream(state.Checkpoint); ok {
+			floor[state.Key.Resource] = state.Checkpoint
+		}
+	}
+	return floor, nil
 }
 
 func streamCheckpointReached(durable, target filament.Checkpoint) bool {

--- a/runner/ack_test.go
+++ b/runner/ack_test.go
@@ -1,0 +1,55 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/checkpoint"
+	"github.com/galaxy-io/filament/datastore/memory"
+)
+
+func TestWaitForDurableStreamCheckpointsRejectsOlderCursor(t *testing.T) {
+	store := memory.New()
+	spec := filament.RunSpec{
+		Run: "run", PipelineID: "pipeline", PipelineVersionID: "version",
+		CheckpointRoute: "route", Resources: []string{"users"},
+	}
+	key, _ := spec.ResourceCheckpointKey("users")
+	if err := store.SaveResourceCheckpoint(context.Background(), filament.ResourceCheckpointState{
+		Key: key, Run: "older", Checkpoint: checkpoint.NewStreamDelta("users", "0/10", 4),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := waitForDurableStreamCheckpoints(ctx, store, spec, map[string]filament.Checkpoint{
+		"users": checkpoint.NewStreamDelta("users", "0/20", 4),
+	})
+	if err == nil {
+		t.Fatal("older durable cursor satisfied final checkpoint")
+	}
+}
+
+func TestWaitForDurableStreamCheckpointsReturnsPromotedCursor(t *testing.T) {
+	store := memory.New()
+	spec := filament.RunSpec{
+		Run: "run", PipelineID: "pipeline", PipelineVersionID: "version",
+		CheckpointRoute: "route", Resources: []string{"users"},
+	}
+	target := checkpoint.NewStreamDelta("users", "0/20", 4)
+	key, _ := spec.ResourceCheckpointKey("users")
+	if err := store.SaveResourceCheckpoint(context.Background(), filament.ResourceCheckpointState{
+		Key: key, Run: spec.Run, Checkpoint: target,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	durable, err := waitForDurableStreamCheckpoints(context.Background(), store, spec, map[string]filament.Checkpoint{"users": target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !streamCheckpointReached(durable["users"], target) {
+		t.Fatalf("durable checkpoint = %#v, want target %#v", durable["users"], target)
+	}
+}

--- a/runner/ack_test.go
+++ b/runner/ack_test.go
@@ -10,21 +10,38 @@ import (
 	"github.com/galaxy-io/filament/datastore/memory"
 )
 
-func TestWaitForDurableStreamCheckpointsRejectsOlderCursor(t *testing.T) {
-	store := memory.New()
-	spec := filament.RunSpec{
+type ackTestSource struct {
+	incrementalTestSource
+	acknowledged map[string]filament.Checkpoint
+}
+
+func (s *ackTestSource) AcknowledgeChanges(_ context.Context, cps map[string]filament.Checkpoint) error {
+	s.acknowledged = cps
+	return nil
+}
+
+func ackTestSpec() filament.RunSpec {
+	return filament.RunSpec{
 		Run: "run", PipelineID: "pipeline", PipelineVersionID: "version",
 		CheckpointRoute: "route", Resources: []string{"users"},
 	}
-	key, _ := spec.ResourceCheckpointKey("users")
-	if err := store.SaveResourceCheckpoint(context.Background(), filament.ResourceCheckpointState{
-		Key: key, Run: "older", Checkpoint: checkpoint.NewStreamDelta("users", "0/10", 4),
-	}); err != nil {
+}
+
+func saveRouteCheckpoint(t *testing.T, store *memory.Store, spec filament.RunSpec, resource string, run filament.RunID, cp filament.Checkpoint) {
+	t.Helper()
+	key, _ := spec.ResourceCheckpointKey(resource)
+	if err := store.SaveResourceCheckpoint(context.Background(), filament.ResourceCheckpointState{Key: key, Run: run, Checkpoint: cp}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestWaitForDurableStreamCheckpointsRejectsOlderCursor(t *testing.T) {
+	store := memory.New()
+	spec := ackTestSpec()
+	saveRouteCheckpoint(t, store, spec, "users", "older", checkpoint.NewStreamDelta("users", "0/10", 4))
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	_, err := waitForDurableStreamCheckpoints(ctx, store, spec, map[string]filament.Checkpoint{
+	err := waitForDurableStreamCheckpoints(ctx, store, spec, map[string]filament.Checkpoint{
 		"users": checkpoint.NewStreamDelta("users", "0/20", 4),
 	})
 	if err == nil {
@@ -32,24 +49,53 @@ func TestWaitForDurableStreamCheckpointsRejectsOlderCursor(t *testing.T) {
 	}
 }
 
-func TestWaitForDurableStreamCheckpointsReturnsPromotedCursor(t *testing.T) {
+func TestWaitForDurableStreamCheckpointsReturnsOncePromoted(t *testing.T) {
 	store := memory.New()
-	spec := filament.RunSpec{
-		Run: "run", PipelineID: "pipeline", PipelineVersionID: "version",
-		CheckpointRoute: "route", Resources: []string{"users"},
-	}
+	spec := ackTestSpec()
 	target := checkpoint.NewStreamDelta("users", "0/20", 4)
-	key, _ := spec.ResourceCheckpointKey("users")
-	if err := store.SaveResourceCheckpoint(context.Background(), filament.ResourceCheckpointState{
-		Key: key, Run: spec.Run, Checkpoint: target,
-	}); err != nil {
+	saveRouteCheckpoint(t, store, spec, "users", spec.Run, target)
+	if err := waitForDurableStreamCheckpoints(context.Background(), store, spec, map[string]filament.Checkpoint{"users": target}); err != nil {
 		t.Fatal(err)
 	}
-	durable, err := waitForDurableStreamCheckpoints(context.Background(), store, spec, map[string]filament.Checkpoint{"users": target})
-	if err != nil {
-		t.Fatal(err)
+}
+
+// A run that covered only users must still hand the source the older orders
+// cursor, so the stream is never released past a resource the run left out.
+// Cursors that are not stream positions share the route but not the stream.
+func TestAcknowledgeDurableChangesUsesRouteFloor(t *testing.T) {
+	store := memory.New()
+	spec := ackTestSpec()
+	target := checkpoint.NewStreamDelta("users", "0/20", 4)
+	saveRouteCheckpoint(t, store, spec, "users", spec.Run, target)
+	saveRouteCheckpoint(t, store, spec, "orders", "older", checkpoint.NewStreamDelta("orders", "0/10", 2))
+	saveRouteCheckpoint(t, store, spec, "events", "older", &filament.CheckpointData{ResourceName: "events", Cursor: map[string]any{"cursor": "2026-01-01"}})
+
+	src := &ackTestSource{}
+	acknowledgeDurableChanges(context.Background(), Deps{DataStore: store}, spec, src, map[string]filament.Checkpoint{"users": target})
+
+	if _, ok := src.acknowledged["orders"]; !ok {
+		t.Fatalf("acknowledged = %v, want the omitted orders cursor", src.acknowledged)
 	}
-	if !streamCheckpointReached(durable["users"], target) {
-		t.Fatalf("durable checkpoint = %#v, want target %#v", durable["users"], target)
+	if !streamCheckpointReached(src.acknowledged["users"], target) {
+		t.Fatalf("users cursor = %#v, want %#v", src.acknowledged["users"], target)
+	}
+	if _, ok := src.acknowledged["events"]; ok {
+		t.Fatal("incremental cursor was offered as a stream position")
+	}
+}
+
+// At run start nothing is pending, so whatever the store holds is acknowledged
+// as is: this repeats an acknowledgement the previous run could not finish.
+func TestAcknowledgeDurableChangesAtRunStart(t *testing.T) {
+	store := memory.New()
+	spec := ackTestSpec()
+	saveRouteCheckpoint(t, store, spec, "users", "older", checkpoint.NewStreamDelta("users", "0/20", 4))
+	saveRouteCheckpoint(t, store, spec, "orders", "older", checkpoint.NewStreamDelta("orders", "0/10", 2))
+
+	src := &ackTestSource{}
+	acknowledgeDurableChanges(context.Background(), Deps{DataStore: store}, spec, src, nil)
+
+	if len(src.acknowledged) != 2 {
+		t.Fatalf("acknowledged = %v, want both route cursors", src.acknowledged)
 	}
 }

--- a/runner/emitter.go
+++ b/runner/emitter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/checkpoint"
 	"github.com/galaxy-io/filament/eventbus"
 	"github.com/galaxy-io/filament/events"
 )
@@ -30,6 +31,9 @@ type emitter struct {
 	runRecords int64
 	runBytes   int64
 	res        map[string]*tally
+	// latestStream is the newest stream checkpoint seen per resource, merged
+	// from batch.written; it is what the run asks the source to acknowledge.
+	latestStream map[string]filament.Checkpoint
 }
 
 type tally struct {
@@ -38,7 +42,10 @@ type tally struct {
 }
 
 func newEmitter(ctx context.Context, bus eventbus.Bus, log filament.Logger, tenant filament.TenantID, run filament.RunID) *emitter {
-	return &emitter{ctx: ctx, bus: bus, log: log, tenant: tenant, run: run, res: map[string]*tally{}}
+	return &emitter{
+		ctx: ctx, bus: bus, log: log, tenant: tenant, run: run,
+		res: map[string]*tally{}, latestStream: map[string]filament.Checkpoint{},
+	}
 }
 
 // seedProgress carries durable progress from a prior paused attempt into this
@@ -91,7 +98,10 @@ func (e *emitter) finish() context.CancelFunc {
 // cancellation because RunOne detaches the emitter first (see finish). Safe to
 // call concurrently — the pipeline's writer goroutine publishes batch facts
 // while the run goroutine publishes lifecycle facts.
-func (e *emitter) publish(f events.Fact) {
+//
+// The transport error is returned for the one fact that gates execution,
+// run.started; every other caller treats publishing as best-effort.
+func (e *emitter) publish(f events.Fact) error {
 	if d, ok := f.Data.(events.BatchWrittenEvent); ok {
 		e.mu.Lock()
 		e.runRecords += d.Records
@@ -103,6 +113,11 @@ func (e *emitter) publish(f events.Fact) {
 		}
 		t.records += d.Records
 		t.bytes += d.Bytes
+		if d.Checkpoint != nil {
+			if _, _, ok := checkpoint.ParseStream(d.Checkpoint); ok {
+				e.latestStream[f.Resource] = checkpoint.MergeStream(e.latestStream[f.Resource], d.Checkpoint)
+			}
+		}
 		e.mu.Unlock()
 	}
 	if e.log != nil {
@@ -129,9 +144,24 @@ func (e *emitter) publish(f events.Fact) {
 			e.log.Info(f.Name, fields...)
 		}
 	}
-	if err := events.Publish(e.ctx, e.bus, f); err != nil && e.log != nil {
-		e.log.Error("runner: publish fact", err, filament.Field{Key: "type", Value: f.Name})
+	if err := events.Publish(e.ctx, e.bus, f); err != nil {
+		if e.log != nil {
+			e.log.Error("runner: publish fact", err, filament.Field{Key: "type", Value: f.Name})
+		}
+		return err
 	}
+	return nil
+}
+
+// streamCheckpoints returns a copy of the newest stream checkpoint per resource.
+func (e *emitter) streamCheckpoints() map[string]filament.Checkpoint {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make(map[string]filament.Checkpoint, len(e.latestStream))
+	for resource, cp := range e.latestStream {
+		out[resource] = cp
+	}
+	return out
 }
 
 // factProgress flattens a typed payload's progress counters and error for logging.
@@ -163,11 +193,11 @@ func factProgress(f events.Fact) (records, bytes int64, errMsg string, hasProgre
 // emit stamps and publishes a run-originated fact for a run or resource.
 // (A free function: Go methods cannot take type parameters.)
 func emit[T any](e *emitter, t events.EventType[T], resource string, data T) {
-	emitAt(e, t, resource, time.Now(), data)
+	_ = emitAt(e, t, resource, time.Now(), data)
 }
 
-func emitAt[T any](e *emitter, t events.EventType[T], resource string, at time.Time, data T) {
-	e.publish(events.NewFact(t, events.Envelope{
+func emitAt[T any](e *emitter, t events.EventType[T], resource string, at time.Time, data T) error {
+	return e.publish(events.NewFact(t, events.Envelope{
 		Tenant:   e.tenant,
 		Run:      e.run,
 		Resource: resource,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -44,6 +44,7 @@ func SpecFromState(s filament.RunState) filament.RunSpec {
 	return filament.RunSpec{
 		Tenant: r.Tenant, Run: s.Run, StartedAt: s.StartedAt,
 		PipelineID: r.PipelineID, PipelineVersionID: r.PipelineVersionID,
+		SourceConnectionID: r.SourceConnectionID, SinkConnectionID: r.SinkConnectionID,
 		CheckpointRoute: r.CheckpointRoute, CursorConfigs: r.CursorConfigs,
 		Source: r.Source, Sink: r.Sink, Resources: r.Resources, Selectors: r.Selectors,
 		IngestionTypes: r.IngestionTypes, Options: r.Options,
@@ -74,72 +75,70 @@ func ShouldRun(state filament.RunState) bool {
 // run.started first and exactly one terminal fact (run.completed | run.failed |
 // run.partial | run.paused | run.canceled).
 //
+// A non-nil return means execution was not admitted (see admit). Once
+// admitted, outcomes travel as terminal facts and RunOne returns nil.
+//
 //nolint:funlen // the run lifecycle reads best as one sequence
-func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
-	var span filament.Span
-	if deps.Tracer != nil {
-		ctx, span = deps.Tracer.Start(ctx, "filament.run")
-		defer span.End()
-		span.SetAttr("run", string(spec.Run))
-		span.SetAttr("tenant", string(spec.Tenant))
-		span.SetAttr("source", spec.Source.Connector)
-		span.SetAttr("sink", spec.Sink.Connector)
-	}
+func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) error {
+	ctx, span, endSpan := startRunSpan(ctx, deps, spec)
+	defer endSpan()
 
 	em := newEmitter(ctx, deps.Bus, deps.Log, spec.Tenant, spec.Run)
 	em.span = span
 	extractCtx, control, err := prepareRunExecution(ctx, deps, spec, em)
 	if err != nil {
 		em.failed(err, nil, false)
-		return
+		return nil
 	}
 	defer control.close()
 	runStartedAt := startedAtFor(spec)
-	emitAt(em, events.RunStarted, "", runStartedAt, events.RunStartedEvent{})
+	if err := admit(em, runStartedAt); err != nil {
+		return err
+	}
 
 	if err := ResolveConfigRefs(extractCtx, deps.Secrets, &spec); err != nil {
 		if emitControlledIfStopped(extractCtx, err, control, em) {
-			return
+			return nil
 		}
 		em.failed(err, nil, false)
-		return
+		return nil
 	}
 
 	src, err := deps.Sources.Resolve(spec.Source.Connector)
 	if err != nil {
 		em.failed(fmt.Errorf("resolve source %q: %w", spec.Source.Connector, err), nil, false)
-		return
+		return nil
 	}
 	if err := src.Configure(extractCtx, filament.NewConfig(spec.Source.Config)); err != nil {
 		if emitControlledIfStopped(extractCtx, err, control, em) {
-			return
+			return nil
 		}
 		em.failed(fmt.Errorf("configure source %q: %w", spec.Source.Connector, err), nil, false)
-		return
+		return nil
 	}
 	defer func() { _ = src.Teardown(ctx) }()
 	plannedResources, err := PlanResources(extractCtx, src, spec.Resources, spec.Selectors)
 	if err != nil {
 		if emitControlledIfStopped(extractCtx, err, control, em) {
-			return
+			return nil
 		}
 		em.failed(fmt.Errorf("plan resources: %w", err), nil, false)
-		return
+		return nil
 	}
 	spec.Resources = plannedResources
 
 	snk, err := deps.Sinks.Resolve(spec.Sink.Connector)
 	if err != nil {
 		em.failed(fmt.Errorf("resolve sink %q: %w", spec.Sink.Connector, err), nil, false)
-		return
+		return nil
 	}
 	plan, err := filament.ResolveIngestionPlan(extractCtx, src, snk, spec)
 	if err != nil {
 		if emitControlledIfStopped(extractCtx, err, control, em) {
-			return
+			return nil
 		}
 		em.failed(err, nil, false)
-		return
+		return nil
 	}
 	spec.WritePolicies = plan.WritePolicies
 	// Ordered reads (incremental cursors, CDC streams, checkpointed resume)
@@ -150,10 +149,10 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	}
 	if err := snk.Open(extractCtx, spec); err != nil {
 		if emitControlledIfStopped(extractCtx, err, control, em) {
-			return
+			return nil
 		}
 		em.failed(fmt.Errorf("open sink %q: %w", spec.Sink.Connector, err), nil, false)
-		return
+		return nil
 	}
 
 	// A schema-aware sink needs typed DDL before any write. When the source can
@@ -162,10 +161,10 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	if err := ensureSchemas(extractCtx, src, snk, spec); err != nil {
 		abortSink(ctx, deps, spec, snk)
 		if emitControlledIfStopped(extractCtx, err, control, em) {
-			return
+			return nil
 		}
 		em.failed(fmt.Errorf("ensure schema: %w", err), nil, false)
-		return
+		return nil
 	}
 
 	// Announce the resources this run will touch (when known up front).
@@ -177,17 +176,17 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	if err != nil {
 		abortSink(ctx, deps, spec, snk)
 		if emitControlledIfStopped(extractCtx, err, control, em) {
-			return
+			return nil
 		}
 		em.failed(err, spec.Resources, false)
-		return
+		return nil
 	}
 
 	p := pipeline.New(pipeline.Config{
 		Tenant:        spec.Tenant,
 		Run:           spec.Run,
 		Sink:          snk,
-		Emit:          em.publish,
+		Emit:          func(f events.Fact) { _ = em.publish(f) },
 		NextSeq:       em.next,
 		WritePolicies: plan.WritePolicies,
 		Options:       spec.Options,
@@ -231,32 +230,61 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) {
 	resources := resolveResources(spec.Resources, em.seenResources())
 	if waitErr == nil && stoppedByControl(extractCtx, extractErr, control.requested()) {
 		finishControlled(ctx, deps, spec, plan, snk, em, resources, control.seal())
-		return
+		return nil
 	}
 
 	if runErr != nil {
 		resumable := isResumableRun(spec, plan)
 		em.failed(runErr, resources, resumable)
 		if resumable {
-			return
+			return nil
 		}
 		// Abort after the obituary, on its own detached context: cleanup must
 		// not eat the terminal publish window, and a slow sink must not strand
 		// the row in RunRunning.
 		abortSink(ctx, deps, spec, snk)
-		return
+		return nil
 	}
 
 	if signal := control.seal(); signal != controlNone {
 		finishControlled(ctx, deps, spec, plan, snk, em, resources, signal)
-		return
+		return nil
 	}
 	if err := snk.Commit(ctx); err != nil {
 		em.failed(fmt.Errorf("commit sink %q: %w", spec.Sink.Connector, err), resources, false)
 		abortSink(ctx, deps, spec, snk)
-		return
+		return nil
 	}
 	em.completed(resources)
+	acknowledgeDurableChanges(ctx, deps, spec, src, em.streamCheckpoints())
+	return nil
+}
+
+// startRunSpan opens the run's trace span when a tracer is configured. Without
+// one the span is nil, which the emitter tolerates, and endSpan is a no-op.
+func startRunSpan(ctx context.Context, deps Deps, spec filament.RunSpec) (_ context.Context, span filament.Span, endSpan func()) {
+	if deps.Tracer == nil {
+		return ctx, nil, func() {}
+	}
+	ctx, span = deps.Tracer.Start(ctx, "filament.run")
+	span.SetAttr("run", string(spec.Run))
+	span.SetAttr("tenant", string(spec.Tenant))
+	span.SetAttr("source", spec.Source.Connector)
+	span.SetAttr("sink", spec.Sink.Connector)
+	return ctx, span, span.End
+}
+
+// admit publishes run.started, the one fact that gates execution. On failure
+// it leaves a best-effort run.failed obituary: the broker may have stored the
+// fact despite the failed ack, and a Running row with no worker behind it
+// would otherwise wait on the reaper.
+func admit(em *emitter, startedAt time.Time) error {
+	if err := emitAt(em, events.RunStarted, "", startedAt, events.RunStartedEvent{}); err != nil {
+		notAdmitted := fmt.Errorf("publish run.started: %w", err)
+		em.failed(notAdmitted, nil, false)
+		return notAdmitted
+	}
+	return nil
 }
 
 func startedAtFor(spec filament.RunSpec) time.Time {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -181,6 +181,10 @@ func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) error {
 		em.failed(err, spec.Resources, false)
 		return nil
 	}
+	// Everything already in the checkpoint store is durable, so release stream
+	// retention up to it now; this repeats any acknowledgement the previous
+	// run could not complete.
+	acknowledgeDurableChanges(ctx, deps, spec, src, nil)
 
 	p := pipeline.New(pipeline.Config{
 		Tenant:        spec.Tenant,
@@ -275,14 +279,13 @@ func startRunSpan(ctx context.Context, deps Deps, spec filament.RunSpec) (_ cont
 }
 
 // admit publishes run.started, the one fact that gates execution. On failure
-// it leaves a best-effort run.failed obituary: the broker may have stored the
-// fact despite the failed ack, and a Running row with no worker behind it
-// would otherwise wait on the reaper.
+// the run is left as it was, Requested, so the dispatcher's retry executes it.
+// No obituary is published: it would turn a transient broker fault into a
+// terminal run. A fact the broker stored despite a failed ack leaves a
+// Running row with no worker, which the reaper resolves.
 func admit(em *emitter, startedAt time.Time) error {
 	if err := emitAt(em, events.RunStarted, "", startedAt, events.RunStartedEvent{}); err != nil {
-		notAdmitted := fmt.Errorf("publish run.started: %w", err)
-		em.failed(notAdmitted, nil, false)
-		return notAdmitted
+		return fmt.Errorf("publish run.started: %w", err)
 	}
 	return nil
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -102,6 +102,86 @@ func TestRunOneDoesNotExecuteWithoutPublishedStart(t *testing.T) {
 	}
 }
 
+// publishFailOnceBus fails the first publish only, the shape of a transient
+// broker fault at worker start.
+type publishFailOnceBus struct {
+	eventbus.Bus
+	failed atomic.Bool
+}
+
+func (b *publishFailOnceBus) Publish(ctx context.Context, subject string, payload any) error {
+	if b.failed.CompareAndSwap(false, true) {
+		return errors.New("broker unavailable")
+	}
+	return b.Bus.Publish(ctx, subject, payload)
+}
+
+func TestRunOneRetriesAfterTransientStartPublishFailure(t *testing.T) {
+	base := inproc.New()
+	defer func() { _ = base.Close() }()
+	facts, err := base.Subscribe(events.AllPattern(), eventbus.SubOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = facts.Close() }()
+	completed := make(chan struct{}, 1)
+	obituary := make(chan string, 1)
+	go func() {
+		for msg := range facts.C() {
+			f, decodeErr := events.Decode(msg)
+			_ = msg.Ack()
+			if decodeErr != nil {
+				continue
+			}
+			switch d := f.Data.(type) {
+			case events.RunCompletedEvent:
+				completed <- struct{}{}
+			case events.RunFailedEvent:
+				obituary <- d.Error
+			}
+		}
+	}()
+
+	sources := registry.NewSources()
+	sources.Register("test", func() filament.Source { return &commitTestSource{} })
+	sinks := registry.NewSinks()
+	sinks.Register("test-sink", func() filament.Sink { return &controlledTestSink{} })
+	store := memory.New()
+	state := filament.RunState{Run: "r1", Tenant: "t1", Status: filament.RunRequested}
+	if err := store.SaveRun(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+	deps := Deps{Bus: &publishFailOnceBus{Bus: base}, DataStore: store, Sources: sources, Sinks: sinks}
+	spec := filament.RunSpec{
+		Tenant: state.Tenant, Run: state.Run,
+		Source: filament.Ref{Connector: "test"}, Sink: filament.Ref{Connector: "test-sink"},
+		Resources:      []string{"users"},
+		IngestionTypes: map[string]filament.IngestionType{"": filament.IngestionFullUpsert},
+	}
+
+	err = RunOne(context.Background(), deps, spec)
+	if err == nil || !strings.Contains(err.Error(), "publish run.started") {
+		t.Fatalf("first RunOne error = %v, want run.started publication failure", err)
+	}
+	select {
+	case msg := <-obituary:
+		t.Fatalf("admission failure published run.failed %q; the retry could never execute", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if got, _ := store.LoadRun(context.Background(), state.Run); got.Status != filament.RunRequested {
+		t.Fatalf("status after failed admission = %v, want Requested", got.Status)
+	}
+
+	if err := RunOne(context.Background(), deps, spec); err != nil {
+		t.Fatalf("retry RunOne error = %v", err)
+	}
+	select {
+	case <-completed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("retry did not publish run.completed")
+	}
+}
+
 func TestRunOneFailsWhenProgressCannotBeRestored(t *testing.T) {
 	bus := inproc.New()
 	facts, err := bus.Subscribe(events.AllPattern(), eventbus.SubOpts{})

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -72,6 +72,36 @@ func (progressLoadErrorStore) LoadRun(context.Context, filament.RunID) (filament
 	return filament.RunState{}, errors.New("database unavailable")
 }
 
+type publishErrorBus struct{ eventbus.Bus }
+
+func (publishErrorBus) Publish(context.Context, string, any) error {
+	return errors.New("broker unavailable")
+}
+
+func TestRunOneDoesNotExecuteWithoutPublishedStart(t *testing.T) {
+	base := inproc.New()
+	defer func() { _ = base.Close() }()
+	store := memory.New()
+	state := filament.RunState{Run: "r1", Tenant: "t1", Status: filament.RunRequested}
+	if err := store.SaveRun(context.Background(), state); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunOne(context.Background(), Deps{
+		Bus: publishErrorBus{Bus: base}, DataStore: store,
+	}, filament.RunSpec{Tenant: state.Tenant, Run: state.Run})
+	if err == nil || !strings.Contains(err.Error(), "publish run.started") {
+		t.Fatalf("RunOne error = %v, want run.started publication failure", err)
+	}
+	got, err := store.LoadRun(context.Background(), state.Run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != filament.RunRequested {
+		t.Fatalf("status = %v, want Requested", got.Status)
+	}
+}
+
 func TestRunOneFailsWhenProgressCannotBeRestored(t *testing.T) {
 	bus := inproc.New()
 	facts, err := bus.Subscribe(events.AllPattern(), eventbus.SubOpts{})

--- a/source.go
+++ b/source.go
@@ -33,6 +33,14 @@ type ChangeSource interface {
 	ExtractChanges(ctx context.Context, sink RecordSink, opts ChangeExtractOpts) error
 }
 
+// ChangeAcknowledger lets a CDC source release upstream stream retention after
+// the sink commit and the final per-resource checkpoints are both durable.
+// The runner calls it only after observing those checkpoints in the DataStore;
+// implementations must never advance beyond the supplied positions.
+type ChangeAcknowledger interface {
+	AcknowledgeChanges(ctx context.Context, checkpoints map[string]Checkpoint) error
+}
+
 // ResourcePlanner lets a source translate externally selected resources into the
 // concrete resource names it will emit. Selectors remain source-private; the
 // returned names are used by the engine for policy, schema, and checkpoint setup.

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -249,6 +249,25 @@ func TestPostgresCDCCatchupAndResume(t *testing.T) {
 	}
 
 	next := streamCheckpointFromRecords(t, changes.recs, "cdc_users")
+	// The runner invokes this only after the sink commit and tracker promotion.
+	// Advancing here verifies the source releases WAL for the final completed
+	// cycle instead of waiting for another extraction to start.
+	if err := src.AcknowledgeChanges(ctx, map[string]filament.Checkpoint{"cdc_users": next}); err != nil {
+		t.Fatal(err)
+	}
+	nextLSN, _, ok := checkpoint.ParseStream(next)
+	if !ok {
+		t.Fatalf("next checkpoint is not a stream cursor: %#v", next)
+	}
+	var acknowledged bool
+	if err := pg.Pool().QueryRow(ctx, `SELECT confirmed_flush_lsn >= $2::pg_lsn
+		FROM pg_replication_slots WHERE slot_name=$1`, "filament_test_cdc", nextLSN).Scan(&acknowledged); err != nil {
+		t.Fatal(err)
+	}
+	if !acknowledged {
+		t.Fatalf("slot confirmed_flush_lsn is behind acknowledged checkpoint %s", nextLSN)
+	}
+
 	idle := &collectSink{}
 	if err := src.ExtractChanges(ctx, idle, filament.ChangeExtractOpts{
 		Resources: []string{"cdc_users"}, Checkpoints: map[string]filament.Checkpoint{"cdc_users": next},

--- a/tests/integration/reaper_test.go
+++ b/tests/integration/reaper_test.go
@@ -23,8 +23,8 @@ import (
 
 // TestReaperKillsStaleRuns drives the reaper against a real API server. A
 // stale Running run with no worker Job is failed through the bus and folded
-// terminal by the tracker; one whose Job still has an active pod is held by
-// the Alive probe; deleting that Job lets the next sweep kill it too.
+// terminal by the tracker; one whose Job is still unfinished is held by the
+// workload probe; deleting that Job lets the next sweep kill it too.
 func TestReaperKillsStaleRuns(t *testing.T) {
 	cluster := testcontainers.SharedK3s(t)
 	ctx := context.Background()
@@ -38,8 +38,8 @@ func TestReaperKillsStaleRuns(t *testing.T) {
 		WorkerImage:      "ghcr.io/galaxy-io/filament/worker:test",
 		WorkerSecretName: "filament-secret",
 		// The default ServiceAccount, so the Job controller can actually create
-		// the pod: Alive needs Status.Active > 0, and a pod stuck pulling a
-		// nonexistent image still counts as active.
+		// the pod; a pod stuck pulling a nonexistent image keeps the Job
+		// unfinished, which is what holds the run.
 		WorkerServiceAccount: "default",
 		JobNamePrefix:        "filament",
 		Kubeconfig:           cluster.KubeconfigPath,
@@ -75,7 +75,7 @@ func TestReaperKillsStaleRuns(t *testing.T) {
 	reap := reaper.New(
 		reaper.WithInterval(250*time.Millisecond),
 		reaper.WithStaleAfter(2*time.Second),
-		reaper.WithAliveCheck(dispatcher.Alive),
+		reaper.WithWorkloadProbe(dispatcher.Workload),
 	)
 	mods, err := module.MountAll(ctx, module.Deps{Bus: bus, DataStore: ds}, tracker.New(), reap)
 	if err != nil {
@@ -98,7 +98,7 @@ func TestReaperKillsStaleRuns(t *testing.T) {
 	}
 
 	// Several more sweeps pass; the held run stays Running because its Job
-	// still has an active pod.
+	// is still unfinished.
 	time.Sleep(time.Second)
 	if st, err := ds.LoadRun(ctx, held); err != nil || st.Status != filament.RunRunning {
 		t.Fatalf("held run: status %v err %v, want still running", st.Status, err)


### PR DESCRIPTION
-Runner calls `pg_replication_slot_advance` after sink commit and checkpoint promotion
-RunOne returns a failed run.started, worker exits non-zero, engine naks
-Reaper sweeps requested
-NATS naks redeliver after 1s instead of immediately
-k8s Alive trusts Job conditions, not the active-pod counter
-Jobs labelled with source and sink connection ids