### PR TITLE
Add CLI remote target

### DIFF
--- a/cmd/filament/cli.go
+++ b/cmd/filament/cli.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 
 	cliapp "github.com/galaxy-io/filament/cmd/internal/cli/app"
+	cliauth "github.com/galaxy-io/filament/cmd/internal/cli/auth"
 	"github.com/galaxy-io/filament/cmd/internal/cli/contexts"
 	climodel "github.com/galaxy-io/filament/cmd/internal/cli/model"
 	dadorenderer "github.com/galaxy-io/filament/cmd/internal/cli/renderer/dado"
 	localtarget "github.com/galaxy-io/filament/cmd/internal/cli/target/local"
+	remotetarget "github.com/galaxy-io/filament/cmd/internal/cli/target/remote"
 )
 
 type cliApp struct {
@@ -60,14 +62,6 @@ func (a *cliApp) renderer() *dadorenderer.Renderer {
 	})
 }
 
-type unimplementedTargetError struct {
-	kind contexts.Kind
-}
-
-func (e *unimplementedTargetError) Error() string {
-	return fmt.Sprintf("%s target is not implemented", e.kind)
-}
-
 func (a *cliApp) initializeTarget(ctx context.Context) error {
 	selected := contexts.NamedTarget{
 		Name:   "local",
@@ -87,12 +81,16 @@ func (a *cliApp) initializeTarget(ctx context.Context) error {
 		selected.Target.ConfigPath = a.configPath
 	}
 	a.target = selected
-	if selected.Target.Kind != contexts.KindLocal {
-		return &unimplementedTargetError{kind: selected.Target.Kind}
+	if selected.Target.Kind == contexts.KindRemote {
+		options := remotetarget.Options{Endpoint: selected.Target.Endpoint}
+		if profile := selected.Target.AuthProfile; profile != "" {
+			options.Tokens = cliauth.Source{Store: cliauth.Store{Path: a.credentialsPath()}, Profile: profile}
+		}
+		a.service = cliapp.NewService(remotetarget.NewTarget(options))
+	} else {
+		a.configPath = selected.Target.ConfigPath
+		a.service = cliapp.NewService(localtarget.NewTarget(localtarget.Store{Path: a.configPath}, a.catalog))
 	}
-	a.configPath = selected.Target.ConfigPath
-	target := localtarget.NewTarget(localtarget.Store{Path: a.configPath}, a.catalog)
-	a.service = cliapp.NewService(target)
 	catalog, err := a.service.Catalog(ctx)
 	if err != nil {
 		return err

--- a/cmd/filament/cli_test.go
+++ b/cmd/filament/cli_test.go
@@ -59,7 +59,7 @@ func TestNonTerminalWithoutCommandFallsBackToHelp(t *testing.T) {
 	}
 }
 
-func TestRemoteContextFailsBeforeRendererExecution(t *testing.T) {
+func TestUnreachableRemoteContextFailsBeforeRendererExecution(t *testing.T) {
 	t.Parallel()
 	directory := t.TempDir()
 	contextPath := filepath.Join(directory, "contexts.yaml")
@@ -72,7 +72,7 @@ func TestRemoteContextFailsBeforeRendererExecution(t *testing.T) {
 		configPath: filepath.Join(directory, "filament.yaml"), contextPath: contextPath, catalog: loadCatalog(),
 	}
 	err := app.run(context.Background(), []string{"source", "list"})
-	if err == nil || err.Error() != "remote target is not implemented" {
-		t.Fatalf("error = %v, want remote target is not implemented", err)
+	if err == nil || !strings.Contains(err.Error(), "cannot reach https://filament.example.test") {
+		t.Fatalf("error = %v, want cannot reach https://filament.example.test", err)
 	}
 }

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/galaxy-io/filament/identity/zitadel v0.0.0-00010101000000-000000000000
 	github.com/galaxy-io/filament/secret/aws v0.0.0-00010101000000-000000000000
 	github.com/gdamore/tcell/v2 v2.13.4
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
@@ -29,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.45.0
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -132,7 +134,6 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/google/wire v0.7.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.18 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
@@ -247,7 +248,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/grpc v1.82.1 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect

--- a/cmd/internal/cli/app/environment.go
+++ b/cmd/internal/cli/app/environment.go
@@ -117,3 +117,27 @@ func ResolvedConnectionConfig(connection model.Connection, scoped map[string]any
 	config = canonicalizeConfig(schema, config)
 	return normalizeSavedSecretReferences(schema, config)
 }
+
+// ConfigWithoutSecretValues returns a copy with every referenced secret path
+// removed: the wire shape paired with a secret_refs map. Local YAML keeps its
+// env: references in Config.
+func ConfigWithoutSecretValues(values map[string]any, refs map[string]string) map[string]any {
+	result := cloneConfigMap(values)
+	for path := range refs {
+		deleteConfigPath(result, strings.Split(path, "."))
+	}
+	return result
+}
+
+// deleteConfigPath removes path from values and reports whether values is
+// now empty, so emptied parents are pruned on the way back up.
+func deleteConfigPath(values map[string]any, path []string) bool {
+	if len(path) == 1 {
+		delete(values, path[0])
+		return len(values) == 0
+	}
+	if nested, ok := values[path[0]].(map[string]any); ok && deleteConfigPath(nested, path[1:]) {
+		delete(values, path[0])
+	}
+	return len(values) == 0
+}

--- a/cmd/internal/cli/app/operations_test.go
+++ b/cmd/internal/cli/app/operations_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/galaxy-io/filament"
@@ -257,5 +258,38 @@ func newMemoryTarget() *memoryTarget {
 				},
 			},
 		},
+	}
+}
+
+// deploymentTarget validates on the deployment, as the remote target does,
+// so documents may hold modes the in-process runner cannot execute.
+type deploymentTarget struct{ *memoryTarget }
+
+func (deploymentTarget) ValidateConfiguration(context.Context, model.Document) error { return nil }
+
+func TestSavedPipelineKeepsSyncMode(t *testing.T) {
+	t.Parallel()
+	target := newMemoryTarget()
+	target.document.Sources["input"] = model.Connection{Type: "sample"}
+	target.document.Sinks["output"] = model.Connection{Type: "stdout"}
+	target.document.Pipelines["inc"] = model.Pipeline{
+		Source: model.PipelineNode{Ref: "input"}, Sink: model.PipelineNode{Ref: "output"},
+		SyncMode: "incremental", WriteMode: "append",
+	}
+	service := NewService(deploymentTarget{target})
+	ctx := context.Background()
+
+	submission, err := service.PrepareRun(ctx, RunRequest{Pipeline: "inc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if submission.Override || submission.Pipeline == nil || len(submission.Spec.IngestionTypes) != 0 {
+		t.Fatalf("submission = %+v", submission)
+	}
+
+	rows := []string{"users"}
+	_, err = service.PrepareRun(ctx, RunRequest{Pipeline: "inc", Overrides: SavePipelineRequest{Resources: &rows}})
+	if err == nil || !strings.Contains(err.Error(), "in-process") {
+		t.Fatalf("override err = %v, want in-process refusal", err)
 	}
 }

--- a/cmd/internal/cli/app/runs.go
+++ b/cmd/internal/cli/app/runs.go
@@ -58,9 +58,14 @@ func (s *Service) PrepareRun(ctx context.Context, request RunRequest) (model.Run
 		return model.RunSubmission{}, fmt.Errorf("sink %q: %w", pipeline.Sink.Ref, err)
 	}
 	sinkConfig = applySinkSchemaDefault(sinkConfig, catalog.Sinks[sink.Type], pipeline.Source.Ref)
-	spec, err := makeRunSpec(request.Pipeline, source.Type, sink.Type, sourceConfig, sinkConfig, pipeline.Resources, pipeline.SyncMode, pipeline.WriteMode)
-	if err != nil {
-		return model.RunSubmission{}, err
+	spec := makeRunSpec(request.Pipeline, source.Type, sink.Type, sourceConfig, sinkConfig, pipeline.Resources)
+	// A saved pipeline runs on the deployment, which derives ingestion from
+	// the stored pipeline and keeps its checkpoints. An override runs in
+	// process with no state, so it takes only the full modes.
+	if override {
+		if spec, err = withDirectIngestion(spec, pipeline.SyncMode, pipeline.WriteMode); err != nil {
+			return model.RunSubmission{}, err
+		}
 	}
 	return model.RunSubmission{
 		Pipeline: &model.EntityReference{Name: request.Pipeline, Metadata: pipeline.Metadata},
@@ -112,26 +117,32 @@ func prepareInlineRun(run InlineRun, catalog model.Catalog) (filament.RunSpec, e
 		return filament.RunSpec{}, err
 	}
 	sinkConfig = applySinkSchemaDefault(sinkConfig, sinkSpec, run.Source.Connector)
-	return makeRunSpec("", run.Source.Connector, run.Sink.Connector, sourceConfig, sinkConfig, run.Resources, run.SyncMode, run.WriteMode)
+	spec := makeRunSpec("", run.Source.Connector, run.Sink.Connector, sourceConfig, sinkConfig, run.Resources)
+	return withDirectIngestion(spec, run.SyncMode, run.WriteMode)
 }
 
-func makeRunSpec(pipelineID, sourceName, sinkName string, sourceConfig, sinkConfig map[string]any, resources []string, syncName, writeName string) (filament.RunSpec, error) {
-	syncMode := filament.ModeFull
-	if syncName != "" && syncName != "full" {
-		return filament.RunSpec{}, fmt.Errorf("sync mode %q is not supported; use full", syncName)
+func makeRunSpec(pipelineID, sourceName, sinkName string, sourceConfig, sinkConfig map[string]any, resources []string) filament.RunSpec {
+	return filament.RunSpec{
+		PipelineID: pipelineID,
+		Source:     filament.Ref{Connector: sourceName, Config: sourceConfig},
+		Sink:       filament.Ref{Connector: sinkName, Config: sinkConfig},
+		Resources:  append([]string(nil), resources...),
 	}
-	writeMode := filament.WriteMode(writeName)
-	ingestionType, err := filament.IngestionFor(syncMode, writeMode)
+}
+
+// withDirectIngestion sets the ingestion for a run the CLI executes in
+// process. That runner keeps no state between runs, so incremental and cdc
+// have nothing to resume from and only full is accepted.
+func withDirectIngestion(spec filament.RunSpec, syncName, writeName string) (filament.RunSpec, error) {
+	if syncName != "" && syncName != "full" {
+		return filament.RunSpec{}, fmt.Errorf("sync mode %q is not supported for in-process runs; use full", syncName)
+	}
+	ingestionType, err := filament.IngestionFor(filament.ModeFull, filament.WriteMode(writeName))
 	if err != nil {
 		return filament.RunSpec{}, err
 	}
-	return filament.RunSpec{
-		PipelineID:     pipelineID,
-		Source:         filament.Ref{Connector: sourceName, Config: sourceConfig},
-		Sink:           filament.Ref{Connector: sinkName, Config: sinkConfig},
-		Resources:      append([]string(nil), resources...),
-		IngestionTypes: map[string]filament.IngestionType{"": ingestionType},
-	}, nil
+	spec.IngestionTypes = map[string]filament.IngestionType{"": ingestionType}
+	return spec, nil
 }
 
 func applySinkSchemaDefault(config map[string]any, spec filament.SinkSpec, sourceName string) map[string]any {

--- a/cmd/internal/cli/app/service.go
+++ b/cmd/internal/cli/app/service.go
@@ -58,6 +58,12 @@ type Target interface {
 	RunTarget
 }
 
+// PipelineModesTarget is an optional target capability that resolves the
+// read and write modes a proposed route supports.
+type PipelineModesTarget interface {
+	PipelineModes(context.Context, model.Pipeline) (model.PipelineModes, error)
+}
+
 // RawConfigurationTarget is an optional target capability for byte-preserving
 // configuration editing. Remote targets do not need to expose it.
 type RawConfigurationTarget interface {

--- a/cmd/internal/cli/model/config.go
+++ b/cmd/internal/cli/model/config.go
@@ -1,5 +1,7 @@
 package model
 
+import "time"
+
 // ConfigVersion is the current configuration document version.
 const ConfigVersion = 1
 
@@ -22,9 +24,19 @@ type EntityMetadata struct {
 
 // Connection is a persisted source or sink configuration.
 type Connection struct {
-	Metadata EntityMetadata `json:"-" yaml:"-"`
-	Type     string         `json:"type" yaml:"type"`
-	Config   map[string]any `json:"config,omitempty" yaml:"config,omitempty"`
+	Metadata   EntityMetadata    `json:"-" yaml:"-"`
+	Info       ConnectionInfo    `json:"-" yaml:"-"`
+	Type       string            `json:"type" yaml:"type"`
+	Config     map[string]any    `json:"config,omitempty" yaml:"config,omitempty"`
+	SecretRefs map[string]string `json:"-" yaml:"-"`
+}
+
+// ConnectionInfo is target-owned metadata. Local documents leave it zero;
+// deployments fill it.
+type ConnectionInfo struct {
+	Replication string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // NamedConnection identifies a connection returned by a target query.
@@ -37,6 +49,7 @@ type NamedConnection struct {
 // Pipeline is a persisted source-to-sink pipeline.
 type Pipeline struct {
 	Metadata  EntityMetadata `json:"-" yaml:"-"`
+	Info      PipelineInfo   `json:"-" yaml:"-"`
 	Source    PipelineNode   `json:"source" yaml:"source"`
 	Sink      PipelineNode   `json:"sink" yaml:"sink"`
 	Resources []string       `json:"resources,omitempty" yaml:"resources,omitempty"`
@@ -45,6 +58,19 @@ type Pipeline struct {
 	// Graph retains the target's complete graph. It never reaches YAML, which
 	// stays a simple source-to-sink pipeline.
 	Graph *PipelineGraph `json:"-" yaml:"-"`
+}
+
+// PipelineInfo is target-owned metadata. Local documents leave it zero;
+// deployments fill it.
+type PipelineInfo struct {
+	Schedule      string
+	LastRunStatus string
+	LastRunAt     time.Time
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	// EditBlockedReason is set when the deployed graph cannot be represented
+	// by the simple source-to-sink editor without losing something.
+	EditBlockedReason string
 }
 
 // NamedPipeline identifies a pipeline returned by a target query.

--- a/cmd/internal/cli/model/result.go
+++ b/cmd/internal/cli/model/result.go
@@ -116,3 +116,11 @@ type ResourceSummary struct {
 	PrimaryKey    []string
 	EstimatedRows int64
 }
+
+// PipelineModes is the target's authoritative read and write levers for one
+// proposed source-to-sink route.
+type PipelineModes struct {
+	Replication string
+	ReadModes   []string
+	WriteModes  []string
+}

--- a/cmd/internal/cli/target/remote/capabilities.go
+++ b/cmd/internal/cli/target/remote/capabilities.go
@@ -1,0 +1,79 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"connectrpc.com/connect"
+
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+)
+
+// PipelineModes asks the deployment's graph validator which modes a route
+// supports, the same source of truth the web canvas uses.
+func (t *Target) PipelineModes(ctx context.Context, pipeline model.Pipeline) (model.PipelineModes, error) {
+	graph, _, err := t.graphToProto(ctx, pipeline)
+	if err != nil {
+		return model.PipelineModes{}, err
+	}
+	response, err := t.client.ValidatePipeline(ctx, connect.NewRequest(&ingestionv1.ValidatePipelineRequest{Graph: graph}))
+	if err != nil {
+		return model.PipelineModes{}, t.rpcError(err)
+	}
+	edges := response.Msg.GetEdges()
+	if len(edges) == 0 {
+		for _, problem := range response.Msg.GetErrors() {
+			if problem.GetMessage() != "" {
+				return model.PipelineModes{}, fmt.Errorf("validate pipeline: %s", problem.GetMessage())
+			}
+		}
+		return model.PipelineModes{}, fmt.Errorf("validate pipeline returned no route")
+	}
+	result := model.PipelineModes{Replication: "standard"}
+	var readSets [][]string
+	for _, edge := range edges {
+		if edge.GetReplication() == ingestionv1.ReplicationMode_REPLICATION_MODE_CDC {
+			result.Replication = model.SyncModeCDC
+		}
+		for _, mode := range edge.GetSupportedWriteModes() {
+			result.WriteModes = appendUnique(result.WriteModes, writeModeString(mode))
+		}
+		for _, resource := range edge.GetResources() {
+			var modes []string
+			for _, mode := range resource.GetSupportedReadModes() {
+				modes = appendUnique(modes, readModeString(mode))
+			}
+			readSets = append(readSets, modes)
+		}
+	}
+	if result.Replication == model.SyncModeCDC {
+		result.ReadModes = []string{model.SyncModeCDC}
+		return result, nil
+	}
+	result.ReadModes = intersect(readSets)
+	if len(result.ReadModes) == 0 {
+		result.ReadModes = []string{"full"}
+	}
+	return result, nil
+}
+
+func appendUnique(values []string, value string) []string {
+	if value == "" || slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
+}
+
+// intersect keeps the values present in every set, in first-set order.
+func intersect(sets [][]string) []string {
+	if len(sets) == 0 {
+		return nil
+	}
+	result := slices.Clone(sets[0])
+	for _, set := range sets[1:] {
+		result = slices.DeleteFunc(result, func(value string) bool { return !slices.Contains(set, value) })
+	}
+	return result
+}

--- a/cmd/internal/cli/target/remote/catalog.go
+++ b/cmd/internal/cli/target/remote/catalog.go
@@ -1,0 +1,155 @@
+package remote
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	"github.com/galaxy-io/filament"
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+)
+
+// Catalog returns the connectors the deployment was built with, so flags
+// and wizards reflect the server rather than the CLI's own build.
+func (t *Target) Catalog(ctx context.Context) (model.Catalog, error) {
+	specs, err := drain(func(cursor string) ([]*ingestionv1.ConnectorSpec, *ingestionv1.PaginationResponse, error) {
+		response, err := t.client.ListConnectors(ctx, connect.NewRequest(&ingestionv1.ListConnectorsRequest{Pagination: pagination(cursor)}))
+		if err != nil {
+			return nil, nil, t.rpcError(err)
+		}
+		return response.Msg.GetConnectors(), response.Msg.GetPagination(), nil
+	})
+	if err != nil {
+		return model.Catalog{}, err
+	}
+	catalog := model.Catalog{
+		Sources: map[string]filament.ConnectorSpec{},
+		Sinks:   map[string]filament.SinkSpec{},
+	}
+	for _, spec := range specs {
+		switch spec.GetKind() {
+		case ingestionv1.ConnectorKind_CONNECTOR_KIND_SOURCE:
+			catalog.Sources[spec.GetName()] = filament.ConnectorSpec{
+				Name:        spec.GetName(),
+				DisplayName: spec.GetDisplayName(),
+				Description: spec.GetDescription(),
+				Version:     spec.GetVersion(),
+				Maturity:    maturityFromProto(spec.GetMaturity()),
+				Modes:       readModesFromProto(spec.GetModes()),
+				Config:      filament.ConfigSchema{Fields: fieldsFromProto(spec.GetConfigSchema().GetFields())},
+			}
+		case ingestionv1.ConnectorKind_CONNECTOR_KIND_SINK:
+			catalog.Sinks[spec.GetName()] = filament.SinkSpec{
+				Name:        spec.GetName(),
+				DisplayName: spec.GetDisplayName(),
+				Description: spec.GetDescription(),
+				Version:     spec.GetVersion(),
+				Maturity:    maturityFromProto(spec.GetMaturity()),
+				Config:      filament.ConfigSchema{Fields: fieldsFromProto(spec.GetConfigSchema().GetFields())},
+				SchemaField: spec.GetSchemaField(),
+			}
+		case ingestionv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED:
+		}
+	}
+	return catalog, nil
+}
+
+func maturityFromProto(maturity ingestionv1.ConnectorMaturity) filament.ConnectorMaturity {
+	switch maturity {
+	case ingestionv1.ConnectorMaturity_CONNECTOR_MATURITY_BETA:
+		return filament.MaturityBeta
+	case ingestionv1.ConnectorMaturity_CONNECTOR_MATURITY_STABLE:
+		return filament.MaturityStable
+	default:
+		return filament.MaturityAlpha
+	}
+}
+
+// readModesFromProto expands replication modes into read levers: standard
+// connections read full or incremental, CDC reads the stream.
+func readModesFromProto(modes []ingestionv1.ReplicationMode) []filament.ReadMode {
+	var out []filament.ReadMode
+	for _, mode := range modes {
+		switch mode {
+		case ingestionv1.ReplicationMode_REPLICATION_MODE_STANDARD:
+			out = append(out, filament.ModeFull, filament.ModeIncremental)
+		case ingestionv1.ReplicationMode_REPLICATION_MODE_CDC:
+			out = append(out, filament.ModeCDC)
+		case ingestionv1.ReplicationMode_REPLICATION_MODE_UNSPECIFIED:
+		}
+	}
+	return out
+}
+
+func fieldsFromProto(fields []*ingestionv1.ConfigField) []filament.ConfigField {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]filament.ConfigField, 0, len(fields))
+	for _, field := range fields {
+		out = append(out, filament.ConfigField{
+			Name:        field.GetName(),
+			Type:        fieldTypeFromProto(field.GetType()),
+			Required:    field.GetRequired(),
+			Default:     field.GetDefault().AsInterface(),
+			Enum:        enumOptionsFromProto(field.GetEnum()),
+			Help:        field.GetHelp(),
+			Scope:       fieldScopeFromProto(field.GetScope()),
+			Secret:      field.GetSecret(),
+			VisibleWhen: fieldConditionFromProto(field.GetVisibleWhen()),
+			Fields:      fieldsFromProto(field.GetFields()),
+		})
+	}
+	return out
+}
+
+func fieldTypeFromProto(t ingestionv1.FieldType) filament.FieldType {
+	switch t {
+	case ingestionv1.FieldType_FIELD_TYPE_INT:
+		return filament.FieldInt
+	case ingestionv1.FieldType_FIELD_TYPE_BOOL:
+		return filament.FieldBool
+	case ingestionv1.FieldType_FIELD_TYPE_SECRET:
+		return filament.FieldSecret
+	case ingestionv1.FieldType_FIELD_TYPE_DURATION:
+		return filament.FieldDuration
+	case ingestionv1.FieldType_FIELD_TYPE_ENUM:
+		return filament.FieldEnum
+	case ingestionv1.FieldType_FIELD_TYPE_OBJECT:
+		return filament.FieldObject
+	case ingestionv1.FieldType_FIELD_TYPE_LIST:
+		return filament.FieldList
+	default:
+		return filament.FieldString
+	}
+}
+
+func fieldScopeFromProto(scope ingestionv1.FieldScope) filament.FieldScope {
+	switch scope {
+	case ingestionv1.FieldScope_FIELD_SCOPE_CONNECTION:
+		return filament.ScopeConnection
+	case ingestionv1.FieldScope_FIELD_SCOPE_PIPELINE:
+		return filament.ScopePipeline
+	default:
+		return filament.ScopeUnspecified
+	}
+}
+
+func enumOptionsFromProto(options []*ingestionv1.EnumOption) []filament.EnumOption {
+	if len(options) == 0 {
+		return nil
+	}
+	out := make([]filament.EnumOption, 0, len(options))
+	for _, option := range options {
+		out = append(out, filament.EnumOption{Value: option.GetValue(), Label: option.GetLabel()})
+	}
+	return out
+}
+
+func fieldConditionFromProto(condition *ingestionv1.FieldCondition) *filament.FieldCondition {
+	if condition == nil {
+		return nil
+	}
+	return &filament.FieldCondition{Field: condition.GetField(), Values: condition.GetValues()}
+}

--- a/cmd/internal/cli/target/remote/connections.go
+++ b/cmd/internal/cli/target/remote/connections.go
@@ -1,0 +1,169 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+
+	"connectrpc.com/connect"
+
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+	cliapp "github.com/galaxy-io/filament/cmd/internal/cli/app"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+)
+
+// ListConnections returns every connection of one kind.
+func (t *Target) ListConnections(ctx context.Context, kind string) ([]model.NamedConnection, error) {
+	protoKind, err := connectorKind(kind)
+	if err != nil {
+		return nil, err
+	}
+	items, err := t.connections(ctx, protoKind, "")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.NamedConnection, 0, len(items))
+	for _, item := range items {
+		out = append(out, model.NamedConnection{Kind: kind, Name: item.GetName(), Connection: connectionFromProto(item)})
+	}
+	return out, nil
+}
+
+// GetConnection returns one connection by name.
+func (t *Target) GetConnection(ctx context.Context, kind, name string) (model.Connection, error) {
+	item, err := t.findConnection(ctx, kind, name)
+	if err != nil {
+		return model.Connection{}, err
+	}
+	return connectionFromProto(item), nil
+}
+
+// CreateConnection creates a named connection on the deployment.
+func (t *Target) CreateConnection(ctx context.Context, kind, name string, connection model.Connection) (model.Connection, error) {
+	protoKind, err := connectorKind(kind)
+	if err != nil {
+		return model.Connection{}, err
+	}
+	config, err := configStruct(cliapp.ConfigWithoutSecretValues(connection.Config, connection.SecretRefs))
+	if err != nil {
+		return model.Connection{}, err
+	}
+	response, err := t.client.CreateConnection(ctx, connect.NewRequest(&ingestionv1.CreateConnectionRequest{
+		Kind: protoKind, Name: name, Connector: connection.Type, Config: config,
+		SecretRefs: maps.Clone(connection.SecretRefs),
+	}))
+	if err != nil {
+		return model.Connection{}, t.rpcError(err)
+	}
+	return connectionFromProto(response.Msg.GetConnection()), nil
+}
+
+// UpdateConnection replaces a connection's configuration under the revision
+// it was read at; the deployment rejects a stale one.
+func (t *Target) UpdateConnection(ctx context.Context, kind, name string, connection model.Connection) (model.Connection, error) {
+	protoKind, err := connectorKind(kind)
+	if err != nil {
+		return model.Connection{}, err
+	}
+	id, err := t.connectionID(ctx, kind, name, connection.Metadata)
+	if err != nil {
+		return model.Connection{}, err
+	}
+	version, err := strconv.ParseInt(connection.Metadata.Revision, 10, 64)
+	if err != nil {
+		return model.Connection{}, fmt.Errorf("%s %q carries no read revision", kind, name)
+	}
+	config, err := configStruct(cliapp.ConfigWithoutSecretValues(connection.Config, connection.SecretRefs))
+	if err != nil {
+		return model.Connection{}, err
+	}
+	response, err := t.client.UpdateConnection(ctx, connect.NewRequest(&ingestionv1.UpdateConnectionRequest{
+		Connection: &ingestionv1.Connection{
+			Id: id, Kind: protoKind, Name: name, Connector: connection.Type,
+			Config: config, SecretRefs: maps.Clone(connection.SecretRefs), Version: version,
+		},
+	}))
+	if err != nil {
+		return model.Connection{}, t.rpcError(err)
+	}
+	return connectionFromProto(response.Msg.GetConnection()), nil
+}
+
+// DeleteConnection removes a connection by name.
+func (t *Target) DeleteConnection(ctx context.Context, kind, name string, metadata model.EntityMetadata) error {
+	id, err := t.connectionID(ctx, kind, name, metadata)
+	if err != nil {
+		return err
+	}
+	_, err = t.client.DeleteConnection(ctx, connect.NewRequest(&ingestionv1.DeleteConnectionRequest{Id: id}))
+	return t.rpcError(err)
+}
+
+// connectionID prefers the id the caller read; a bare name is resolved.
+func (t *Target) connectionID(ctx context.Context, kind, name string, metadata model.EntityMetadata) (string, error) {
+	if metadata.ID != "" {
+		return metadata.ID, nil
+	}
+	item, err := t.findConnection(ctx, kind, name)
+	if err != nil {
+		return "", err
+	}
+	return item.GetId(), nil
+}
+
+// findConnection resolves a name, narrowed server-side by the substring
+// search and matched exactly here.
+func (t *Target) findConnection(ctx context.Context, kind, name string) (*ingestionv1.Connection, error) {
+	protoKind, err := connectorKind(kind)
+	if err != nil {
+		return nil, err
+	}
+	items, err := t.connections(ctx, protoKind, name)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.GetName() == name {
+			return item, nil
+		}
+	}
+	return nil, fmt.Errorf("%s %q does not exist", kind, name)
+}
+
+func (t *Target) connections(ctx context.Context, kind ingestionv1.ConnectorKind, search string) ([]*ingestionv1.Connection, error) {
+	return drain(func(cursor string) ([]*ingestionv1.Connection, *ingestionv1.PaginationResponse, error) {
+		response, err := t.client.ListConnections(ctx, connect.NewRequest(&ingestionv1.ListConnectionsRequest{
+			Kind: kind, Search: search, Pagination: pagination(cursor),
+		}))
+		if err != nil {
+			return nil, nil, t.rpcError(err)
+		}
+		return response.Msg.GetConnections(), response.Msg.GetPagination(), nil
+	})
+}
+
+func connectionFromProto(item *ingestionv1.Connection) model.Connection {
+	return model.Connection{
+		Metadata: model.EntityMetadata{ID: item.GetId(), Revision: revisionOf(item.GetVersion())},
+		Info: model.ConnectionInfo{
+			Replication: replicationString(item.GetReplication()),
+			CreatedAt:   timeFromMillis(item.GetCreatedAt()),
+			UpdatedAt:   timeFromMillis(item.GetUpdatedAt()),
+		},
+		Type:       item.GetConnector(),
+		Config:     configMap(item.GetConfig()),
+		SecretRefs: maps.Clone(item.GetSecretRefs()),
+	}
+}
+
+func replicationString(mode ingestionv1.ReplicationMode) string {
+	switch mode {
+	case ingestionv1.ReplicationMode_REPLICATION_MODE_STANDARD:
+		return "standard"
+	case ingestionv1.ReplicationMode_REPLICATION_MODE_CDC:
+		return model.SyncModeCDC
+	default:
+		return ""
+	}
+}

--- a/cmd/internal/cli/target/remote/connections.go
+++ b/cmd/internal/cli/target/remote/connections.go
@@ -9,7 +9,6 @@ import (
 	"connectrpc.com/connect"
 
 	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
-	cliapp "github.com/galaxy-io/filament/cmd/internal/cli/app"
 	"github.com/galaxy-io/filament/cmd/internal/cli/model"
 )
 
@@ -45,7 +44,7 @@ func (t *Target) CreateConnection(ctx context.Context, kind, name string, connec
 	if err != nil {
 		return model.Connection{}, err
 	}
-	config, err := configStruct(cliapp.ConfigWithoutSecretValues(connection.Config, connection.SecretRefs))
+	config, err := configStruct(connection.Config)
 	if err != nil {
 		return model.Connection{}, err
 	}
@@ -74,7 +73,7 @@ func (t *Target) UpdateConnection(ctx context.Context, kind, name string, connec
 	if err != nil {
 		return model.Connection{}, fmt.Errorf("%s %q carries no read revision", kind, name)
 	}
-	config, err := configStruct(cliapp.ConfigWithoutSecretValues(connection.Config, connection.SecretRefs))
+	config, err := configStruct(connection.Config)
 	if err != nil {
 		return model.Connection{}, err
 	}

--- a/cmd/internal/cli/target/remote/discovery.go
+++ b/cmd/internal/cli/target/remote/discovery.go
@@ -1,0 +1,42 @@
+package remote
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+)
+
+// Discover runs connector discovery on the deployment, against a saved
+// connection when the request names one.
+func (t *Target) Discover(ctx context.Context, request model.DiscoverRequest) (model.ResourceList, error) {
+	config, err := configStruct(request.Config)
+	if err != nil {
+		return model.ResourceList{}, err
+	}
+	message := &ingestionv1.DiscoverResourcesRequest{Connector: request.Connector, Config: config, Refresh: request.Refresh}
+	if request.Source != "" {
+		connection, err := t.findConnection(ctx, "source", request.Source)
+		if err != nil {
+			return model.ResourceList{}, err
+		}
+		message.ConnectionId = connection.GetId()
+	}
+	response, err := t.client.DiscoverResources(ctx, connect.NewRequest(message))
+	if err != nil {
+		return model.ResourceList{}, t.rpcError(err)
+	}
+	resources := response.Msg.GetResources()
+	list := model.ResourceList{Source: request.Source, Items: make([]model.ResourceSummary, 0, len(resources))}
+	for _, resource := range resources {
+		list.Items = append(list.Items, model.ResourceSummary{
+			Name:        resource.GetName(),
+			DisplayName: resource.GetDisplayName(),
+			Selectable:  resource.GetIsSelectable(),
+			PrimaryKey:  resource.GetPrimaryKey(),
+		})
+	}
+	return list, nil
+}

--- a/cmd/internal/cli/target/remote/pagination.go
+++ b/cmd/internal/cli/target/remote/pagination.go
@@ -1,0 +1,43 @@
+package remote
+
+import (
+	"time"
+
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+)
+
+// pageSize is the deployment's maximum, so a full collection costs as few
+// round trips as the server allows.
+const pageSize int32 = 1000
+
+func pagination(cursor string) *ingestionv1.PaginationRequest {
+	request := &ingestionv1.PaginationRequest{PageSize: pageSize}
+	if cursor != "" {
+		request.Cursor = &cursor
+	}
+	return request
+}
+
+// drain collects every item behind a cursor-paged fetch.
+func drain[T any](fetch func(cursor string) ([]T, *ingestionv1.PaginationResponse, error)) ([]T, error) {
+	var items []T
+	cursor := ""
+	for {
+		page, next, err := fetch(cursor)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, page...)
+		cursor = next.GetNextCursor()
+		if cursor == "" {
+			return items, nil
+		}
+	}
+}
+
+func timeFromMillis(millis int64) time.Time {
+	if millis == 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(millis)
+}

--- a/cmd/internal/cli/target/remote/pipelines.go
+++ b/cmd/internal/cli/target/remote/pipelines.go
@@ -1,0 +1,345 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+
+	"connectrpc.com/connect"
+
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+	cliapp "github.com/galaxy-io/filament/cmd/internal/cli/app"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+)
+
+var readModeFromString = map[string]ingestionv1.ReadMode{
+	"":                ingestionv1.ReadMode_READ_MODE_UNSPECIFIED,
+	"full":            ingestionv1.ReadMode_READ_MODE_FULL,
+	"incremental":     ingestionv1.ReadMode_READ_MODE_INCREMENTAL,
+	model.SyncModeCDC: ingestionv1.ReadMode_READ_MODE_UNSPECIFIED,
+}
+
+var writeModeFromString = map[string]ingestionv1.WriteMode{
+	"":        ingestionv1.WriteMode_WRITE_MODE_UNSPECIFIED,
+	"append":  ingestionv1.WriteMode_WRITE_MODE_APPEND,
+	"replace": ingestionv1.WriteMode_WRITE_MODE_REPLACE,
+	"upsert":  ingestionv1.WriteMode_WRITE_MODE_UPSERT,
+	"merge":   ingestionv1.WriteMode_WRITE_MODE_MERGE,
+}
+
+// ListPipelines returns every pipeline, projected to the simple shape where
+// the graph allows it.
+func (t *Target) ListPipelines(ctx context.Context) ([]model.NamedPipeline, error) {
+	items, err := t.pipelines(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	connections, err := t.connectionIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.NamedPipeline, 0, len(items))
+	for _, item := range items {
+		out = append(out, model.NamedPipeline{Name: item.GetName(), Pipeline: pipelineFromProto(item, connections)})
+	}
+	return out, nil
+}
+
+// GetPipeline returns one pipeline by name.
+func (t *Target) GetPipeline(ctx context.Context, name string) (model.Pipeline, error) {
+	item, err := t.findPipeline(ctx, name)
+	if err != nil {
+		return model.Pipeline{}, err
+	}
+	connections, err := t.connectionIndex(ctx)
+	if err != nil {
+		return model.Pipeline{}, err
+	}
+	return pipelineFromProto(item, connections), nil
+}
+
+// CreatePipeline creates the pipeline and its first graph version. The API
+// has no single call for both, so a failed version deletes the shell again.
+func (t *Target) CreatePipeline(ctx context.Context, name string, pipeline model.Pipeline) (model.Pipeline, error) {
+	graph, connections, err := t.graphToProto(ctx, pipeline)
+	if err != nil {
+		return model.Pipeline{}, err
+	}
+	created, err := t.client.CreatePipeline(ctx, connect.NewRequest(&ingestionv1.CreatePipelineRequest{Name: name}))
+	if err != nil {
+		return model.Pipeline{}, t.rpcError(err)
+	}
+	shell := created.Msg.GetPipeline()
+	version, err := t.client.CreatePipelineVersion(ctx, connect.NewRequest(&ingestionv1.CreatePipelineVersionRequest{
+		PipelineId: shell.GetId(), Graph: graph,
+	}))
+	if err != nil {
+		_, deleteErr := t.client.DeletePipeline(ctx, connect.NewRequest(&ingestionv1.DeletePipelineRequest{Id: shell.GetId()}))
+		if deleteErr != nil {
+			deleteErr = fmt.Errorf("delete pipeline %q by hand: %w", name, t.rpcError(deleteErr))
+		}
+		return model.Pipeline{}, errors.Join(t.rpcError(err), deleteErr)
+	}
+	shell.CurrentVersion = version.Msg.GetVersion()
+	return pipelineFromProto(shell, connections), nil
+}
+
+// UpdatePipeline stores a new graph version. The read revision must still
+// be current and the deployed graph must project to the simple shape.
+func (t *Target) UpdatePipeline(ctx context.Context, name string, pipeline model.Pipeline) (model.Pipeline, error) {
+	existing, err := t.findPipeline(ctx, name)
+	if err != nil {
+		return model.Pipeline{}, err
+	}
+	connections, err := t.connectionIndex(ctx)
+	if err != nil {
+		return model.Pipeline{}, err
+	}
+	if reason := pipelineFromProto(existing, connections).Info.EditBlockedReason; reason != "" {
+		return model.Pipeline{}, fmt.Errorf("pipeline %q cannot be edited here without losing part of its graph (%s); edit it in the UI", name, reason)
+	}
+	if current := revisionOf(existing.GetCurrentVersion().GetVersion()); pipeline.Metadata.Revision != current {
+		return model.Pipeline{}, fmt.Errorf("pipeline %q has changed since it was read; fetch it again", name)
+	}
+	graph, connections, err := t.graphToProto(ctx, pipeline)
+	if err != nil {
+		return model.Pipeline{}, err
+	}
+	version, err := t.client.CreatePipelineVersion(ctx, connect.NewRequest(&ingestionv1.CreatePipelineVersionRequest{
+		PipelineId: existing.GetId(), Graph: graph,
+	}))
+	if err != nil {
+		return model.Pipeline{}, t.rpcError(err)
+	}
+	existing.CurrentVersion = version.Msg.GetVersion()
+	return pipelineFromProto(existing, connections), nil
+}
+
+// DeletePipeline removes a pipeline by name.
+func (t *Target) DeletePipeline(ctx context.Context, name string, metadata model.EntityMetadata) error {
+	id := metadata.ID
+	if id == "" {
+		existing, err := t.findPipeline(ctx, name)
+		if err != nil {
+			return err
+		}
+		id = existing.GetId()
+	}
+	_, err := t.client.DeletePipeline(ctx, connect.NewRequest(&ingestionv1.DeletePipelineRequest{Id: id}))
+	return t.rpcError(err)
+}
+
+// findPipeline resolves a name, narrowed server-side by the substring search
+// and matched exactly here.
+func (t *Target) findPipeline(ctx context.Context, name string) (*ingestionv1.Pipeline, error) {
+	items, err := t.pipelines(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.GetName() == name {
+			return item, nil
+		}
+	}
+	return nil, fmt.Errorf("pipeline %q does not exist", name)
+}
+
+func (t *Target) pipelines(ctx context.Context, search string) ([]*ingestionv1.Pipeline, error) {
+	return drain(func(cursor string) ([]*ingestionv1.Pipeline, *ingestionv1.PaginationResponse, error) {
+		response, err := t.client.ListPipelines(ctx, connect.NewRequest(&ingestionv1.ListPipelinesRequest{
+			IncludeLastRun: true, IncludeSchedule: true, Search: search, Pagination: pagination(cursor),
+		}))
+		if err != nil {
+			return nil, nil, t.rpcError(err)
+		}
+		return response.Msg.GetPipelines(), response.Msg.GetPagination(), nil
+	})
+}
+
+// connectionRef is what a graph needs to know about a saved connection.
+type connectionRef struct {
+	ID          string
+	Name        string
+	Kind        string
+	Replication string
+}
+
+// connectionIndex lists every connection once, keyed by id and by kind+name,
+// so graph mapping in either direction is a lookup.
+type connectionIndex struct {
+	byID   map[string]connectionRef
+	byName map[string]connectionRef
+}
+
+func nameKey(kind, name string) string { return kind + "/" + name }
+
+func (t *Target) connectionIndex(ctx context.Context) (connectionIndex, error) {
+	items, err := t.connections(ctx, ingestionv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED, "")
+	if err != nil {
+		return connectionIndex{}, err
+	}
+	index := connectionIndex{byID: map[string]connectionRef{}, byName: map[string]connectionRef{}}
+	for _, item := range items {
+		ref := connectionRef{
+			ID: item.GetId(), Name: item.GetName(), Kind: kindString(item.GetKind()),
+			Replication: replicationString(item.GetReplication()),
+		}
+		index.byID[ref.ID] = ref
+		index.byName[nameKey(ref.Kind, ref.Name)] = ref
+	}
+	return index, nil
+}
+
+func pipelineFromProto(item *ingestionv1.Pipeline, connections connectionIndex) model.Pipeline {
+	pipeline := model.Pipeline{
+		Metadata: model.EntityMetadata{
+			ID:       item.GetId(),
+			Revision: revisionOf(item.GetCurrentVersion().GetVersion()),
+		},
+		Info: model.PipelineInfo{
+			Schedule:      item.GetSchedule().GetConfig().GetCron(),
+			LastRunStatus: runStatusString(item.GetLastRun().GetStatus()),
+			LastRunAt:     timeFromMillis(item.GetLastRun().GetStartedAt()),
+			CreatedAt:     timeFromMillis(item.GetCreatedAt()),
+			UpdatedAt:     timeFromMillis(item.GetUpdatedAt()),
+		},
+	}
+	graph, replication := graphFromProto(item.GetCurrentVersion().GetGraph(), connections)
+	if err := model.ProjectSimpleGraph(&pipeline, graph, replication); err != nil {
+		pipeline.Info.EditBlockedReason = err.Error()
+	}
+	return pipeline
+}
+
+// graphFromProto maps a deployed graph to the model, naming connections and
+// reporting the source's replication so CDC projects correctly.
+func graphFromProto(graph *ingestionv1.PipelineGraph, connections connectionIndex) (model.PipelineGraph, string) {
+	out := model.PipelineGraph{}
+	replication := ""
+	for _, node := range graph.GetNodes() {
+		ref := connections.byID[node.GetConnectionId()]
+		name := ref.Name
+		if name == "" {
+			name = node.GetConnectionId()
+		}
+		if node.GetKind() == ingestionv1.ConnectorKind_CONNECTOR_KIND_SOURCE && replication == "" {
+			replication = ref.Replication
+		}
+		out.Nodes = append(out.Nodes, model.PipelineGraphNode{
+			ID: node.GetId(), Kind: kindString(node.GetKind()), Connection: name,
+			Config: configMap(node.GetConfig()), SecretRefs: maps.Clone(node.GetSecretRefs()),
+		})
+	}
+	for _, edge := range graph.GetEdges() {
+		mapped := model.PipelineGraphEdge{
+			From: edge.GetFromNode(), To: edge.GetToNode(), Resource: edge.GetResource(), Selector: edge.GetSelector(),
+			ReadMode: readModeString(edge.GetReadMode()), WriteMode: writeModeString(edge.GetWriteMode()),
+		}
+		for _, cursor := range edge.GetCursors() {
+			mapped.Cursors = append(mapped.Cursors, model.ResourceCursor{
+				Resource: cursor.GetResource(), Field: cursor.GetField(), LookbackSeconds: cursor.GetLookbackSeconds(),
+			})
+		}
+		out.Edges = append(out.Edges, mapped)
+	}
+	return out, replication
+}
+
+// graphToProto builds the deployment graph for a pipeline, resolving
+// connection names to ids. Simple pipelines are expanded first.
+func (t *Target) graphToProto(ctx context.Context, pipeline model.Pipeline) (*ingestionv1.PipelineGraph, connectionIndex, error) {
+	graph := model.SimplePipelineGraph(pipeline)
+	connections, err := t.connectionIndex(ctx)
+	if err != nil {
+		return nil, connectionIndex{}, err
+	}
+	out := &ingestionv1.PipelineGraph{}
+	for _, node := range graph.Nodes {
+		kind, err := connectorKind(node.Kind)
+		if err != nil {
+			return nil, connectionIndex{}, err
+		}
+		ref, ok := connections.byName[nameKey(node.Kind, node.Connection)]
+		if !ok {
+			return nil, connectionIndex{}, fmt.Errorf("%s %q does not exist", node.Kind, node.Connection)
+		}
+		config, err := configStruct(cliapp.ConfigWithoutSecretValues(node.Config, node.SecretRefs))
+		if err != nil {
+			return nil, connectionIndex{}, fmt.Errorf("%s %q: %w", node.Kind, node.Connection, err)
+		}
+		out.Nodes = append(out.Nodes, &ingestionv1.PipelineNode{
+			Id: node.ID, Kind: kind, ConnectionId: ref.ID, Config: config, SecretRefs: maps.Clone(node.SecretRefs),
+		})
+	}
+	for _, edge := range graph.Edges {
+		readMode, ok := readModeFromString[edge.ReadMode]
+		if !ok {
+			return nil, connectionIndex{}, fmt.Errorf("unknown sync mode %q", edge.ReadMode)
+		}
+		writeMode, ok := writeModeFromString[edge.WriteMode]
+		if !ok {
+			return nil, connectionIndex{}, fmt.Errorf("unknown write mode %q", edge.WriteMode)
+		}
+		mapped := &ingestionv1.PipelineEdge{
+			FromNode: edge.From, ToNode: edge.To, Resource: edge.Resource, Selector: edge.Selector,
+			ReadMode: readMode, WriteMode: writeMode,
+		}
+		for _, cursor := range edge.Cursors {
+			mapped.Cursors = append(mapped.Cursors, &ingestionv1.ResourceCursorConfig{
+				Resource: cursor.Resource, Field: cursor.Field, LookbackSeconds: cursor.LookbackSeconds,
+			})
+		}
+		out.Edges = append(out.Edges, mapped)
+	}
+	return out, connections, nil
+}
+
+func readModeString(mode ingestionv1.ReadMode) string {
+	switch mode {
+	case ingestionv1.ReadMode_READ_MODE_FULL:
+		return "full"
+	case ingestionv1.ReadMode_READ_MODE_INCREMENTAL:
+		return "incremental"
+	default:
+		return ""
+	}
+}
+
+func writeModeString(mode ingestionv1.WriteMode) string {
+	switch mode {
+	case ingestionv1.WriteMode_WRITE_MODE_APPEND:
+		return "append"
+	case ingestionv1.WriteMode_WRITE_MODE_REPLACE:
+		return "replace"
+	case ingestionv1.WriteMode_WRITE_MODE_UPSERT:
+		return "upsert"
+	case ingestionv1.WriteMode_WRITE_MODE_MERGE:
+		return "merge"
+	default:
+		return ""
+	}
+}
+
+func runStatusString(status ingestionv1.RunStatus) string {
+	switch status {
+	case ingestionv1.RunStatus_RUN_STATUS_REQUESTED:
+		return "requested"
+	case ingestionv1.RunStatus_RUN_STATUS_SCHEDULED:
+		return "scheduled"
+	case ingestionv1.RunStatus_RUN_STATUS_RUNNING:
+		return "running"
+	case ingestionv1.RunStatus_RUN_STATUS_COMPLETED:
+		return "completed"
+	case ingestionv1.RunStatus_RUN_STATUS_FAILED:
+		return "failed"
+	case ingestionv1.RunStatus_RUN_STATUS_CANCELED:
+		return "canceled"
+	case ingestionv1.RunStatus_RUN_STATUS_PAUSED:
+		return "paused"
+	case ingestionv1.RunStatus_RUN_STATUS_PARTIAL:
+		return "partial"
+	default:
+		return ""
+	}
+}

--- a/cmd/internal/cli/target/remote/pipelines.go
+++ b/cmd/internal/cli/target/remote/pipelines.go
@@ -9,7 +9,6 @@ import (
 	"connectrpc.com/connect"
 
 	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
-	cliapp "github.com/galaxy-io/filament/cmd/internal/cli/app"
 	"github.com/galaxy-io/filament/cmd/internal/cli/model"
 )
 
@@ -264,7 +263,7 @@ func (t *Target) graphToProto(ctx context.Context, pipeline model.Pipeline) (*in
 		if !ok {
 			return nil, connectionIndex{}, fmt.Errorf("%s %q does not exist", node.Kind, node.Connection)
 		}
-		config, err := configStruct(cliapp.ConfigWithoutSecretValues(node.Config, node.SecretRefs))
+		config, err := configStruct(node.Config)
 		if err != nil {
 			return nil, connectionIndex{}, fmt.Errorf("%s %q: %w", node.Kind, node.Connection, err)
 		}

--- a/cmd/internal/cli/target/remote/remote_test.go
+++ b/cmd/internal/cli/target/remote/remote_test.go
@@ -1,0 +1,132 @@
+package remote_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/app"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+	"github.com/galaxy-io/filament/cmd/internal/cli/target/remote"
+	"github.com/galaxy-io/filament/cmd/internal/cli/target/targettest"
+	_ "github.com/galaxy-io/filament/cmd/internal/connectors" // registers the connector catalog
+	"github.com/galaxy-io/filament/datastore/sqlite"
+	secretenv "github.com/galaxy-io/filament/secret/env"
+)
+
+// serve boots the real stack on a loopback listener and returns a target
+// pointed at it. This is exactly how the CLI's local mode runs.
+func serve(t *testing.T) *remote.Target {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- app.Serve(ctx, listener, app.WithDataStore(sqlite.NewMemory()), app.WithSecrets(secretenv.New()))
+	}()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Errorf("serve: %v", err)
+		}
+	})
+	return remote.NewTarget(remote.Options{Endpoint: "http://" + listener.Addr().String()})
+}
+
+func TestEntityContract(t *testing.T) {
+	targettest.EntityLifecycle(t, serve(t), "sample", "stdout")
+}
+
+func TestCatalogComesFromTheDeployment(t *testing.T) {
+	catalog, err := serve(t).Catalog(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := catalog.Sources["sample"]; !ok {
+		t.Fatalf("sources = %v", catalog.Sources)
+	}
+	if _, ok := catalog.Sinks["stdout"]; !ok {
+		t.Fatalf("sinks = %v", catalog.Sinks)
+	}
+}
+
+func TestPipelineRoundTripAndModes(t *testing.T) {
+	ctx := context.Background()
+	target := serve(t)
+	if _, err := target.CreateConnection(ctx, "source", "src", model.Connection{Type: "sample"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := target.CreateConnection(ctx, "sink", "out", model.Connection{Type: "stdout"}); err != nil {
+		t.Fatal(err)
+	}
+	proposed := model.Pipeline{Source: model.PipelineNode{Ref: "src"}, Sink: model.PipelineNode{Ref: "out"}, SyncMode: "full", WriteMode: "replace"}
+	modes, err := target.PipelineModes(ctx, proposed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modes.Replication != "standard" || len(modes.ReadModes) == 0 || len(modes.WriteModes) == 0 {
+		t.Fatalf("modes = %+v", modes)
+	}
+	created, err := target.CreatePipeline(ctx, "copy", proposed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := target.GetPipeline(ctx, "copy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source.Ref != "src" || got.Sink.Ref != "out" || got.SyncMode != "full" || got.WriteMode != "replace" || got.Metadata.Revision != created.Metadata.Revision {
+		t.Fatalf("pipeline = %+v", got)
+	}
+	if got.Info.EditBlockedReason != "" || got.Graph == nil {
+		t.Fatalf("info = %+v graph = %v", got.Info, got.Graph)
+	}
+	if _, err := target.GetPipeline(ctx, "missing"); err == nil {
+		t.Fatal("missing pipeline resolved")
+	}
+	if _, err := target.CreatePipeline(ctx, "broken", model.Pipeline{Source: model.PipelineNode{Ref: "nope"}, Sink: model.PipelineNode{Ref: "out"}}); err == nil {
+		t.Fatal("unknown connection accepted")
+	}
+}
+
+func TestRunSavedPipelineToCompletion(t *testing.T) {
+	ctx := context.Background()
+	target := serve(t)
+	if _, err := target.CreateConnection(ctx, "source", "src", model.Connection{Type: "sample"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := target.CreateConnection(ctx, "sink", "out", model.Connection{Type: "stdout"}); err != nil {
+		t.Fatal(err)
+	}
+	pipeline, err := target.CreatePipeline(ctx, "copy", model.Pipeline{
+		Source: model.PipelineNode{Ref: "src"}, Sink: model.PipelineNode{Ref: "out"}, SyncMode: "full", WriteMode: "replace",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	group, err := target.SubmitRun(ctx, model.RunSubmission{Pipeline: &model.EntityReference{Name: "copy", Metadata: pipeline.Metadata}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(group.Runs) != 1 {
+		t.Fatalf("runs = %+v", group.Runs)
+	}
+	var events []model.RunEvent
+	result, err := target.TailRun(ctx, group, func(event model.RunEvent) { events = append(events, event) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "complete" || result.Records == 0 {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(events) == 0 {
+		t.Fatal("no progress events observed")
+	}
+	if _, err := target.SubmitRun(ctx, model.RunSubmission{Spec: filament.RunSpec{}}); err == nil {
+		t.Fatal("inline run accepted by the deployment target")
+	}
+}

--- a/cmd/internal/cli/target/remote/remote_test.go
+++ b/cmd/internal/cli/target/remote/remote_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/galaxy-io/filament/cmd/internal/connectors" // registers the connector catalog
 	"github.com/galaxy-io/filament/datastore/sqlite"
 	secretenv "github.com/galaxy-io/filament/secret/env"
+	secretsqlite "github.com/galaxy-io/filament/secret/sqlite"
 )
 
 // serve boots the real stack on a loopback listener and returns a target
@@ -128,5 +129,53 @@ func TestRunSavedPipelineToCompletion(t *testing.T) {
 	}
 	if _, err := target.SubmitRun(ctx, model.RunSubmission{Spec: filament.RunSpec{}}); err == nil {
 		t.Fatal("inline run accepted by the deployment target")
+	}
+}
+
+// serveWithSecrets is serve with a writable secret store, for paths that
+// mint refs.
+func serveWithSecrets(t *testing.T) (*remote.Target, *secretsqlite.Provider) {
+	t.Helper()
+	store := sqlite.NewMemory()
+	secrets, err := secretsqlite.New(store.DB(), "test", []byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- app.Serve(ctx, listener, app.WithDataStore(store), app.WithSecrets(secrets)) }()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Errorf("serve: %v", err)
+		}
+	})
+	return remote.NewTarget(remote.Options{Endpoint: "http://" + listener.Addr().String()}), secrets
+}
+
+// A connection read back from the deployment carries refs and no values, so
+// a value supplied on update is new input and must reach the deployment.
+func TestUpdateReplacesSecret(t *testing.T) {
+	ctx := context.Background()
+	target, secrets := serveWithSecrets(t)
+	created, err := target.CreateConnection(ctx, "source", "crm", model.Connection{Type: "attio", Config: map[string]any{"api_key": "first"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created.Config = map[string]any{"api_key": "second"}
+	updated, err := target.UpdateConnection(ctx, "source", "crm", created)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.SecretRefs["api_key"] == created.SecretRefs["api_key"] {
+		t.Fatal("secret ref unchanged: new value was dropped")
+	}
+	secret, err := secrets.Read(ctx, updated.SecretRefs["api_key"])
+	if err != nil || string(secret.Value) != "second" {
+		t.Fatalf("stored value = %q, err = %v", secret.Value, err)
 	}
 }

--- a/cmd/internal/cli/target/remote/run.go
+++ b/cmd/internal/cli/target/remote/run.go
@@ -1,0 +1,183 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	"github.com/galaxy-io/filament"
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+	"github.com/galaxy-io/filament/events"
+)
+
+// SubmitRun asks the deployment to run a saved pipeline. Inline specs and
+// override flags are work only the local runner executes.
+func (t *Target) SubmitRun(ctx context.Context, submission model.RunSubmission) (model.RunGroup, error) {
+	if submission.Pipeline == nil {
+		return model.RunGroup{}, errors.New("this target runs saved pipelines; create the pipeline first")
+	}
+	if submission.Override {
+		return model.RunGroup{}, errors.New("this target does not take override flags; edit the pipeline instead")
+	}
+	id := submission.Pipeline.Metadata.ID
+	if id == "" {
+		existing, err := t.findPipeline(ctx, submission.Pipeline.Name)
+		if err != nil {
+			return model.RunGroup{}, err
+		}
+		id = existing.GetId()
+	}
+	response, err := t.client.RunPipeline(ctx, connect.NewRequest(&ingestionv1.RunPipelineRequest{
+		PipelineId: id, ClientToken: uuid.NewString(),
+	}))
+	if err != nil {
+		return model.RunGroup{}, t.rpcError(err)
+	}
+	edgeRuns := response.Msg.GetEdgeRuns()
+	if len(edgeRuns) == 0 {
+		return model.RunGroup{}, fmt.Errorf("pipeline %q produced no runs", submission.Pipeline.Name)
+	}
+	group := model.RunGroup{Runs: make([]model.RunRef, 0, len(edgeRuns))}
+	for _, edgeRun := range edgeRuns {
+		group.Runs = append(group.Runs, model.RunRef{ID: edgeRun.GetRun().GetId(), Route: edgeRun.GetPipelineEdgeKey()})
+	}
+	return group, nil
+}
+
+// TailRun follows every run in the group over the deployment's event stream
+// and reports normalized resource progress. The stream closes only after the
+// deployment has persisted the terminal status, so no waiting happens here.
+func (t *Target) TailRun(ctx context.Context, group model.RunGroup, observe func(model.RunEvent)) (model.RunResult, error) {
+	var mu sync.Mutex
+	locked := func(event model.RunEvent) {
+		if observe == nil {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		observe(event)
+	}
+	results := make([]tailResult, len(group.Runs))
+	errs := make([]error, len(group.Runs))
+	var tails sync.WaitGroup
+	for i, ref := range group.Runs {
+		tails.Add(1)
+		go func() {
+			defer tails.Done()
+			results[i], errs[i] = t.tailOne(ctx, ref, locked)
+		}()
+	}
+	tails.Wait()
+	total := model.RunResult{Runs: group.Runs, Status: "complete"}
+	for i, result := range results {
+		total.Records += result.records
+		total.Bytes += result.bytes
+		if statusRank(result.status) > statusRank(total.Status) {
+			total.Status = result.status
+		}
+		if errs[i] != nil && result.status == "" {
+			total.Status = "failed"
+		}
+	}
+	return total, errors.Join(errs...)
+}
+
+// statusRank orders terminal statuses so a group reports its worst member.
+func statusRank(status string) int {
+	switch status {
+	case "failed":
+		return 5
+	case "partial":
+		return 4
+	case "canceled":
+		return 3
+	case "paused":
+		return 2
+	case "complete":
+		return 1
+	default:
+		return 0
+	}
+}
+
+type tailResult struct {
+	status  string
+	records int64
+	bytes   int64
+}
+
+func (t *Target) tailOne(ctx context.Context, ref model.RunRef, observe func(model.RunEvent)) (tailResult, error) {
+	stream, err := t.client.TailRun(ctx, connect.NewRequest(&ingestionv1.TailRunRequest{RunId: ref.ID, ShouldReplay: true}))
+	if err != nil {
+		return tailResult{}, t.rpcError(err)
+	}
+	defer func() { _ = stream.Close() }()
+	for stream.Receive() {
+		event := stream.Msg().GetEvent()
+		fields := event.GetFields()
+		switch event.GetEventType() {
+		case events.ResourceStarted.Name():
+			observe(runEvent(ref, event.GetResource(), "running"))
+		case events.BatchWritten.Name():
+			update := runEvent(ref, event.GetResource(), "running")
+			update.Records, update.Bytes = fields.GetRecords(), fields.GetBytes()
+			observe(update)
+		case events.ResourceCompleted.Name():
+			update := runEvent(ref, event.GetResource(), "complete")
+			update.Records, update.Bytes, update.Final = fields.GetRecords(), fields.GetBytes(), true
+			observe(update)
+		case events.ResourceFailed.Name():
+			update := runEvent(ref, event.GetResource(), "failed")
+			update.Error = fields.GetError()
+			observe(update)
+		case events.RunCompleted.Name():
+			return tailResult{status: "complete", records: fields.GetRecords(), bytes: fields.GetBytes()}, nil
+		case events.RunFailed.Name():
+			return tailResult{status: "failed"}, fmt.Errorf("run %s failed: %s", ref.ID, fields.GetError())
+		case events.RunPartial.Name():
+			return tailResult{status: "partial"}, fmt.Errorf("run %s is partial: %s", ref.ID, fields.GetError())
+		case events.RunPaused.Name():
+			observe(model.RunEvent{Run: ref.ID, Route: ref.Route, Status: "paused", Final: true})
+			return tailResult{status: "paused"}, nil
+		case events.RunCanceled.Name():
+			observe(model.RunEvent{Run: ref.ID, Route: ref.Route, Status: "canceled", Final: true})
+			return tailResult{status: "canceled"}, nil
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return tailResult{}, t.rpcError(err)
+	}
+	return tailResult{}, errors.New("run event stream closed before completion")
+}
+
+// SignalRun sends a lifecycle signal to a deployment run.
+func (t *Target) SignalRun(ctx context.Context, ref model.RunRef, signal filament.Signal) error {
+	protoSignal, err := signalToProto(signal)
+	if err != nil {
+		return err
+	}
+	_, err = t.client.SignalRun(ctx, connect.NewRequest(&ingestionv1.SignalRunRequest{RunId: ref.ID, Signal: protoSignal}))
+	return t.rpcError(err)
+}
+
+func signalToProto(signal filament.Signal) (ingestionv1.RunSignal, error) {
+	switch signal {
+	case filament.SignalPause:
+		return ingestionv1.RunSignal_RUN_SIGNAL_PAUSE, nil
+	case filament.SignalResume:
+		return ingestionv1.RunSignal_RUN_SIGNAL_RESUME, nil
+	case filament.SignalCancel:
+		return ingestionv1.RunSignal_RUN_SIGNAL_CANCEL, nil
+	default:
+		return ingestionv1.RunSignal_RUN_SIGNAL_UNSPECIFIED, fmt.Errorf("unknown run signal %d", signal)
+	}
+}
+
+func runEvent(ref model.RunRef, resource, status string) model.RunEvent {
+	return model.RunEvent{Run: ref.ID, Route: ref.Route, Resource: resource, Status: status}
+}

--- a/cmd/internal/cli/target/remote/target.go
+++ b/cmd/internal/cli/target/remote/target.go
@@ -1,0 +1,209 @@
+// Package remote implements CLI target operations against a deployed
+// Filament service over its Connect API. The CLI's local mode uses it too,
+// pointed at a server embedded in the same process.
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	ingestionv1 "github.com/galaxy-io/filament/api/ingestion/v1"
+	"github.com/galaxy-io/filament/api/ingestion/v1/ingestionv1connect"
+	cliapp "github.com/galaxy-io/filament/cmd/internal/cli/app"
+	"github.com/galaxy-io/filament/cmd/internal/cli/model"
+)
+
+var (
+	_ cliapp.Target              = (*Target)(nil)
+	_ cliapp.PipelineModesTarget = (*Target)(nil)
+)
+
+// TokenSource supplies a bearer token for outgoing requests. A source that
+// also implements Invalidate gets one retry after the server rejects a token.
+type TokenSource interface {
+	Token(context.Context) (string, error)
+}
+
+// Options configures a remote target.
+type Options struct {
+	// Endpoint is the deployment's base URL.
+	Endpoint string
+	// Tokens authenticates requests; nil sends them unauthenticated, which
+	// only an embedded loopback deployment accepts.
+	Tokens TokenSource
+	// HTTPClient issues requests; nil means the default client.
+	HTTPClient *http.Client
+}
+
+// Target implements CLI operations over a deployment's IngestionService.
+type Target struct {
+	client   ingestionv1connect.IngestionServiceClient
+	endpoint string
+}
+
+// NewTarget constructs a remote target.
+func NewTarget(opts Options) *Target {
+	client := opts.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	var options []connect.ClientOption
+	if opts.Tokens != nil {
+		options = append(options, connect.WithInterceptors(bearerInterceptor{tokens: opts.Tokens}))
+	}
+	return &Target{
+		client:   ingestionv1connect.NewIngestionServiceClient(client, opts.Endpoint, options...),
+		endpoint: opts.Endpoint,
+	}
+}
+
+// ValidateConfiguration is satisfied server-side: the deployment validates
+// every mutation and run when it happens.
+func (t *Target) ValidateConfiguration(context.Context, model.Document) error { return nil }
+
+// bearerInterceptor authenticates every RPC in one place. Tenancy is the
+// server's side of the token; requests never carry it.
+type bearerInterceptor struct {
+	tokens TokenSource
+}
+
+type invalidator interface {
+	Invalidate() error
+}
+
+func (i bearerInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if err := i.authorize(ctx, req.Header()); err != nil {
+			return nil, err
+		}
+		resp, err := next(ctx, req)
+		if connect.CodeOf(err) != connect.CodeUnauthenticated {
+			return resp, err
+		}
+		// A cached token the server no longer accepts is dropped and minted
+		// once more before the failure reaches the user.
+		source, ok := i.tokens.(invalidator)
+		if !ok {
+			return resp, err
+		}
+		if err := source.Invalidate(); err != nil {
+			return nil, err
+		}
+		if err := i.authorize(ctx, req.Header()); err != nil {
+			return nil, err
+		}
+		return next(ctx, req)
+	}
+}
+
+func (i bearerInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		wrapped := &streamConn{StreamingClientConn: conn}
+		wrapped.err = i.authorize(ctx, conn.RequestHeader())
+		return wrapped
+	}
+}
+
+func (i bearerInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}
+
+func (i bearerInterceptor) authorize(ctx context.Context, header http.Header) error {
+	token, err := i.tokens.Token(ctx)
+	if err != nil {
+		return err
+	}
+	header.Set("Authorization", "Bearer "+token)
+	return nil
+}
+
+// streamConn surfaces a token failure from the first Send or Receive, since
+// the interceptor cannot return an error while opening the stream.
+type streamConn struct {
+	connect.StreamingClientConn
+	err error
+}
+
+func (c *streamConn) Send(message any) error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.StreamingClientConn.Send(message)
+}
+
+func (c *streamConn) Receive(message any) error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.StreamingClientConn.Receive(message)
+}
+
+// rpcError translates transport and RPC failures into CLI-ready messages.
+func (t *Target) rpcError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		return err
+	}
+	switch connectErr.Code() {
+	case connect.CodeUnauthenticated:
+		return fmt.Errorf("%s rejected the request as unauthenticated; run filament auth login", t.endpoint)
+	case connect.CodeUnavailable:
+		return fmt.Errorf("cannot reach %s: %s", t.endpoint, connectErr.Message())
+	default:
+		return errors.New(connectErr.Message())
+	}
+}
+
+func connectorKind(kind string) (ingestionv1.ConnectorKind, error) {
+	switch kind {
+	case "source":
+		return ingestionv1.ConnectorKind_CONNECTOR_KIND_SOURCE, nil
+	case "sink":
+		return ingestionv1.ConnectorKind_CONNECTOR_KIND_SINK, nil
+	default:
+		return ingestionv1.ConnectorKind_CONNECTOR_KIND_UNSPECIFIED, fmt.Errorf("unknown connection kind %q", kind)
+	}
+}
+
+func kindString(kind ingestionv1.ConnectorKind) string {
+	switch kind {
+	case ingestionv1.ConnectorKind_CONNECTOR_KIND_SOURCE:
+		return "source"
+	case ingestionv1.ConnectorKind_CONNECTOR_KIND_SINK:
+		return "sink"
+	default:
+		return ""
+	}
+}
+
+func configStruct(config map[string]any) (*structpb.Struct, error) {
+	if len(config) == 0 {
+		return nil, nil
+	}
+	value, err := structpb.NewStruct(config)
+	if err != nil {
+		return nil, fmt.Errorf("encode config: %w", err)
+	}
+	return value, nil
+}
+
+func configMap(value *structpb.Struct) map[string]any {
+	if value == nil || len(value.GetFields()) == 0 {
+		return nil
+	}
+	return value.AsMap()
+}
+
+func revisionOf(version int64) string {
+	return strconv.FormatInt(version, 10)
+}


### PR DESCRIPTION
- Catalog, connections, pipelines, discovery, and pipeline modes over the API
- Auth: bearer token on every call from the credentials token source
