### PR TITLE
Support capture only for thread reply differences and full walk-back

### DIFF
--- a/.agents/skills/http-connector/references/grammar-guide.md
+++ b/.agents/skills/http-connector/references/grammar-guide.md
@@ -152,6 +152,27 @@ Types: `string bool int16 int32 int64 float32 float64 decimal date time timestam
     repository: { path: parent.repository, type: string }  # denormalize the parent key
 ```
 
+A parent that exists only to drive a child is `capture_only`. It is walked for
+captures, never emitted or listed, and runs only when a dependent child is
+selected. A child gates its fan-out with `parent.since`, which names a captured
+key: empty values never fan out, and on incremental runs values below the
+child's lower bound (watermark minus lookback, under the child's comparator)
+are skipped. `since` requires an `incremental` block on the child.
+
+```yaml
+- name: threads
+  path: /conversations.history
+  for_each: conversations
+  capture_only: true
+  capture: { thread_ts: ts, latest_reply: latest_reply }
+- name: thread_replies
+  path: /conversations.replies
+  query: { ts: "{{ parent.thread_ts }}" }
+  for_each: threads
+  parent: { since: latest_reply }                  # only threads with new replies
+  incremental: { cursor_field: ts, start_param: oldest, inject_into: query, comparator: numeric }
+```
+
 ### pagination — one strategy key (or inherit from defaults)
 
 ```yaml

--- a/connectors/http/extract.go
+++ b/connectors/http/extract.go
@@ -33,6 +33,9 @@ func (c *Connector) extract(ctx context.Context, sink recordSink, opts extractOp
 	c.incrementalResources = opts.IncrementalResources
 	c.buildEnabledFilter(opts.EnabledResources)
 	c.buildResourceFilter(opts.Resources)
+	c.mu.Lock()
+	c.parentRecords = make(map[string][]Capture)
+	c.mu.Unlock()
 
 	topLevel, children := manifest.Split(c.filteredResources(c.manifest.Resources))
 
@@ -90,6 +93,12 @@ func (c *Connector) extractConcurrent(ctx context.Context, resources []manifest.
 
 func (c *Connector) extractChildResource(ctx context.Context, res manifest.Resource, sink recordSink) error {
 	parents := c.snapshotCaptures(res.Parent.Resource)
+	if res.Parent.Since != "" {
+		var err error
+		if parents, err = c.gateParents(res, parents); err != nil {
+			return err
+		}
+	}
 	if len(parents) == 0 {
 		return nil
 	}
@@ -141,28 +150,9 @@ func (c *Connector) extractResource(ctx context.Context, res manifest.Resource, 
 			return fmt.Errorf("resource name: %w", err)
 		}
 	}
-	var tracker *incremental.Tracker
-	if res.Incremental != nil && c.incrementalEnabled(stateResource, res.Name) {
-		spec := *res.Incremental
-		if field, ok := manifest.IncrementalCursorField(res); ok {
-			spec.CursorPath = field.Path
-		}
-		if lookback, ok := c.incrementalLookbacks[stateResource]; ok {
-			spec.OverlapSeconds = lookback
-		} else if lookback, ok := c.incrementalLookbacks[res.Name]; ok {
-			spec.OverlapSeconds = lookback
-		}
-		seed := ""
-		if c.resumeWatermarks != nil {
-			seed = c.resumeWatermarks[stateResource][spec.DurableCheckpointKey()]
-			if seed == "" && stateResource != res.Name {
-				seed = c.resumeWatermarks[res.Name][spec.DurableCheckpointKey()]
-			}
-		}
-		tracker, err = incremental.New(spec, stateResource, seed)
-		if err != nil {
-			return fmt.Errorf("incremental: %w", err)
-		}
+	tracker, err := c.newTracker(res, stateResource)
+	if err != nil {
+		return err
 	}
 
 	if res.Mode == "stream" {
@@ -181,6 +171,65 @@ func (c *Connector) extractResource(ctx context.Context, res manifest.Resource, 
 
 	_, _, err = c.paginate(ctx, res, sink, parent, pag, extractor, tracker, resumeState)
 	return err
+}
+
+// newTracker builds the incremental tracker for one extraction of res under
+// stateResource, or nil when the resource is not running incrementally.
+func (c *Connector) newTracker(res manifest.Resource, stateResource string) (*incremental.Tracker, error) {
+	if res.Incremental == nil || !c.incrementalEnabled(stateResource, res.Name) {
+		return nil, nil
+	}
+	spec := *res.Incremental
+	if field, ok := manifest.IncrementalCursorField(res); ok {
+		spec.CursorPath = field.Path
+	}
+	if lookback, ok := c.incrementalLookbacks[stateResource]; ok {
+		spec.OverlapSeconds = lookback
+	} else if lookback, ok := c.incrementalLookbacks[res.Name]; ok {
+		spec.OverlapSeconds = lookback
+	}
+	seed := ""
+	if c.resumeWatermarks != nil {
+		seed = c.resumeWatermarks[stateResource][spec.DurableCheckpointKey()]
+		if seed == "" && stateResource != res.Name {
+			seed = c.resumeWatermarks[res.Name][spec.DurableCheckpointKey()]
+		}
+	}
+	tracker, err := incremental.New(spec, stateResource, seed)
+	if err != nil {
+		return nil, fmt.Errorf("incremental: %w", err)
+	}
+	return tracker, nil
+}
+
+// gateParents applies parent.since. Parents with an empty value never had
+// anything for the child to fetch. On an incremental run, parents whose value
+// sorts before the child's effective start have had no activity since the
+// last run, so their fan-out is skipped as well.
+func (c *Connector) gateParents(res manifest.Resource, parents []Capture) ([]Capture, error) {
+	key := res.Parent.Since
+	tracker, err := c.newTracker(res, res.Name)
+	if err != nil {
+		return nil, err
+	}
+	kept := parents[:0]
+	for _, parent := range parents {
+		v := parent[key]
+		if v == "" {
+			continue
+		}
+		if tracker != nil {
+			below, err := tracker.Below(v)
+			if err != nil {
+				return nil, fmt.Errorf("parent.since %q: %w", key, err)
+			}
+			if below {
+				continue
+			}
+		}
+		kept = append(kept, parent)
+	}
+	return kept, nil
 }
 
 func (c *Connector) incrementalEnabled(resource, base string) bool {

--- a/connectors/http/incremental/watermark.go
+++ b/connectors/http/incremental/watermark.go
@@ -57,6 +57,7 @@ type Tracker struct {
 	start string
 
 	wm     *atomicwatermark.Watermark
+	cmp    atomicwatermark.Comparator
 	logger *slog.Logger
 }
 
@@ -106,6 +107,7 @@ func New(spec manifest.IncrementalSpec, resource, initialWatermark string, opts 
 		resource: resource,
 		start:    start,
 		wm:       wm,
+		cmp:      cmp,
 	}
 	for _, opt := range opts {
 		opt(t)
@@ -153,6 +155,20 @@ func (t *Tracker) ObserveChecked(record map[string]any) (bool, error) {
 
 // Current returns the running watermark (max observed or initial).
 func (t *Tracker) Current() string { return t.wm.Current() }
+
+// Start returns the extraction's effective lower bound: the seeded watermark
+// minus overlap. Empty when the run has no starting point.
+func (t *Tracker) Start() string { return t.effective() }
+
+// Below reports whether v sorts before Start under the tracker's comparator.
+// An empty Start admits every value.
+func (t *Tracker) Below(v string) (bool, error) {
+	start := t.effective()
+	if start == "" {
+		return false, nil
+	}
+	return t.cmp.Less(v, start)
+}
 
 // Scope returns a {start_param: effective_start} pair suitable for merging
 // into a template scope's State map. The lower bound is fixed for the entire

--- a/connectors/http/manifest/grammar.v1.json
+++ b/connectors/http/manifest/grammar.v1.json
@@ -200,6 +200,7 @@
         "exclude_fields": { "type": "array", "items": { "type": "string", "minLength": 1 } },
         "params": { "type": "object", "additionalProperties": { "type": "string", "minLength": 1 } },
         "capture": { "type": "object", "additionalProperties": { "type": "string" } },
+        "capture_only": { "type": "boolean" },
         "query": { "type": "object", "additionalProperties": { "type": "string" } },
         "headers": { "type": "object", "additionalProperties": { "type": "string" } },
         "body": {
@@ -228,11 +229,11 @@
         },
         "parent": {
           "type": "object",
-          "required": ["resource"],
           "additionalProperties": false,
           "properties": {
             "resource": { "type": "string" },
-            "concurrency": { "type": "integer", "minimum": 1 }
+            "concurrency": { "type": "integer", "minimum": 1 },
+            "since": { "type": "string", "minLength": 1 }
           }
         },
         "stream": {

--- a/connectors/http/manifest/manifest.go
+++ b/connectors/http/manifest/manifest.go
@@ -263,9 +263,12 @@ type Resource struct {
 	// "$" means an array at the document root; "$.data.items" selects a path.
 	Records string `yaml:"records,omitempty"`
 	// ForEach is concise syntax for parent.resource.
-	ForEach     string            `yaml:"for_each,omitempty"`
-	Params      map[string]string `yaml:"params,omitempty"`
-	Capture     map[string]string `yaml:"capture,omitempty"`
+	ForEach string            `yaml:"for_each,omitempty"`
+	Params  map[string]string `yaml:"params,omitempty"`
+	Capture map[string]string `yaml:"capture,omitempty"`
+	// CaptureOnly resources are walked for their captures and never emitted,
+	// listed, or selectable. They exist to drive children.
+	CaptureOnly bool              `yaml:"capture_only,omitempty"`
 	Query       map[string]string `yaml:"query,omitempty"`
 	Headers     map[string]string `yaml:"headers,omitempty"`
 	Body        BodySpec          `yaml:"body,omitempty"`
@@ -507,6 +510,10 @@ func (s IncrementalSpec) DurableCheckpointKey() string {
 type ParentRef struct {
 	Resource    string `yaml:"resource"`
 	Concurrency int    `yaml:"concurrency,omitempty"`
+	// Since names a captured parent field that gates fan-out. Parents whose
+	// value is empty are skipped; on an incremental run, parents whose value
+	// sorts before the child's effective start are skipped too.
+	Since string `yaml:"since,omitempty"`
 }
 
 // StreamSpec configures streaming-mode decoding of a resource's response.

--- a/connectors/http/manifest/manifest_test.go
+++ b/connectors/http/manifest/manifest_test.go
@@ -207,6 +207,57 @@ func TestParseRejectsInvalidIncrementalContracts(t *testing.T) {
 	}
 }
 
+func TestParseRejectsInvalidCaptureOnlyAndSince(t *testing.T) {
+	const head = "version: 1\nname: test\ndisplay_name: Test\ndescription: Test capture-only manifest.\ndark_logo_url: https://cdn.example.com/test-dark.svg\nlight_logo_url: https://cdn.example.com/test-light.svg\nconnection:\n  base_url: https://example.com\nresources:\n"
+	const incremental = "    incremental:\n      cursor_field: ts\n      start_param: oldest\n      inject_into: query\n      comparator: numeric\n"
+	tests := []struct{ name, body, want string }{
+		{
+			name: "capture_only without capture",
+			body: "  - name: threads\n    path: /threads\n    capture_only: true\n",
+			want: "requires a capture block",
+		},
+		{
+			name: "capture_only with incremental",
+			body: "  - name: threads\n    path: /threads\n    capture_only: true\n    capture:\n      ts: ts\n    fields:\n      ts: string\n" + incremental,
+			want: "cannot be combined with incremental",
+		},
+		{
+			name: "capture_only in discovery include",
+			body: "  - name: threads\n    path: /threads\n    capture_only: true\n    capture:\n      ts: ts\ndiscovery:\n  mode: static\n  include: [threads]\n",
+			want: "is capture_only",
+		},
+		{
+			name: "since without incremental",
+			body: "  - name: threads\n    path: /threads\n    capture:\n      latest_reply: latest_reply\n  - name: replies\n    path: /replies\n    for_each: threads\n    parent:\n      since: latest_reply\n",
+			want: "requires an incremental block",
+		},
+		{
+			name: "since not captured by parent",
+			body: "  - name: threads\n    path: /threads\n    capture:\n      ts: ts\n  - name: replies\n    path: /replies\n    for_each: threads\n    parent:\n      since: latest_reply\n    fields:\n      ts: string\n" + incremental,
+			want: "is not captured by parent",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(head + tt.body))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseForEachPairsWithParentSince(t *testing.T) {
+	m, err := Parse([]byte("version: 1\nname: test\ndisplay_name: Test\ndescription: Test since manifest.\ndark_logo_url: https://cdn.example.com/test-dark.svg\nlight_logo_url: https://cdn.example.com/test-light.svg\nconnection:\n  base_url: https://example.com\nresources:\n  - name: threads\n    path: /threads\n    capture_only: true\n    capture:\n      latest_reply: latest_reply\n  - name: replies\n    path: /replies\n    for_each: threads\n    parent:\n      since: latest_reply\n    fields:\n      ts: string\n    incremental:\n      cursor_field: ts\n      start_param: oldest\n      inject_into: query\n      comparator: numeric\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	replies := m.Resources[1]
+	if replies.Parent == nil || replies.Parent.Resource != "threads" || replies.Parent.Since != "latest_reply" {
+		t.Fatalf("parent = %#v, want for_each resource with since", replies.Parent)
+	}
+}
+
 func TestParseConciseBasicAuth(t *testing.T) {
 	m, err := Parse([]byte(`
 version: 1

--- a/connectors/http/manifest/validate.go
+++ b/connectors/http/manifest/validate.go
@@ -86,8 +86,13 @@ func (m *Manifest) Normalize() {
 				r.Response.RecordsPath = strings.TrimPrefix(r.Records, "$.")
 			}
 		}
-		if r.ForEach != "" && r.Parent == nil {
-			r.Parent = &ParentRef{Resource: r.ForEach}
+		if r.ForEach != "" {
+			if r.Parent == nil {
+				r.Parent = &ParentRef{}
+			}
+			if r.Parent.Resource == "" {
+				r.Parent.Resource = r.ForEach
+			}
 		}
 		if r.Pagination.Type == "none" {
 			r.Pagination.Type = ""
@@ -146,6 +151,7 @@ func (m *Manifest) validateSemantics() error {
 	validateAuthParams(&agg, "connection.auth", m.Connection.Auth.Params)
 
 	names := make(map[string]struct{}, len(m.Resources))
+	byName := make(map[string]*Resource, len(m.Resources))
 	for i := range m.Resources {
 		r := &m.Resources[i]
 		path := fmt.Sprintf("resources[%d]", i)
@@ -153,6 +159,7 @@ func (m *Manifest) validateSemantics() error {
 			_ = agg.Addf(path+".name", "is required")
 			continue
 		}
+		byName[r.Name] = r
 		path = fmt.Sprintf("resources[%q]", r.Name)
 		for j, fieldSet := range r.UseFields {
 			if _, ok := m.FieldSets[fieldSet]; !ok {
@@ -169,6 +176,17 @@ func (m *Manifest) validateSemantics() error {
 		}
 		if r.Parent != nil && r.Parent.Resource == "" {
 			_ = agg.Addf(path+".parent.resource", "is required")
+		}
+		if r.CaptureOnly {
+			if len(r.Capture) == 0 {
+				_ = agg.Addf(path+".capture_only", "requires a capture block")
+			}
+			if r.Incremental != nil {
+				_ = agg.Addf(path+".capture_only", "cannot be combined with incremental")
+			}
+			if r.Mode == "stream" {
+				_ = agg.Addf(path+".capture_only", "is not supported for stream resources")
+			}
 		}
 
 		validateTemplate(&agg, path+".emit_as", r.EmitAs)
@@ -300,6 +318,8 @@ func (m *Manifest) validateSemantics() error {
 	for i, name := range m.Discovery.Include {
 		if _, ok := names[name]; !ok {
 			_ = agg.Addf(fmt.Sprintf("discovery.include[%d]", i), "unknown resource %q", name)
+		} else if byName[name].CaptureOnly {
+			_ = agg.Addf(fmt.Sprintf("discovery.include[%d]", i), "resource %q is capture_only", name)
 		}
 	}
 	if m.Discovery.Mode == "dynamic" && len(m.Discovery.Include) > 0 {
@@ -329,9 +349,21 @@ func (m *Manifest) validateSemantics() error {
 		if r.Parent == nil {
 			continue
 		}
-		if _, ok := names[r.Parent.Resource]; !ok {
+		parent, ok := byName[r.Parent.Resource]
+		if !ok {
 			_ = agg.Addf(fmt.Sprintf("resources[%q].parent.resource", r.Name),
 				"unknown parent %q", r.Parent.Resource)
+			continue
+		}
+		if r.Parent.Since == "" {
+			continue
+		}
+		if r.Incremental == nil {
+			_ = agg.Addf(fmt.Sprintf("resources[%q].parent.since", r.Name), "requires an incremental block")
+		}
+		if _, captured := parent.Capture[r.Parent.Since]; !captured {
+			_ = agg.Addf(fmt.Sprintf("resources[%q].parent.since", r.Name),
+				"field %q is not captured by parent %q", r.Parent.Since, r.Parent.Resource)
 		}
 	}
 

--- a/connectors/http/manifests/slack.yaml
+++ b/connectors/http/manifests/slack.yaml
@@ -173,8 +173,6 @@ resources:
       reactions: json?
       metadata: json?
       raw: { path: $, type: json, mode: remainder }
-    capture:
-      thread_ts: ts
     response:
       records: $.messages
       pagination:
@@ -188,13 +186,38 @@ resources:
       checkpoint_key: messages_since
       comparator: numeric
 
+  - name: threads
+    # Slack exposes new activity on an old thread only through the parent's
+    # latest_reply, and conversations.history has no updated-since filter, so
+    # every run re-walks history to find threads that moved. Capture-only:
+    # nothing is emitted, and thread_replies fans out over the result.
+    path: /conversations.history
+    query:
+      channel: "{{ parent.channel_id }}"
+      limit: "999"
+    for_each: conversations
+    capture_only: true
+    capture:
+      thread_ts: ts
+      latest_reply: latest_reply
+    response:
+      records: $.messages
+      pagination:
+        cursor:
+          response: response_metadata.next_cursor
+          request: query.cursor
+
   - name: thread_replies
     path: /conversations.replies
     query:
       channel: "{{ parent.channel_id }}"
       ts: "{{ parent.thread_ts }}"
       limit: "200"
-    for_each: messages
+    for_each: threads
+    parent:
+      # Only threads with a reply newer than the saved watermark fan out.
+      # Messages without latest_reply never started a thread.
+      since: latest_reply
     primary_key: [channel_id, thread_ts, ts]
     fields:
       channel_id: { path: parent.channel_id, type: string }
@@ -220,6 +243,12 @@ resources:
         cursor:
           response: response_metadata.next_cursor
           request: query.cursor
+    incremental:
+      cursor_field: ts
+      start_param: oldest
+      inject_into: query
+      checkpoint_key: replies_since
+      comparator: numeric
 
   - name: files
     path: /files.list

--- a/connectors/http/paginate.go
+++ b/connectors/http/paginate.go
@@ -366,8 +366,8 @@ func (c *Connector) sendRecords(
 
 	var captured []Capture
 	n := 0
-	emitResource := len(c.enabledResources) == 0
-	if !emitResource {
+	emitResource := !res.CaptureOnly && len(c.enabledResources) == 0
+	if !emitResource && !res.CaptureOnly {
 		_, emitResource = c.enabledResources[res.Name]
 	}
 	for _, rec := range records {

--- a/connectors/http/source.go
+++ b/connectors/http/source.go
@@ -292,7 +292,7 @@ func (s *Source) Discover(ctx context.Context, _ filament.DiscoverOpts) (filamen
 		return filament.DiscoverResult{}, err
 	}
 	if len(res.Resources) == 0 {
-		staticResources := s.connector.manifest.Resources
+		staticResources := listableResources(s.connector.manifest.Resources)
 		if include := s.connector.manifest.Discovery.Include; len(include) > 0 {
 			byName := make(map[string]manifest.Resource, len(staticResources))
 			for _, resource := range staticResources {
@@ -417,12 +417,24 @@ func (s *Source) Schema(_ context.Context, resource string) (rowmodel.Schema, er
 	}
 	base := s.baseResourceName(resource)
 	for _, res := range s.connector.manifest.Resources {
-		if res.Name != base {
+		if res.Name != base || res.CaptureOnly {
 			continue
 		}
 		return rowmodel.Schema{Resource: resource, Fields: schemaFields(res), PrimaryKey: append([]string(nil), res.PrimaryKey...)}, nil
 	}
 	return rowmodel.Schema{}, fmt.Errorf("httpapi source: unknown resource %q", resource)
+}
+
+// listableResources drops capture-only resources, which exist to drive
+// children and are never discovered, selected, or emitted.
+func listableResources(resources []manifest.Resource) []manifest.Resource {
+	out := make([]manifest.Resource, 0, len(resources))
+	for _, res := range resources {
+		if !res.CaptureOnly {
+			out = append(out, res)
+		}
+	}
+	return out
 }
 
 func (s *Source) extract(ctx context.Context, sink arrowbatch.Inlet, opts filament.ExtractOpts, resumeStates map[string]pagination.State, resumeWatermarks map[string]map[string]string) error {
@@ -487,7 +499,7 @@ func (s *Source) planResources(resources, selectors []string) ([]string, error) 
 	if len(resources) > 0 && !hasDynamicSelector {
 		return resources, nil
 	}
-	sorted := manifest.SortResources(s.connector.manifest.Resources)
+	sorted := manifest.SortResources(listableResources(s.connector.manifest.Resources))
 	out := make([]string, 0, len(sorted)+len(selectors))
 	seen := map[string]struct{}{}
 	add := func(resource string) {

--- a/connectors/http/source_test.go
+++ b/connectors/http/source_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -764,14 +765,14 @@ func TestSlackEmbeddedManifestAndMessageFanOut(t *testing.T) {
 			conversationTypes = r.URL.Query().Get("types")
 			fmt.Fprint(w, `{"ok":true,"channels":[{"id":"C123","name":"general","is_channel":true}],"response_metadata":{"next_cursor":""}}`)
 		case "/conversations.history":
-			historyChannels = append(historyChannels, r.URL.Query().Get("channel"))
+			historyChannels = append(historyChannels, r.URL.Query().Get("channel")+"|"+r.URL.Query().Get("oldest"))
 			if r.URL.Query().Get("cursor") == "" {
-				fmt.Fprint(w, `{"ok":true,"messages":[{"type":"message","user":"U123","text":"hello","ts":"1710000000.000001"}],"response_metadata":{"next_cursor":"next-page"}}`)
+				fmt.Fprint(w, `{"ok":true,"messages":[{"type":"message","user":"U123","text":"hello","ts":"1710000000.000001","reply_count":1,"latest_reply":"1710000100.000001"},{"type":"message","user":"U111","text":"no thread","ts":"1710000000.000005"}],"response_metadata":{"next_cursor":"next-page"}}`)
 				return
 			}
-			fmt.Fprint(w, `{"ok":true,"messages":[{"type":"message","user":"U456","text":"world","ts":"1710000001.000002"}],"response_metadata":{"next_cursor":""}}`)
+			fmt.Fprint(w, `{"ok":true,"messages":[{"type":"message","user":"U456","text":"world","ts":"1710000001.000002","reply_count":1,"latest_reply":"1710000300.000002"}],"response_metadata":{"next_cursor":""}}`)
 		case "/conversations.replies":
-			replyScopes = append(replyScopes, r.URL.Query().Get("channel")+"|"+r.URL.Query().Get("ts"))
+			replyScopes = append(replyScopes, r.URL.Query().Get("channel")+"|"+r.URL.Query().Get("ts")+"|"+r.URL.Query().Get("oldest"))
 			fmt.Fprintf(w, `{"ok":true,"messages":[{"type":"message","user":"U789","text":"reply","ts":"%s"}],"response_metadata":{"next_cursor":""}}`, r.URL.Query().Get("ts"))
 		default:
 			http.NotFound(w, r)
@@ -817,17 +818,12 @@ func TestSlackEmbeddedManifestAndMessageFanOut(t *testing.T) {
 	if conversationTypes != "public_channel" {
 		t.Fatalf("conversation types = %q, want least-privilege public_channel default", conversationTypes)
 	}
-	if len(historyChannels) != 2 || historyChannels[0] != "C123" || historyChannels[1] != "C123" {
-		t.Fatalf("history channels = %v, want C123 for both pages", historyChannels)
+	if len(historyChannels) != 2 || historyChannels[0] != "C123|" || historyChannels[1] != "C123|" {
+		t.Fatalf("history channels = %v, want an unfiltered C123 walk for both pages", historyChannels)
 	}
-	gotReplyScopes := make(map[string]bool, len(replyScopes))
-	for _, scope := range replyScopes {
-		gotReplyScopes[scope] = true
-	}
-	if len(replyScopes) != 2 ||
-		!gotReplyScopes["C123|1710000000.000001"] ||
-		!gotReplyScopes["C123|1710000001.000002"] {
-		t.Fatalf("reply scopes = %v, want inherited channel and message timestamps", replyScopes)
+	sort.Strings(replyScopes)
+	if want := []string{"C123|1710000000.000001|", "C123|1710000001.000002|"}; !slices.Equal(replyScopes, want) {
+		t.Fatalf("reply scopes = %v, want only thread parents with inherited channel", replyScopes)
 	}
 	if len(sink.records) != 2 {
 		t.Fatalf("records = %#v, want two thread replies only", sink.records)
@@ -843,6 +839,33 @@ func TestSlackEmbeddedManifestAndMessageFanOut(t *testing.T) {
 		if data["channel_id"] != "C123" {
 			t.Fatalf("channel_id = %#v, want inherited C123", data["channel_id"])
 		}
+	}
+
+	// Incremental: history is still walked in full, but only the thread whose
+	// latest_reply passed the saved replies watermark fans out, with oldest set.
+	historyChannels, replyScopes = nil, nil
+	prev := map[string]filament.Checkpoint{
+		"thread_replies": checkpoint.KeysetCheckpoint{
+			Mode: checkpoint.ModeIncremental, Cols: []string{"replies_since"}, Types: []string{"string"},
+			Shards: []checkpoint.KeysetShard{{Key: []string{"1710000200"}}},
+		}.ToCheckpoint("thread_replies"),
+	}
+	plan, err := src.PlanIncremental(ctx, []string{"thread_replies"}, prev, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var incr collectSink
+	if err := src.ExtractFrom(ctx, &incr, filament.ExtractOpts{Resources: []string{"thread_replies"}, Parallelism: 1}, plan); err != nil {
+		t.Fatalf("extract incremental thread replies: %v", err)
+	}
+	if len(historyChannels) != 2 || historyChannels[0] != "C123|" {
+		t.Fatalf("incremental history channels = %v, want an unfiltered walk", historyChannels)
+	}
+	if want := []string{"C123|1710000001.000002|1710000200"}; !slices.Equal(replyScopes, want) {
+		t.Fatalf("incremental reply scopes = %v, want %v", replyScopes, want)
+	}
+	if len(incr.records) != 1 {
+		t.Fatalf("incremental records = %#v, want one", incr.records)
 	}
 }
 
@@ -1096,6 +1119,139 @@ discovery:
 	}
 	if fanOut.Resource != "children" || fanOut.ParentsTotal != 1 {
 		t.Fatalf("fan-out progress = %#v", fanOut)
+	}
+}
+
+func TestCaptureOnlyParentGatesChildFanOutOnSince(t *testing.T) {
+	ctx := context.Background()
+	var threadRequests int
+	var replyRequests []string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/threads":
+			threadRequests++
+			fmt.Fprint(w, `[{"ts":"1"},{"ts":"2","latest_reply":"100"},{"ts":"3","latest_reply":"300"}]`)
+		case "/replies":
+			q := r.URL.Query()
+			replyRequests = append(replyRequests, q.Get("ts")+"|"+q.Get("oldest"))
+			fmt.Fprintf(w, `[{"ts":"%s"}]`, q.Get("ts")+"50")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	path := filepath.Join(t.TempDir(), "since.yaml")
+	data := fmt.Sprintf(`version: 1
+name: since
+display_name: Since
+description: Test parent.since gating.
+dark_logo_url: https://cdn.example.com/since-dark.svg
+light_logo_url: https://cdn.example.com/since-light.svg
+connection:
+  base_url: %s
+resources:
+  - name: threads
+    path: /threads
+    capture_only: true
+    capture:
+      thread_ts: ts
+      latest_reply: latest_reply
+    response:
+      records: $
+      pagination: none
+  - name: replies
+    path: /replies
+    query:
+      ts: "{{ parent.thread_ts }}"
+    for_each: threads
+    parent:
+      since: latest_reply
+    primary_key: [ts]
+    fields:
+      ts: string
+    response:
+      records: $
+      pagination: none
+    incremental:
+      cursor_field: ts
+      start_param: oldest
+      inject_into: query
+      checkpoint_key: replies_since
+      comparator: numeric
+`, api.URL)
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	src := New()
+	if err := src.Configure(ctx, filament.NewConfig(map[string]any{"manifest_path": path})); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	defer src.Teardown(ctx)
+
+	discovered, err := src.Discover(ctx, filament.DiscoverOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(discovered.Resources) != 1 || discovered.Resources[0].Name != "replies" {
+		t.Fatalf("discovered = %#v, want only replies", discovered.Resources)
+	}
+	planned, err := src.PlanResources(ctx, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(planned) != 1 || planned[0] != "replies" {
+		t.Fatalf("planned = %v, want only replies", planned)
+	}
+	if _, err := src.Schema(ctx, "threads"); err == nil {
+		t.Fatal("schema for capture-only resource should fail")
+	}
+
+	// Full run: every parent with a since value fans out, none of the
+	// capture-only parent's records are emitted.
+	var full collectSink
+	if err := src.Extract(ctx, &full, filament.ExtractOpts{Resources: []string{"replies"}}); err != nil {
+		t.Fatalf("extract full: %v", err)
+	}
+	if threadRequests != 1 {
+		t.Fatalf("thread requests = %d, want 1", threadRequests)
+	}
+	sort.Strings(replyRequests)
+	if want := []string{"2|", "3|"}; !slices.Equal(replyRequests, want) {
+		t.Fatalf("full-run reply requests = %v, want %v", replyRequests, want)
+	}
+	for _, rec := range full.records {
+		if rec.Resource != "replies" {
+			t.Fatalf("emitted %q, want only replies", rec.Resource)
+		}
+	}
+	if len(full.records) != 2 {
+		t.Fatalf("emitted %d records, want 2", len(full.records))
+	}
+
+	// Incremental run: only parents at or past the replies watermark fan out,
+	// and the watermark is pushed into the request.
+	replyRequests = nil
+	prev := map[string]filament.Checkpoint{
+		"replies": checkpoint.KeysetCheckpoint{
+			Mode: checkpoint.ModeIncremental, Cols: []string{"replies_since"}, Types: []string{"string"},
+			Shards: []checkpoint.KeysetShard{{Key: []string{"200"}}},
+		}.ToCheckpoint("replies"),
+	}
+	plan, err := src.PlanIncremental(ctx, []string{"replies"}, prev, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var incr collectSink
+	if err := src.ExtractFrom(ctx, &incr, filament.ExtractOpts{Resources: []string{"replies"}}, plan); err != nil {
+		t.Fatalf("extract incremental: %v", err)
+	}
+	if want := []string{"3|200"}; !slices.Equal(replyRequests, want) {
+		t.Fatalf("incremental reply requests = %v, want %v", replyRequests, want)
+	}
+	if len(incr.records) != 1 || incr.records[0].Key[0] != "350" {
+		t.Fatalf("incremental records = %#v, want one keyed by the new watermark", incr.records)
 	}
 }
 

--- a/docs/pages/connectors/building-a-connector/http-manifests.mdx
+++ b/docs/pages/connectors/building-a-connector/http-manifests.mdx
@@ -123,6 +123,19 @@ The parent's `capture` block names the values available to the child. Child
 requests default to five concurrent calls, and relationships can nest, such as
 Resend webhooks → events → attempts.
 
+A resource marked `capture_only: true` is walked for its captures and nothing
+else. It is never emitted, discovered, or selectable, and it only runs when a
+child that depends on it is selected. Use it when the parent walk a child needs
+differs from the parent resource users read, for example a full history walk
+that finds threads with new activity while the readable messages resource
+stays incremental.
+
+A child can gate its fan-out with `parent.since: <captured key>`. Parents whose
+captured value is empty are skipped on every run. On an incremental run, parents
+whose value sorts before the child's effective lower bound under the child's
+comparator are skipped too, so the child only calls the API for parents that
+changed since the last run. The child must declare an `incremental` block.
+
 ### Incremental
 
 An `incremental` block turns a resource into an incremental read:

--- a/docs/pages/connectors/sources/slack.mdx
+++ b/docs/pages/connectors/sources/slack.mdx
@@ -25,10 +25,15 @@ because `conversations.history` rejects channels the bot can discover but has
 not joined. It captures each channel id, and `messages` (one history walk per
 conversation), `bookmarks`, and `pins` fan out from it.
 
-`thread_replies` fans out from `messages`. The capture is unconditional, so
-it issues one `conversations.replies` request for **every** message, not just
-messages that started a thread. On a busy workspace this dominates the
-request count. `files` is an independent top-level list.
+`thread_replies` fans out from a capture-only `threads` walk of
+`conversations.history`, not from `messages`. Slack reveals new replies on an
+old thread only through the parent message's `latest_reply`, and history has
+no updated-since filter, so the walk reads every message in every enabled
+conversation on every run. It emits nothing. `thread_replies` then calls
+`conversations.replies` only for parents whose `latest_reply` is at or past the
+saved replies watermark, so messages that never started a thread and threads
+with no new activity cost no request. `files` is an independent top-level
+list.
 
 ## Modes
 
@@ -37,21 +42,31 @@ after its last completed page. Children
 (`messages`, `thread_replies`, `bookmarks`, `pins`) always restart with their
 parent.
 
-Two resources are incremental.
+Three resources are incremental.
 
 | Resource | Cursor field | Request parameter | Checkpoint key |
 |---|---|---|---|
 | `messages` | `ts` | `oldest` (query) | `messages_since` |
+| `thread_replies` | `ts` | `oldest` (query) | `replies_since` |
 | `files` | `created` | `ts_from` (query) | `files_created` |
 
-Both use the `numeric` comparator (Slack timestamps are epoch numbers) and
+All use the `numeric` comparator (Slack timestamps are epoch numbers) and
 declare no overlap window. The cursor field is fixed by the manifest. Only a
 lookback window is user-configurable, which the numeric comparator supports.
-All conversations share one saved `messages` cursor. For example, Filament may
-finish scanning a busy channel after a newer message was posted to a quiet
-channel that it already scanned. Without a lookback, that quiet-channel message
-can fall before the next run's starting cursor. Configure a lookback window if
-late arrivals matter.
+All conversations share one saved `messages` cursor, and all threads share one
+saved `replies_since` cursor. For example, Filament may finish scanning a busy
+channel after a newer message was posted to a quiet channel that it already
+scanned. Without a lookback, that quiet-channel message can fall before the
+next run's starting cursor. The same race applies to a reply posted in one
+thread while a later thread is still being read. Configure a lookback of at
+least one run's duration on `messages` and `thread_replies` if late arrivals
+matter.
+
+An incremental `thread_replies` run still walks the full history of every
+enabled conversation to find threads that moved. On a Tier 3 token that is
+about one request per thousand messages at fifty or more requests a minute.
+Edits and deletions of messages and replies are never observed, because Slack
+keeps the original `ts` and history exposes no change filter.
 
 ## Behavior
 
@@ -64,6 +79,11 @@ late arrivals matter.
   exception. It uses page-number pagination (`page`/`count`, 100 per page,
   bounded by `paging.pages`).
 - **Rate limiting**: no client-side limiter is configured. The engine backs
-  off on 429 responses using `Retry-After`.
+  off on 429 responses using `Retry-After`. Use a token from an app you
+  created in your own workspace. Since May 2025 Slack limits apps distributed
+  commercially outside the Slack Marketplace to one `conversations.history` or
+  `conversations.replies` request per minute with fifteen messages per page,
+  which makes every message resource unusable at scale. Internal apps and
+  Marketplace apps keep the standard Tier 3 limits.
 - Every resource carries a `raw` remainder column preserving fields the
   manifest does not project.


### PR DESCRIPTION
- Slack only reveals new replies on old threads through the parent's latest_reply, and history has no updated-since filter.
- Previously thread_replies fanned out from incremental messages, so replies on any thread older than the messages watermark were never fetched
- Engine: capture_only: true marks a resource that is walked for captures and never emitted, listed, or selectable
- Slack: new capture-only threads walk of conversations.history