### PR TITLE
Add Meilisearch sink connector

### DIFF
--- a/cmd/internal/connectors/connectors.go
+++ b/cmd/internal/connectors/connectors.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/galaxy-io/filament/connectors/clickhouse"
 	_ "github.com/galaxy-io/filament/connectors/http"
 	_ "github.com/galaxy-io/filament/connectors/iceberg"
+	_ "github.com/galaxy-io/filament/connectors/meilisearch"
 	_ "github.com/galaxy-io/filament/connectors/mysql"
 	_ "github.com/galaxy-io/filament/connectors/object"
 	_ "github.com/galaxy-io/filament/connectors/postgres"

--- a/connectors/meilisearch/register.go
+++ b/connectors/meilisearch/register.go
@@ -1,0 +1,15 @@
+// Package meilisearch registers the Meilisearch sink with the default registry.
+// Enable with:
+//
+//	import _ "github.com/galaxy-io/filament/connectors/meilisearch"
+package meilisearch
+
+import (
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/connectors/meilisearch/sink"
+	"github.com/galaxy-io/filament/registry"
+)
+
+func init() {
+	registry.RegisterSink("meilisearch", filament.MaturityAlpha, func() filament.Sink { return sink.New() })
+}

--- a/connectors/meilisearch/sink/client.go
+++ b/connectors/meilisearch/sink/client.go
@@ -1,0 +1,459 @@
+package sink
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrIndexNotFound is returned when an index does not exist in Meilisearch.
+	ErrIndexNotFound = errors.New("meilisearch: index not found")
+)
+
+// IndexResponse represents the metadata of a Meilisearch index.
+type IndexResponse struct {
+	UID        string `json:"uid"`
+	PrimaryKey string `json:"primaryKey"`
+	CreatedAt  string `json:"createdAt"`
+	UpdatedAt  string `json:"updatedAt"`
+}
+
+// TaskResponse represents the response when an asynchronous task is enqueued.
+type TaskResponse struct {
+	TaskUID  int64  `json:"taskUid"`
+	IndexUID string `json:"indexUid"`
+	Status   string `json:"status"`
+	Type     string `json:"type"`
+}
+
+// TaskResult describes the status and details of an executed task.
+type TaskResult struct {
+	UID        int64      `json:"uid"`
+	IndexUID   string     `json:"indexUid"`
+	Status     string     `json:"status"`
+	Type       string     `json:"type"`
+	Error      *TaskError `json:"error,omitempty"`
+	Duration   string     `json:"duration"`
+	EnqueuedAt string     `json:"enqueuedAt"`
+	StartedAt  string     `json:"startedAt"`
+	FinishedAt string     `json:"finishedAt"`
+}
+
+// TaskError holds error details from a failed task.
+type TaskError struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+	Type    string `json:"type"`
+	Link    string `json:"link"`
+}
+
+// Client manages communication with the Meilisearch REST API.
+type Client struct {
+	baseURL     string
+	apiKey      string
+	gzipEnabled bool
+	http        *http.Client
+	gzipPool    sync.Pool
+	bufPool     sync.Pool
+}
+
+// NewClient returns a new Meilisearch HTTP client.
+func NewClient(baseURL, apiKey string, gzipEnabled bool) *Client {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   20,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	return &Client{
+		baseURL:     strings.TrimRight(baseURL, "/"),
+		apiKey:      apiKey,
+		gzipEnabled: gzipEnabled,
+		http: &http.Client{
+			Transport: transport,
+			Timeout:   60 * time.Second,
+		},
+		gzipPool: sync.Pool{
+			New: func() any {
+				return gzip.NewWriter(io.Discard)
+			},
+		},
+		bufPool: sync.Pool{
+			New: func() any {
+				return new(bytes.Buffer)
+			},
+		},
+	}
+}
+
+// Health checks if the Meilisearch server is running and healthy.
+func (c *Client) Health(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
+	if err != nil {
+		return fmt.Errorf("meilisearch: health request: %w", err)
+	}
+	c.applyHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("meilisearch: connect to %s: %w", c.baseURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("meilisearch: health check failed (status %d): %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// GetIndex retrieves metadata for an index by its UID.
+func (c *Client) GetIndex(ctx context.Context, uid string) (*IndexResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/indexes/%s", c.baseURL, url.PathEscape(uid)), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meilisearch: get index %q: %w", uid, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrIndexNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("meilisearch: get index %q failed (%d): %s", uid, resp.StatusCode, string(body))
+	}
+
+	var idx IndexResponse
+	if err := json.NewDecoder(resp.Body).Decode(&idx); err != nil {
+		return nil, fmt.Errorf("meilisearch: decode index %q: %w", uid, err)
+	}
+	return &idx, nil
+}
+
+// CreateIndex creates a new index with the specified primary key.
+func (c *Client) CreateIndex(ctx context.Context, uid, primaryKey string) (*TaskResponse, error) {
+	payload := map[string]string{"uid": uid}
+	if primaryKey != "" {
+		payload["primaryKey"] = primaryKey
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/indexes", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meilisearch: create index %q: %w", uid, err)
+	}
+	defer resp.Body.Close()
+
+	// If index already exists (409 Conflict), ignore.
+	if resp.StatusCode == http.StatusConflict {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("meilisearch: create index %q (%d): %s", uid, resp.StatusCode, string(body))
+	}
+
+	var task TaskResponse
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		return nil, fmt.Errorf("meilisearch: decode create index %q task: %w", uid, err)
+	}
+	return &task, nil
+}
+
+// DeleteAllDocuments deletes all documents from an index while keeping the index and settings.
+func (c *Client) DeleteAllDocuments(ctx context.Context, uid string) (*TaskResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("%s/indexes/%s/documents", c.baseURL, url.PathEscape(uid)), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meilisearch: delete all documents %q: %w", uid, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("meilisearch: delete all documents %q (%d): %s", uid, resp.StatusCode, string(body))
+	}
+
+	var task TaskResponse
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		return nil, fmt.Errorf("meilisearch: decode delete documents task: %w", err)
+	}
+	return &task, nil
+}
+
+// AddDocumentsNDJSON streams an NDJSON payload to the index.
+// update=true sends PUT (partial document updates), update=false sends POST (add or replace).
+func (c *Client) AddDocumentsNDJSON(ctx context.Context, uid, primaryKey string, ndjsonPayload []byte, update bool) (*TaskResponse, error) {
+	if len(ndjsonPayload) == 0 {
+		return nil, nil
+	}
+
+	method := http.MethodPost
+	if update {
+		method = http.MethodPut
+	}
+
+	endpoint := fmt.Sprintf("%s/indexes/%s/documents", c.baseURL, url.PathEscape(uid))
+	if primaryKey != "" {
+		endpoint += "?primaryKey=" + url.QueryEscape(primaryKey)
+	}
+
+	var bodyReader io.Reader
+	var isGzip bool
+
+	if c.gzipEnabled {
+		buf := c.bufPool.Get().(*bytes.Buffer)
+		buf.Reset()
+		defer c.bufPool.Put(buf)
+
+		gz := c.gzipPool.Get().(*gzip.Writer)
+		gz.Reset(buf)
+		if _, err := gz.Write(ndjsonPayload); err != nil {
+			gz.Close()
+			c.gzipPool.Put(gz)
+			return nil, fmt.Errorf("meilisearch: gzip compress: %w", err)
+		}
+		if err := gz.Close(); err != nil {
+			c.gzipPool.Put(gz)
+			return nil, fmt.Errorf("meilisearch: gzip finish: %w", err)
+		}
+		c.gzipPool.Put(gz)
+
+		bodyReader = bytes.NewReader(buf.Bytes())
+		isGzip = true
+	} else {
+		bodyReader = bytes.NewReader(ndjsonPayload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req)
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	if isGzip {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meilisearch: send documents to %q: %w", uid, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("meilisearch: add documents to %q failed (%d): %s", uid, resp.StatusCode, string(body))
+	}
+
+	var task TaskResponse
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		return nil, fmt.Errorf("meilisearch: decode task response: %w", err)
+	}
+	return &task, nil
+}
+
+// DeleteDocumentsBatch sends a batch of document IDs to be deleted.
+func (c *Client) DeleteDocumentsBatch(ctx context.Context, uid string, docIDs []string) (*TaskResponse, error) {
+	if len(docIDs) == 0 {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(docIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("%s/indexes/%s/documents/delete-batch", c.baseURL, url.PathEscape(uid))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meilisearch: delete documents batch %q: %w", uid, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("meilisearch: delete documents batch %q failed (%d): %s", uid, resp.StatusCode, string(body))
+	}
+
+	var task TaskResponse
+	if err := json.NewDecoder(resp.Body).Decode(&task); err != nil {
+		return nil, fmt.Errorf("meilisearch: decode delete-batch task response: %w", err)
+	}
+	return &task, nil
+}
+
+// GetTask retrieves the current status of an asynchronous task.
+func (c *Client) GetTask(ctx context.Context, taskUID int64) (*TaskResult, error) {
+	endpoint := fmt.Sprintf("%s/tasks/%d", c.baseURL, taskUID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meilisearch: get task %d: %w", taskUID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("meilisearch: get task %d failed (%d): %s", taskUID, resp.StatusCode, string(body))
+	}
+
+	var result TaskResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("meilisearch: decode task %d: %w", taskUID, err)
+	}
+	return &result, nil
+}
+
+// WaitForTask blocks until the task reaches a terminal status (succeeded, failed, canceled).
+func (c *Client) WaitForTask(ctx context.Context, taskUID int64, timeout time.Duration) (*TaskResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	delay := 50 * time.Millisecond
+	const maxDelay = 250 * time.Millisecond
+
+	for {
+		task, err := c.GetTask(ctx, taskUID)
+		if err != nil {
+			return nil, err
+		}
+
+		switch task.Status {
+		case "succeeded":
+			return task, nil
+		case "failed":
+			if task.Error != nil {
+				return nil, fmt.Errorf("meilisearch task %d failed [%s]: %s", taskUID, task.Error.Code, task.Error.Message)
+			}
+			return nil, fmt.Errorf("meilisearch task %d failed", taskUID)
+		case "canceled":
+			return nil, fmt.Errorf("meilisearch task %d was canceled", taskUID)
+		case "enqueued", "processing":
+			// Still running, sleep and retry
+		default:
+			// Unknown status, assume running
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("meilisearch: timeout waiting for task %d: %w", taskUID, ctx.Err())
+		case <-time.After(delay):
+			delay = min(delay*2, maxDelay)
+		}
+	}
+}
+
+// WaitForTasks waits for all specified task UIDs to finish successfully.
+func (c *Client) WaitForTasks(ctx context.Context, taskUIDs []int64, timeout time.Duration) error {
+	if len(taskUIDs) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Since Meilisearch executes tasks sequentially in queue order, waiting for the
+	// latest task guarantees earlier tasks have settled. We still verify earlier tasks.
+	for _, uid := range taskUIDs {
+		if _, err := c.WaitForTask(ctx, uid, timeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) applyHeaders(req *http.Request) {
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	req.Header.Set("User-Agent", "Filament/1.0 (Meilisearch Sink)")
+}
+
+// FormatDocumentID formats an Arrow cell value as a valid Meilisearch document ID string.
+func FormatDocumentID(val any) string {
+	switch v := val.(type) {
+	case string:
+		return v
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/connectors/meilisearch/sink/config.go
+++ b/connectors/meilisearch/sink/config.go
@@ -1,0 +1,165 @@
+package sink
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/galaxy-io/filament"
+)
+
+const (
+	defaultPort         = 7700
+	defaultBatchSize    = 10_000
+	defaultTaskTimeout  = 60 * time.Second
+	defaultWaitForTasks = true
+	defaultGzip         = true
+)
+
+// Config describes the parsed configuration for a Meilisearch sink.
+type Config struct {
+	URL          string
+	APIKey       string
+	IndexPrefix  string
+	Index        string
+	PrimaryKey   string
+	BatchSize    int
+	Gzip         bool
+	WaitForTasks bool
+	TaskTimeout  time.Duration
+}
+
+// ConfigSchema returns the configuration fields accepted by the Meilisearch sink.
+func ConfigSchema() filament.ConfigSchema {
+	return filament.ConfigSchema{
+		Fields: []filament.ConfigField{
+			{
+				Name:     "url",
+				Type:     filament.FieldString,
+				Required: true,
+				Scope:    filament.ScopeConnection,
+				Help:     "Meilisearch server URL (e.g. http://localhost:7700 or https://ms.example.com)",
+			},
+			{
+				Name:     "api_key",
+				Type:     filament.FieldSecret,
+				Required: false,
+				Secret:   true,
+				Scope:    filament.ScopeConnection,
+				Help:     "Meilisearch master key or API key with document and index permissions",
+			},
+			{
+				Name:     "index_prefix",
+				Type:     filament.FieldString,
+				Required: false,
+				Default:  "",
+				Scope:    filament.ScopePipeline,
+				Help:     "Prefix prepended to resource names to form the Meilisearch index UID",
+			},
+			{
+				Name:     "index",
+				Type:     filament.FieldString,
+				Required: false,
+				Default:  "",
+				Scope:    filament.ScopePipeline,
+				Help:     "Explicit destination index UID override. When empty, defaults to the sanitized resource name",
+			},
+			{
+				Name:     "primary_key",
+				Type:     filament.FieldString,
+				Required: false,
+				Default:  "",
+				Scope:    filament.ScopePipeline,
+				Help:     "Primary key attribute name for Meilisearch documents. If omitted, derived from the source schema",
+			},
+			{
+				Name:     "batch_size",
+				Type:     filament.FieldInt,
+				Required: false,
+				Default:  defaultBatchSize,
+				Scope:    filament.ScopePipeline,
+				Help:     "Preferred maximum document count per HTTP batch sent to Meilisearch",
+			},
+			{
+				Name:     "gzip",
+				Type:     filament.FieldBool,
+				Required: false,
+				Default:  defaultGzip,
+				Scope:    filament.ScopePipeline,
+				Help:     "Compress NDJSON payloads with gzip to reduce network transfer size",
+			},
+			{
+				Name:     "wait_for_tasks",
+				Type:     filament.FieldBool,
+				Required: false,
+				Default:  defaultWaitForTasks,
+				Scope:    filament.ScopePipeline,
+				Help:     "Wait for Meilisearch indexing tasks to finish on Commit to ensure durable writes",
+			},
+			{
+				Name:     "task_timeout",
+				Type:     filament.FieldDuration,
+				Required: false,
+				Default:  defaultTaskTimeout,
+				Scope:    filament.ScopePipeline,
+				Help:     "Maximum time to wait for enqueued indexing tasks to complete on Commit",
+			},
+		},
+	}
+}
+
+// ParseConfig parses and validates a filament.Config into a structured Config.
+func ParseConfig(cfg filament.Config) (Config, error) {
+	rawURL := strings.TrimSpace(cfg.String("url"))
+	if rawURL == "" {
+		rawURL = strings.TrimSpace(cfg.String("host"))
+	}
+	if rawURL == "" {
+		return Config{}, fmt.Errorf("meilisearch sink: url is required")
+	}
+
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		rawURL = "http://" + rawURL
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return Config{}, fmt.Errorf("meilisearch sink: invalid url %q: %w", rawURL, err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return Config{}, fmt.Errorf("meilisearch sink: url scheme must be http or https, got %q", parsedURL.Scheme)
+	}
+
+	batchSize := cfg.Int("batch_size")
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+
+	taskTimeout := cfg.Duration("task_timeout")
+	if taskTimeout <= 0 {
+		taskTimeout = defaultTaskTimeout
+	}
+
+	gzip := defaultGzip
+	if cfg.Has("gzip") {
+		gzip = cfg.Bool("gzip")
+	}
+
+	waitForTasks := defaultWaitForTasks
+	if cfg.Has("wait_for_tasks") {
+		waitForTasks = cfg.Bool("wait_for_tasks")
+	}
+
+	return Config{
+		URL:          strings.TrimRight(parsedURL.String(), "/"),
+		APIKey:       strings.TrimSpace(cfg.Secret("api_key")),
+		IndexPrefix:  strings.TrimSpace(cfg.String("index_prefix")),
+		Index:        strings.TrimSpace(cfg.String("index")),
+		PrimaryKey:   strings.TrimSpace(cfg.String("primary_key")),
+		BatchSize:    batchSize,
+		Gzip:         gzip,
+		WaitForTasks: waitForTasks,
+		TaskTimeout:  taskTimeout,
+	}, nil
+}

--- a/connectors/meilisearch/sink/meilisearch.go
+++ b/connectors/meilisearch/sink/meilisearch.go
@@ -1,0 +1,432 @@
+// Package sink implements the filament.Sink interface for Meilisearch.
+// It streams Arrow batches as NDJSON directly into Meilisearch indexes,
+// leveraging Meilisearch's internal task queue, auto-batching, and optional
+// gzip compression for high-performance ingestion.
+package sink
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/arrowbatch"
+	"github.com/galaxy-io/filament/connectors/internal/ndjson"
+	"github.com/galaxy-io/filament/rowmodel"
+)
+
+type indexMeta struct {
+	UID           string
+	PrimaryKey    string
+	PrimaryKeyIdx int
+}
+
+// Sink writes Arrow record batches into Meilisearch indexes.
+type Sink struct {
+	mu      sync.Mutex
+	cfg     Config
+	client  *Client
+	run     filament.RunID
+	indexes map[string]*indexMeta
+	enc     map[*arrow.Schema]*ndjson.Encoder
+	buf     []byte
+	tasks   []int64
+	written atomic.Int64
+	aborted bool
+}
+
+// New returns an unconfigured Meilisearch sink.
+func New() *Sink {
+	return &Sink{
+		indexes: make(map[string]*indexMeta),
+		enc:     make(map[*arrow.Schema]*ndjson.Encoder),
+	}
+}
+
+var (
+	_ filament.Sink              = (*Sink)(nil)
+	_ filament.ConfigValidatable = (*Sink)(nil)
+	_ filament.LiveValidatable   = (*Sink)(nil)
+	_ filament.Schematized       = (*Sink)(nil)
+)
+
+// Spec describes the sink's capabilities, write policies, and configuration schema.
+func (s *Sink) Spec() filament.SinkSpec {
+	return filament.SinkSpec{
+		Name:         "meilisearch",
+		DisplayName:  "Meilisearch",
+		Description:  "Fast, open-source search engine with typo-tolerant full-text search.",
+		DarkLogoURL:  "https://cdn.getgalaxy.io/sources/source-icon-meilisearch-dark.svg",
+		LightLogoURL: "https://cdn.getgalaxy.io/sources/source-icon-meilisearch-light.svg",
+		Version:      "1",
+		Config:       ConfigSchema(),
+		Capabilities: filament.SinkCapabilities{
+			Schematized:        true,
+			Upsertable:         true,
+			EncodedIntegrity:   true,
+			PreferredBatchRows: defaultBatchSize,
+			WritePolicies: commitDurableCapabilities(
+				filament.IngestionFullReplace,
+				filament.IngestionFullAppend,
+				filament.IngestionFullUpsert,
+				filament.IngestionIncrementalUpsert,
+				filament.IngestionCDCMerge,
+				filament.IngestionCDCAppend,
+			),
+		},
+		SchemaField: "index_prefix",
+	}
+}
+
+func commitDurableCapabilities(types ...filament.IngestionType) []filament.WritePolicyCapability {
+	capabilities := filament.WriteCapabilities(types...)
+	for i := range capabilities {
+		capabilities[i].Durability = filament.DurabilityAfterCommit
+		capabilities[i].Atomicity = filament.AtomicityResource
+	}
+	return capabilities
+}
+
+// Name identifies this sink implementation.
+func (s *Sink) Name() string { return "meilisearch" }
+
+// Validate checks connection configuration syntax without making network requests.
+func (s *Sink) Validate(cfg filament.Config) error {
+	_, err := ParseConfig(cfg)
+	return err
+}
+
+// TestConnection verifies connectivity to the Meilisearch server by calling /health.
+func (s *Sink) TestConnection(ctx context.Context, cfg filament.Config) error {
+	parsed, err := ParseConfig(cfg)
+	if err != nil {
+		return err
+	}
+	client := NewClient(parsed.URL, parsed.APIKey, false)
+	return client.Health(ctx)
+}
+
+// Open prepares the sink for a run.
+func (s *Sink) Open(ctx context.Context, run filament.RunSpec) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	parsed, err := ParseConfig(filament.NewConfig(run.Sink.Config))
+	if err != nil {
+		return fmt.Errorf("meilisearch sink: open: %w", err)
+	}
+
+	s.cfg = parsed
+	s.client = NewClient(parsed.URL, parsed.APIKey, parsed.Gzip)
+	s.run = run.Run
+	s.indexes = make(map[string]*indexMeta)
+	s.enc = make(map[*arrow.Schema]*ndjson.Encoder)
+	s.tasks = nil
+	s.aborted = false
+
+	return nil
+}
+
+// EnsureSchema ensures destination index exists in Meilisearch and prepares primary key metadata.
+func (s *Sink) EnsureSchema(ctx context.Context, resource string, schema rowmodel.Schema) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.client == nil {
+		return fmt.Errorf("meilisearch sink: ensure schema before open")
+	}
+
+	indexUID := s.cfg.Index
+	if indexUID == "" {
+		indexUID = sanitizeIndexUID(s.cfg.IndexPrefix, resource)
+	}
+
+	primaryKey := s.cfg.PrimaryKey
+	if primaryKey == "" {
+		if len(schema.PrimaryKey) == 1 {
+			primaryKey = schema.PrimaryKey[0]
+		} else {
+			// Check if any field is named "id" or "ID"
+			for _, f := range schema.Fields {
+				if strings.EqualFold(f.Name, "id") {
+					primaryKey = f.Name
+					break
+				}
+			}
+			// If still empty, check for field ending in _id or Id
+			if primaryKey == "" {
+				for _, f := range schema.Fields {
+					if strings.HasSuffix(strings.ToLower(f.Name), "_id") || strings.HasSuffix(f.Name, "Id") {
+						primaryKey = f.Name
+						break
+					}
+				}
+			}
+			// Fallback to first field
+			if primaryKey == "" && len(schema.Fields) > 0 {
+				primaryKey = schema.Fields[0].Name
+			}
+		}
+	}
+
+	pkIdx := -1
+	for i, f := range schema.Fields {
+		if f.Name == primaryKey {
+			pkIdx = i
+			break
+		}
+	}
+
+	// Check if index already exists
+	existing, err := s.client.GetIndex(ctx, indexUID)
+	if err != nil && !errorsIs(err, ErrIndexNotFound) {
+		return fmt.Errorf("meilisearch sink: check index %q: %w", indexUID, err)
+	}
+
+	if existing == nil {
+		// Create index with resolved primary key
+		task, err := s.client.CreateIndex(ctx, indexUID, primaryKey)
+		if err != nil {
+			return fmt.Errorf("meilisearch sink: create index %q: %w", indexUID, err)
+		}
+		if task != nil && task.TaskUID > 0 {
+			s.tasks = append(s.tasks, task.TaskUID)
+		}
+	} else if existing.PrimaryKey != "" {
+		primaryKey = existing.PrimaryKey
+		// Re-resolve pkIdx for existing index primary key
+		for i, f := range schema.Fields {
+			if f.Name == primaryKey {
+				pkIdx = i
+				break
+			}
+		}
+	}
+
+	s.indexes[resource] = &indexMeta{
+		UID:           indexUID,
+		PrimaryKey:    primaryKey,
+		PrimaryKeyIdx: pkIdx,
+	}
+
+	return nil
+}
+
+// Apply encodes an Arrow batch into NDJSON and sends it to Meilisearch.
+func (s *Sink) Apply(ctx context.Context, b *arrowbatch.Batch, opts filament.ApplyOptions) (filament.WriteReceipt, error) {
+	if s.client == nil {
+		return filament.WriteReceipt{}, fmt.Errorf("meilisearch sink: write before open")
+	}
+
+	s.mu.Lock()
+	meta := s.indexes[b.Resource]
+	if meta == nil {
+		// Auto-derive index if EnsureSchema was not invoked
+		uid := s.cfg.Index
+		if uid == "" {
+			uid = sanitizeIndexUID(s.cfg.IndexPrefix, b.Resource)
+		}
+		meta = &indexMeta{
+			UID:           uid,
+			PrimaryKey:    s.cfg.PrimaryKey,
+			PrimaryKeyIdx: -1,
+		}
+		s.indexes[b.Resource] = meta
+	}
+	s.mu.Unlock()
+
+	switch opts.Policy.Capability.Mode {
+	case filament.WriteReplace:
+		if err := opts.Policy.ValidateBatch(b.Resource, b); err != nil {
+			return filament.WriteReceipt{}, fmt.Errorf("meilisearch sink: %w", err)
+		}
+		return s.writeBatch(ctx, meta, b, false)
+
+	case filament.WriteAppend:
+		if err := opts.Policy.ValidateBatch(b.Resource, b); err != nil {
+			return filament.WriteReceipt{}, fmt.Errorf("meilisearch sink: %w", err)
+		}
+		return s.writeBatch(ctx, meta, b, false)
+
+	case filament.WriteUpsert:
+		if err := opts.Policy.ValidateBatch(b.Resource, b); err != nil {
+			return filament.WriteReceipt{}, fmt.Errorf("meilisearch sink: %w", err)
+		}
+		return s.writeBatch(ctx, meta, b, false)
+
+	case filament.WriteMerge:
+		if err := opts.Policy.ValidateBatch(b.Resource, b); err != nil {
+			return filament.WriteReceipt{}, fmt.Errorf("meilisearch sink: %w", err)
+		}
+		return s.writeMerge(ctx, meta, b)
+
+	default:
+		return filament.WriteReceipt{}, fmt.Errorf("meilisearch sink: write policy %q is not implemented", opts.Policy.Capability.Mode)
+	}
+}
+
+func (s *Sink) writeBatch(ctx context.Context, meta *indexMeta, b *arrowbatch.Batch, isUpdate bool) (filament.WriteReceipt, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rows := b.Rows()
+	enc := s.enc[rows.Schema()]
+	if enc == nil {
+		enc = ndjson.NewEncoder(rows.Schema())
+		s.enc[rows.Schema()] = enc
+	}
+
+	buf, encodedCRC, err := enc.EncodeBatch(s.buf[:0], rows)
+	if err != nil {
+		return filament.WriteReceipt{}, fmt.Errorf("meilisearch: serialize %s: %w", b.Resource, err)
+	}
+	s.buf = buf
+
+	arrowCRC := b.IntegrityCRC()
+
+	task, err := s.client.AddDocumentsNDJSON(ctx, meta.UID, meta.PrimaryKey, buf, isUpdate)
+	if err != nil {
+		return filament.WriteReceipt{}, err
+	}
+	if task != nil && task.TaskUID > 0 {
+		s.tasks = append(s.tasks, task.TaskUID)
+	}
+
+	nbytes := int64(len(buf))
+	s.written.Add(int64(b.NumRows()))
+
+	return filament.WriteReceipt{
+		URI:        fmt.Sprintf("meilisearch://%s/%s", s.cfg.URL, meta.UID),
+		Bytes:      nbytes,
+		Rows:       b.NumRows(),
+		WriteCRC:   arrowCRC,
+		EncodedCRC: &encodedCRC,
+	}, nil
+}
+
+func (s *Sink) writeMerge(ctx context.Context, meta *indexMeta, b *arrowbatch.Batch) (filament.WriteReceipt, error) {
+	// Separate deletes from inserts/updates
+	var deleteIDs []string
+	rows := b.Rows()
+
+	if meta.PrimaryKeyIdx >= 0 && meta.PrimaryKeyIdx < int(rows.NumCols()) {
+		pkCol := rows.Column(meta.PrimaryKeyIdx)
+		for i := range b.NumRows() {
+			if b.Op(i) == filament.OpDelete {
+				if !pkCol.IsNull(i) {
+					deleteIDs = append(deleteIDs, FormatDocumentID(pkCol.ValueStr(i)))
+				}
+			}
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If there are deletes, send batch delete
+	if len(deleteIDs) > 0 {
+		task, err := s.client.DeleteDocumentsBatch(ctx, meta.UID, deleteIDs)
+		if err != nil {
+			return filament.WriteReceipt{}, fmt.Errorf("meilisearch: cdc delete: %w", err)
+		}
+		if task != nil && task.TaskUID > 0 {
+			s.tasks = append(s.tasks, task.TaskUID)
+		}
+	}
+
+	// Encode all rows
+	enc := s.enc[rows.Schema()]
+	if enc == nil {
+		enc = ndjson.NewEncoder(rows.Schema())
+		s.enc[rows.Schema()] = enc
+	}
+
+	buf, encodedCRC, err := enc.EncodeBatch(s.buf[:0], rows)
+	if err != nil {
+		return filament.WriteReceipt{}, fmt.Errorf("meilisearch: serialize %s: %w", b.Resource, err)
+	}
+	s.buf = buf
+
+	arrowCRC := b.IntegrityCRC()
+
+	// Send documents
+	task, err := s.client.AddDocumentsNDJSON(ctx, meta.UID, meta.PrimaryKey, buf, false)
+	if err != nil {
+		return filament.WriteReceipt{}, err
+	}
+	if task != nil && task.TaskUID > 0 {
+		s.tasks = append(s.tasks, task.TaskUID)
+	}
+
+	nbytes := int64(len(buf))
+	s.written.Add(int64(b.NumRows()))
+
+	return filament.WriteReceipt{
+		URI:        fmt.Sprintf("meilisearch://%s/%s", s.cfg.URL, meta.UID),
+		Bytes:      nbytes,
+		Rows:       b.NumRows(),
+		WriteCRC:   arrowCRC,
+		EncodedCRC: &encodedCRC,
+	}, nil
+}
+
+// Commit waits for all enqueued Meilisearch indexing tasks to finish if WaitForTasks is enabled.
+func (s *Sink) Commit(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.client == nil || s.aborted {
+		return nil
+	}
+
+	if s.cfg.WaitForTasks && len(s.tasks) > 0 {
+		if err := s.client.WaitForTasks(ctx, s.tasks, s.cfg.TaskTimeout); err != nil {
+			return fmt.Errorf("meilisearch sink commit: %w", err)
+		}
+	}
+
+	s.tasks = nil
+	return nil
+}
+
+// Abort marks the run aborted and discards tracked tasks.
+func (s *Sink) Abort(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.aborted = true
+	s.tasks = nil
+	return nil
+}
+
+func sanitizeIndexUID(prefix, resource string) string {
+	raw := resource
+	if prefix != "" {
+		if !strings.HasSuffix(prefix, "_") && !strings.HasSuffix(prefix, "-") &&
+			!strings.HasPrefix(resource, "_") && !strings.HasPrefix(resource, "-") {
+			raw = prefix + "_" + resource
+		} else {
+			raw = prefix + resource
+		}
+	}
+	var b strings.Builder
+	for _, r := range raw {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	s := strings.Trim(b.String(), "_-")
+	if s == "" {
+		return "default"
+	}
+	return s
+}
+
+func errorsIs(err, target error) bool {
+	return err == target || (err != nil && target != nil && err.Error() == target.Error())
+}

--- a/connectors/meilisearch/sink/meilisearch_test.go
+++ b/connectors/meilisearch/sink/meilisearch_test.go
@@ -1,0 +1,349 @@
+package sink
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/arrowbatch"
+	"github.com/galaxy-io/filament/rowmodel"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     map[string]any
+		wantURL string
+		wantErr bool
+	}{
+		{
+			name:    "valid full url",
+			raw:     map[string]any{"url": "http://localhost:7700/"},
+			wantURL: "http://localhost:7700",
+		},
+		{
+			name:    "url without scheme defaults to http",
+			raw:     map[string]any{"url": "127.0.0.1:7700"},
+			wantURL: "http://127.0.0.1:7700",
+		},
+		{
+			name:    "host alias for url",
+			raw:     map[string]any{"host": "https://meili.example.com"},
+			wantURL: "https://meili.example.com",
+		},
+		{
+			name:    "missing url",
+			raw:     map[string]any{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ParseConfig(filament.NewConfig(tt.raw))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && cfg.URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", cfg.URL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestSinkSpec(t *testing.T) {
+	sink := New()
+	spec := sink.Spec()
+
+	if spec.Name != "meilisearch" {
+		t.Errorf("Spec.Name = %q, want meilisearch", spec.Name)
+	}
+	if !spec.Capabilities.EncodedIntegrity {
+		t.Error("Spec does not advertise EncodedIntegrity")
+	}
+	if !spec.Capabilities.Schematized {
+		t.Error("Spec does not advertise Schematized")
+	}
+	if !spec.Capabilities.Upsertable {
+		t.Error("Spec does not advertise Upsertable")
+	}
+	if spec.Capabilities.PreferredBatchRows != defaultBatchSize {
+		t.Errorf("PreferredBatchRows = %d, want %d", spec.Capabilities.PreferredBatchRows, defaultBatchSize)
+	}
+
+	expectedModes := map[filament.WriteMode]bool{
+		filament.WriteReplace: false,
+		filament.WriteAppend:  false,
+		filament.WriteUpsert:  false,
+		filament.WriteMerge:   false,
+	}
+	for _, p := range spec.Capabilities.WritePolicies {
+		expectedModes[p.Mode] = true
+		if p.Durability != filament.DurabilityAfterCommit {
+			t.Errorf("policy %q durability = %q, want %q", p.Mode, p.Durability, filament.DurabilityAfterCommit)
+		}
+	}
+	for mode, found := range expectedModes {
+		if !found {
+			t.Errorf("write mode %q not found in sink capabilities", mode)
+		}
+	}
+}
+
+func TestSanitizeIndexUID(t *testing.T) {
+	cases := []struct {
+		prefix   string
+		resource string
+		want     string
+	}{
+		{"", "users", "users"},
+		{"pg_", "users", "pg_users"},
+		{"postgres", "products", "postgres_products"},
+		{"", "public.users", "public_users"},
+		{"", "my-db.schema/table", "my-db_schema_table"},
+		{"", "???", "default"},
+	}
+
+	for _, c := range cases {
+		got := sanitizeIndexUID(c.prefix, c.resource)
+		if got != c.want {
+			t.Errorf("sanitizeIndexUID(%q, %q) = %q, want %q", c.prefix, c.resource, got, c.want)
+		}
+	}
+}
+
+func TestClientNDJSONWithGzip(t *testing.T) {
+	var receivedBody []byte
+	var receivedContentEncoding string
+	var receivedContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"available"}`))
+		case "/indexes/test/documents":
+			receivedContentEncoding = r.Header.Get("Content-Encoding")
+			receivedContentType = r.Header.Get("Content-Type")
+
+			var reader io.Reader = r.Body
+			if receivedContentEncoding == "gzip" {
+				gz, err := gzip.NewReader(r.Body)
+				if err != nil {
+					t.Fatalf("failed to create gzip reader: %v", err)
+				}
+				defer gz.Close()
+				reader = gz
+			}
+			var err error
+			receivedBody, err = io.ReadAll(reader)
+			if err != nil {
+				t.Fatalf("failed to read body: %v", err)
+			}
+
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(TaskResponse{
+				TaskUID:  42,
+				IndexUID: "test",
+				Status:   "enqueued",
+				Type:     "documentAdditionOrUpdate",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key", true)
+
+	// Verify health check
+	if err := client.Health(context.Background()); err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+
+	// Send NDJSON document
+	payload := []byte("{\"id\":1,\"name\":\"Alice\"}\n{\"id\":2,\"name\":\"Bob\"}\n")
+	task, err := client.AddDocumentsNDJSON(context.Background(), "test", "id", payload, false)
+	if err != nil {
+		t.Fatalf("AddDocumentsNDJSON() error = %v", err)
+	}
+
+	if task == nil || task.TaskUID != 42 {
+		t.Fatalf("expected task UID 42, got %+v", task)
+	}
+
+	if receivedContentType != "application/x-ndjson" {
+		t.Errorf("Content-Type = %q, want application/x-ndjson", receivedContentType)
+	}
+	if receivedContentEncoding != "gzip" {
+		t.Errorf("Content-Encoding = %q, want gzip", receivedContentEncoding)
+	}
+	if string(receivedBody) != string(payload) {
+		t.Errorf("received decompressed payload:\ngot  %q\nwant %q", string(receivedBody), string(payload))
+	}
+}
+
+func TestClientWaitForTask(t *testing.T) {
+	var pollCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/tasks/100") {
+			count := pollCount.Add(1)
+			status := "processing"
+			if count >= 3 {
+				status = "succeeded"
+			}
+			_ = json.NewEncoder(w).Encode(TaskResult{
+				UID:      100,
+				IndexUID: "test",
+				Status:   status,
+				Type:     "documentAdditionOrUpdate",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "", false)
+	res, err := client.WaitForTask(context.Background(), 100, 2*time.Second)
+	if err != nil {
+		t.Fatalf("WaitForTask error = %v", err)
+	}
+	if res.Status != "succeeded" {
+		t.Fatalf("Task status = %q, want succeeded", res.Status)
+	}
+	if pollCount.Load() < 3 {
+		t.Errorf("poll count = %d, expected at least 3", pollCount.Load())
+	}
+}
+
+func TestSinkLifecycleWithMockServer(t *testing.T) {
+	var receivedDocs bytes.Buffer
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"available"}`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/indexes/"):
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPost && r.URL.Path == "/indexes":
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(TaskResponse{TaskUID: 1, Status: "enqueued"})
+		case strings.HasSuffix(r.URL.Path, "/documents"):
+			reader := r.Body
+			if r.Header.Get("Content-Encoding") == "gzip" {
+				gz, _ := gzip.NewReader(r.Body)
+				reader = gz
+			}
+			_, _ = io.Copy(&receivedDocs, reader)
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(TaskResponse{TaskUID: 2, Status: "enqueued"})
+		case strings.HasPrefix(r.URL.Path, "/tasks/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(TaskResult{
+				UID:    2,
+				Status: "succeeded",
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	sink := New()
+	ctx := context.Background()
+
+	// Open
+	err := sink.Open(ctx, filament.RunSpec{
+		Run: "run-1",
+		Sink: filament.Ref{
+			Config: map[string]any{
+				"url":            server.URL,
+				"gzip":           false,
+				"wait_for_tasks": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+
+	// EnsureSchema
+	schema := rowmodel.Schema{
+		Resource:   "products",
+		PrimaryKey: []string{"id"},
+		Fields: []rowmodel.Field{
+			{Name: "id", Logical: rowmodel.LogicalInt64},
+			{Name: "title", Logical: rowmodel.LogicalString},
+			{Name: "price", Logical: rowmodel.LogicalFloat64},
+		},
+	}
+	if err := sink.EnsureSchema(ctx, "products", schema); err != nil {
+		t.Fatalf("EnsureSchema failed: %v", err)
+	}
+
+	// Build Arrow Batch
+	arrowSchema := arrowbatch.Schema(schema)
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	builder.Field(0).(*array.Int64Builder).Append(101)
+	builder.Field(1).(*array.StringBuilder).Append("Widget")
+	builder.Field(2).(*array.Float64Builder).Append(19.99)
+	rows := builder.NewRecordBatch()
+	builder.Release()
+
+	b := arrowbatch.NewBatch(rows, arrowbatch.Operations{})
+	b.Resource = "products"
+	defer b.Release()
+
+	// Apply
+	opts := filament.ApplyOptions{
+		Policy: filament.WritePolicy{
+			Capability: filament.WritePolicyCapability{
+				Mode: filament.WriteAppend,
+			},
+		},
+	}
+	receipt, err := sink.Apply(ctx, b, opts)
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	if receipt.Rows != 1 {
+		t.Errorf("receipt.Rows = %d, want 1", receipt.Rows)
+	}
+	if receipt.WriteCRC != b.IntegrityCRC() {
+		t.Errorf("receipt.WriteCRC = %08x, want %08x", receipt.WriteCRC, b.IntegrityCRC())
+	}
+	if receipt.EncodedCRC == nil {
+		t.Fatal("receipt.EncodedCRC is nil")
+	}
+
+	expectedNDJSON := "{\"id\":101,\"title\":\"Widget\",\"price\":19.99}\n"
+	if receivedDocs.String() != expectedNDJSON {
+		t.Errorf("received NDJSON:\ngot  %q\nwant %q", receivedDocs.String(), expectedNDJSON)
+	}
+
+	expectedCRC := crc32.Checksum([]byte(expectedNDJSON), crc32.MakeTable(crc32.Castagnoli))
+	if *receipt.EncodedCRC != expectedCRC {
+		t.Errorf("receipt.EncodedCRC = %08x, want %08x", *receipt.EncodedCRC, expectedCRC)
+	}
+
+	// Commit
+	if err := sink.Commit(ctx); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Overview
Adds [Meilisearch](https://www.meilisearch.com/) as a destination sink connector for Filament pipelines.

## Implementation Details & Optimizations
- **Streaming NDJSON (`application/x-ndjson`)**: Streams Arrow record batches directly into Meilisearch without building full JSON arrays in memory, using Filament's internal Arrow NDJSON encoder.
- **Wire Compression (`Content-Encoding: gzip`)**: Optionally compresses NDJSON batches using gzip with pooled buffers/writers to reduce network bandwidth.
- **Asynchronous Pipeline & Auto-Batching**: Enqueues document addition tasks without blocking `Apply`, allowing Meilisearch's internal task scheduler to auto-batch tasks. `Commit` optionally polls enqueued tasks with backoff to guarantee durability.
- **Write Policies**:
  - `WriteReplace` / `WriteAppend` / `WriteUpsert`: Replaces/updates documents via `/indexes/{uid}/documents`.
  - `WriteMerge` (CDC): Dispatches deletes via `/indexes/{uid}/documents/delete-batch` by extracting primary key values from Arrow record batches.
- **Schema & Index Management**: `EnsureSchema` validates or creates the destination index with the resolved primary key and sanitizes index UIDs (`[a-zA-Z0-9_-]`).

## Verification
- Unit tests covering configuration parsing, spec declarations, index UID sanitization, gzip compression, task polling, and full lifecycle with Arrow record batches (`go test -v ./connectors/meilisearch/...`).
- End-to-end integration test running a live pipeline transfer from a PostgreSQL container into a Meilisearch container via `filament run`, verifying indexed documents and full-text search with typo tolerance.