### PR TITLE
Atterpac/stream core

### DIFF
--- a/arrowbatch/builder.go
+++ b/arrowbatch/builder.go
@@ -314,6 +314,9 @@ func (b *Builder) EndRow(meta rowmodel.Meta) error {
 	if b.ops != nil {
 		b.ops = append(b.ops, meta.Op)
 	}
+	// EndRow borrows stream metadata; retain an independent copy. Nil leaves
+	// the ordinary bounded path allocation-free.
+	meta.Stream = meta.Stream.Clone()
 	b.last = meta
 	b.rows++
 	b.total++

--- a/arrowbatch/ownership_test.go
+++ b/arrowbatch/ownership_test.go
@@ -60,3 +60,36 @@ func TestBuilderCloseIsIdempotent(t *testing.T) {
 		t.Fatalf("EndRow after Close = %v, want ErrClosed", err)
 	}
 }
+
+func TestBuilderOwnsRetainedStreamMeta(t *testing.T) {
+	recv := &collect{}
+	builder := NewBuilder(Schema(rowmodel.Schema{Fields: []rowmodel.Field{{Name: "id", Logical: rowmodel.LogicalInt64}}}), nil, Options{MaxRows: 10}, recv)
+	defer builder.Close()
+	meta := rowmodel.Meta{LSN: "bounded", Seq: 7, Stream: &rowmodel.StreamMeta{Identity: rowmodel.EventIdentity{Domain: rowmodel.DomainKey{Incarnation: "i", Domain: "d"}, Position: rowmodel.Position{Codec: "opaque", Value: []byte("p")}, Ordinal: 3}}}
+	builder.Int64(1)
+	if err := builder.EndRow(meta); err != nil {
+		t.Fatal(err)
+	}
+	// The source may reuse its metadata immediately after EndRow.
+	meta.Stream.Identity.Position.Value[0] = 'x'
+	meta.Stream.Identity.Ordinal = 9
+	if err := builder.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	defer recv.chunks[0].Release()
+	got := recv.chunks[0].Last
+	if got.Stream == meta.Stream || string(got.Stream.Identity.Position.Value) != "p" || got.Stream.Identity.Ordinal != 3 || got.LSN != "bounded" || got.Seq != 7 {
+		t.Fatalf("retained metadata aliases source: %+v", got)
+	}
+	builder.Int64(2)
+	if err := builder.EndRow(rowmodel.Meta{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := builder.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	defer recv.chunks[1].Release()
+	if recv.chunks[1].Last.Stream != nil {
+		t.Fatal("stream metadata leaked into bounded row")
+	}
+}

--- a/epoch.go
+++ b/epoch.go
@@ -1,0 +1,62 @@
+package filament
+
+import (
+	"errors"
+	"github.com/galaxy-io/filament/rowmodel"
+	"sort"
+	"unicode/utf8"
+)
+
+// InboxClaimRef identifies an exact claim, never a sequence watermark.
+// The enclosing certificate supplies tenant scope. No inbox infrastructure is
+// implemented by these value types.
+type InboxClaimRef struct {
+	RowID, Owner string
+	Token        int64
+}
+type Coverage struct {
+	Positions DomainPositions
+	Claims    []InboxClaimRef
+}
+
+// Validate checks representation only; it cannot prove contiguous processing,
+// transaction completion, claim authority or pipeline durability. Empty coverage
+// is rejected until a coordinator defines an explicit idle/no-progress policy.
+func (c Coverage) Validate() error {
+	if (len(c.Positions) == 0) == (len(c.Claims) == 0) {
+		return ErrIncompleteCoverage
+	}
+	if _, err := c.Positions.Entries(); err != nil {
+		return err
+	}
+	seen := make(map[string]bool, len(c.Claims))
+	for _, claim := range c.Claims {
+		if claim.RowID == "" || claim.Owner == "" || claim.Token <= 0 || seen[claim.RowID] || !utf8.ValidString(claim.RowID) || !utf8.ValidString(claim.Owner) {
+			return ErrIncompleteCoverage
+		}
+		seen[claim.RowID] = true
+	}
+	return nil
+}
+func (c Coverage) Clone() Coverage {
+	c.Positions = c.Positions.Clone()
+	c.Claims = append([]InboxClaimRef(nil), c.Claims...)
+	return c
+}
+func (c Coverage) Canonicalize(r CodecResolver) (Coverage, error) {
+	if err := c.Validate(); err != nil {
+		return Coverage{}, err
+	}
+	c = c.Clone()
+	for domain, p := range c.Positions {
+		v, err := rowmodel.CanonicalPosition(r, p)
+		if err != nil {
+			return Coverage{}, err
+		}
+		c.Positions[domain] = v
+	}
+	sort.Slice(c.Claims, func(i, j int) bool { return c.Claims[i].RowID < c.Claims[j].RowID })
+	return c, nil
+}
+
+var ErrIncompleteCoverage = errors.New("stream: incomplete or mixed coverage")

--- a/epoch.go
+++ b/epoch.go
@@ -6,7 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
-	"sort"
+	"slices"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -27,12 +28,12 @@ func (a AttemptRef) Validate() error {
 }
 
 type EpochRef struct {
-	AttemptRef
+	Attempt                   AttemptRef
 	Epoch, MembershipRevision int64
 }
 
 func (e EpochRef) Validate() error {
-	if err := e.AttemptRef.Validate(); err != nil {
+	if err := e.Attempt.Validate(); err != nil {
 		return err
 	}
 	if e.Epoch <= 0 || e.MembershipRevision <= 0 {
@@ -47,7 +48,7 @@ func (e EpochRef) ValidateApply(opts ApplyOptions) error {
 		return err
 	}
 	if opts.Epoch == nil || *opts.Epoch != e {
-		return ErrFenced
+		return ErrEpochMismatch
 	}
 	return nil
 }
@@ -57,7 +58,7 @@ type EpochKey struct {
 	Generation, Epoch int64
 }
 
-func (e EpochRef) Key() EpochKey { return EpochKey{e.StreamID, e.Generation, e.Epoch} }
+func (e EpochRef) Key() EpochKey { return EpochKey{e.Attempt.StreamID, e.Attempt.Generation, e.Epoch} }
 
 // InboxClaimRef identifies an exact claim, never a sequence watermark.
 // The enclosing certificate supplies tenant scope. No inbox infrastructure is
@@ -71,10 +72,10 @@ type Coverage struct {
 	Claims    []InboxClaimRef
 }
 
-// Validate checks representation only; it cannot prove contiguous processing,
+// ValidateRepresentation checks representation only; it cannot prove contiguous processing,
 // transaction completion, claim authority or pipeline durability. Empty coverage
 // is rejected until a coordinator defines an explicit idle/no-progress policy.
-func (c Coverage) Validate() error {
+func (c Coverage) ValidateRepresentation() error {
 	if (len(c.Positions) == 0) == (len(c.Claims) == 0) {
 		return ErrIncompleteCoverage
 	}
@@ -96,7 +97,7 @@ func (c Coverage) Clone() Coverage {
 	return c
 }
 func (c Coverage) Canonicalize(r CodecResolver) (Coverage, error) {
-	if err := c.Validate(); err != nil {
+	if err := c.ValidateRepresentation(); err != nil {
 		return Coverage{}, err
 	}
 	c = c.Clone()
@@ -107,8 +108,28 @@ func (c Coverage) Canonicalize(r CodecResolver) (Coverage, error) {
 		}
 		c.Positions[domain] = v
 	}
-	sort.Slice(c.Claims, func(i, j int) bool { return c.Claims[i].RowID < c.Claims[j].RowID })
+	slices.SortFunc(c.Claims, func(a, b InboxClaimRef) int { return strings.Compare(a.RowID, b.RowID) })
 	return c, nil
+}
+
+// NewPositionCoverage validates and takes an independent copy of candidate
+// positions. Receiving boundaries must still validate exported fields.
+func NewPositionCoverage(positions DomainPositions) (Coverage, error) {
+	c := Coverage{Positions: positions}
+	if err := c.ValidateRepresentation(); err != nil {
+		return Coverage{}, err
+	}
+	return c.Clone(), nil
+}
+
+// NewClaimCoverage validates and copies exact claims; it does not verify live
+// claim ownership or settle inbox rows.
+func NewClaimCoverage(claims []InboxClaimRef) (Coverage, error) {
+	c := Coverage{Claims: claims}
+	if err := c.ValidateRepresentation(); err != nil {
+		return Coverage{}, err
+	}
+	return c.Clone(), nil
 }
 
 // StreamingSink extends an opened Sink with a native reusable epoch lifecycle.
@@ -123,14 +144,42 @@ type StreamingSink interface {
 	CloseSession(context.Context) error
 }
 
+// ReceiptEvidence is destination-owned evidence, not comparable source progress.
+// Nil evidence means absent. A present value must name its format and have a
+// nonnegative version selected by that destination format.
+type ReceiptEvidence struct {
+	Format  string
+	Version int
+	Payload []byte
+}
+
+func (e *ReceiptEvidence) Validate() error {
+	if e == nil {
+		return nil
+	}
+	if e.Format == "" || !utf8.ValidString(e.Format) || e.Version < 0 {
+		return errors.New("epoch: invalid receipt evidence")
+	}
+	return nil
+}
+func (e *ReceiptEvidence) Clone() *ReceiptEvidence {
+	if e == nil {
+		return nil
+	}
+	return &ReceiptEvidence{Format: e.Format, Version: e.Version, Payload: bytes.Clone(e.Payload)}
+}
+
 // EpochReceipt contains stable aggregate evidence; it is not a dedup guarantee.
 // Evidence uses a destination-owned versioned encoding, immutable across retries.
 type EpochReceipt struct {
 	Resource    string
 	Rows, Bytes int64
 	WriteCRC    uint32
-	Evidence    Position
+	Evidence    *ReceiptEvidence
 }
+
+// EpochCertificateFormatVersion identifies the canonical certificate format.
+const EpochCertificateFormatVersion = 1
 
 // EpochCertificate is immutable input to a future fenced store transaction.
 // Structural canonicalization does not seal coverage or authorize its commit.
@@ -159,7 +208,7 @@ func (c EpochCertificate) Clone() EpochCertificate {
 // Position canonicalization is codec-owned. Receipt evidence is already encoded
 // by the destination and is not interpreted as source progress.
 func (c EpochCertificate) CanonicalBytes(r CodecResolver) ([]byte, error) {
-	if c.FormatVersion != 1 || c.Tenant == "" || c.PipelineVersionID == "" || c.Records < 0 || c.Bytes < 0 || !utf8.ValidString(string(c.Tenant)) || !utf8.ValidString(c.PipelineVersionID) {
+	if c.FormatVersion != EpochCertificateFormatVersion || c.Tenant == "" || c.PipelineVersionID == "" || c.Records < 0 || c.Bytes < 0 || !utf8.ValidString(string(c.Tenant)) || !utf8.ValidString(c.PipelineVersionID) {
 		return nil, errors.New("epoch: invalid certificate")
 	}
 	if err := c.Ref.Validate(); err != nil {
@@ -178,21 +227,19 @@ func (c EpochCertificate) CanonicalBytes(r CodecResolver) ([]byte, error) {
 		if receipt.Resource == "" || receipt.Rows < 0 || receipt.Bytes < 0 || !utf8.ValidString(receipt.Resource) {
 			return nil, errors.New("epoch: invalid receipt")
 		}
-		if receipt.Evidence.Codec != "" {
-			if err := receipt.Evidence.Validate(); err != nil {
-				return nil, err
-			}
-		} else if receipt.Evidence.Version != 0 || receipt.Evidence.Payload != nil {
-			return nil, errors.New("epoch: unversioned receipt evidence")
+		if err := receipt.Evidence.Validate(); err != nil {
+			return nil, err
 		}
 	}
-	sort.Slice(c.Receipts, func(i, j int) bool {
-		a, _ := json.Marshal(c.Receipts[i])
-		b, _ := json.Marshal(c.Receipts[j])
-		return bytes.Compare(a, b) < 0
+	// Receipt ordering has no semantic meaning.
+	slices.SortFunc(c.Receipts, func(a, b EpochReceipt) int {
+		left, _ := json.Marshal(a)
+		right, _ := json.Marshal(b)
+		return bytes.Compare(left, right)
 	})
 	return json.Marshal(c)
 }
+
 func (c EpochCertificate) Digest(r CodecResolver) ([32]byte, error) {
 	data, err := c.CanonicalBytes(r)
 	if err != nil {
@@ -207,6 +254,7 @@ type CommittedEpoch struct {
 }
 
 var (
+	ErrEpochMismatch        = errors.New("stream: epoch mismatch")
 	ErrFenced               = errors.New("stream: fenced")
 	ErrLeaseExpired         = errors.New("stream: lease expired")
 	ErrEpochConflict        = errors.New("stream: epoch conflict")

--- a/epoch.go
+++ b/epoch.go
@@ -14,12 +14,14 @@ import (
 	"github.com/galaxy-io/filament/rowmodel"
 )
 
+// AttemptRef identifies a stream worker and its admitted ownership token.
 type AttemptRef struct {
 	RunID                 RunID
 	ExecutionID, StreamID string
 	Generation, Token     int64
 }
 
+// Validate requires complete attempt identity and positive generation and token values.
 func (a AttemptRef) Validate() error {
 	if a.RunID == "" || a.ExecutionID == "" || a.StreamID == "" || a.Generation <= 0 || a.Token <= 0 || !utf8.ValidString(string(a.RunID)) || !utf8.ValidString(a.ExecutionID) || !utf8.ValidString(a.StreamID) {
 		return errors.New("epoch: incomplete attempt identity")
@@ -27,11 +29,13 @@ func (a AttemptRef) Validate() error {
 	return nil
 }
 
+// EpochRef binds a commit cycle and membership revision to an admitted attempt.
 type EpochRef struct {
 	Attempt                   AttemptRef
 	Epoch, MembershipRevision int64
 }
 
+// Validate checks epoch identity without verifying live ownership or durability.
 func (e EpochRef) Validate() error {
 	if err := e.Attempt.Validate(); err != nil {
 		return err
@@ -53,11 +57,13 @@ func (e EpochRef) ValidateApply(opts ApplyOptions) error {
 	return nil
 }
 
+// EpochKey identifies a certificate across attempts within a stream generation.
 type EpochKey struct {
 	StreamID          string
 	Generation, Epoch int64
 }
 
+// Key returns the attempt-independent certificate identity.
 func (e EpochRef) Key() EpochKey { return EpochKey{e.Attempt.StreamID, e.Attempt.Generation, e.Epoch} }
 
 // InboxClaimRef identifies an exact claim, never a sequence watermark.
@@ -67,6 +73,8 @@ type InboxClaimRef struct {
 	RowID, Owner string
 	Token        int64
 }
+
+// Coverage holds either candidate domain progress or exact inbox claims, never both.
 type Coverage struct {
 	Positions DomainPositions
 	Claims    []InboxClaimRef
@@ -91,11 +99,15 @@ func (c Coverage) ValidateRepresentation() error {
 	}
 	return nil
 }
+
+// Clone returns independently owned positions and claims.
 func (c Coverage) Clone() Coverage {
 	c.Positions = c.Positions.Clone()
 	c.Claims = append([]InboxClaimRef(nil), c.Claims...)
 	return c
 }
+
+// Canonicalize validates the representation, copies it, and normalizes positions and claim order.
 func (c Coverage) Canonicalize(r CodecResolver) (Coverage, error) {
 	if err := c.ValidateRepresentation(); err != nil {
 		return Coverage{}, err
@@ -153,6 +165,7 @@ type ReceiptEvidence struct {
 	Payload []byte
 }
 
+// Validate checks a present evidence format and version; nil means absent.
 func (e *ReceiptEvidence) Validate() error {
 	if e == nil {
 		return nil
@@ -162,6 +175,8 @@ func (e *ReceiptEvidence) Validate() error {
 	}
 	return nil
 }
+
+// Clone copies evidence bytes and preserves absent evidence and nil-versus-empty payloads.
 func (e *ReceiptEvidence) Clone() *ReceiptEvidence {
 	if e == nil {
 		return nil
@@ -194,6 +209,7 @@ type EpochCertificate struct {
 	Records, Bytes    int64
 }
 
+// Clone returns independently owned coverage and receipt evidence.
 func (c EpochCertificate) Clone() EpochCertificate {
 	c.Coverage = c.Coverage.Clone()
 	c.Receipts = append([]EpochReceipt(nil), c.Receipts...)
@@ -240,6 +256,7 @@ func (c EpochCertificate) CanonicalBytes(r CodecResolver) ([]byte, error) {
 	return json.Marshal(c)
 }
 
+// Digest hashes the canonical immutable certificate content.
 func (c EpochCertificate) Digest(r CodecResolver) ([32]byte, error) {
 	data, err := c.CanonicalBytes(r)
 	if err != nil {
@@ -248,11 +265,13 @@ func (c EpochCertificate) Digest(r CodecResolver) ([32]byte, error) {
 	return sha256.Sum256(data), nil
 }
 
+// CommittedEpoch pairs a persisted certificate with its datastore-assigned commit time.
 type CommittedEpoch struct {
 	Certificate EpochCertificate
 	CommittedAt time.Time
 }
 
+// Stream error categories distinguish ownership, epoch binding, progress, and coverage failures.
 var (
 	ErrEpochMismatch        = errors.New("stream: epoch mismatch")
 	ErrFenced               = errors.New("stream: fenced")

--- a/epoch.go
+++ b/epoch.go
@@ -1,11 +1,63 @@
 package filament
 
 import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
-	"github.com/galaxy-io/filament/rowmodel"
 	"sort"
+	"time"
 	"unicode/utf8"
+
+	"github.com/galaxy-io/filament/rowmodel"
 )
+
+type AttemptRef struct {
+	RunID                 RunID
+	ExecutionID, StreamID string
+	Generation, Token     int64
+}
+
+func (a AttemptRef) Validate() error {
+	if a.RunID == "" || a.ExecutionID == "" || a.StreamID == "" || a.Generation <= 0 || a.Token <= 0 || !utf8.ValidString(string(a.RunID)) || !utf8.ValidString(a.ExecutionID) || !utf8.ValidString(a.StreamID) {
+		return errors.New("epoch: incomplete attempt identity")
+	}
+	return nil
+}
+
+type EpochRef struct {
+	AttemptRef
+	Epoch, MembershipRevision int64
+}
+
+func (e EpochRef) Validate() error {
+	if err := e.AttemptRef.Validate(); err != nil {
+		return err
+	}
+	if e.Epoch <= 0 || e.MembershipRevision <= 0 {
+		return errors.New("epoch: invalid epoch or membership revision")
+	}
+	return nil
+}
+
+// ValidateApply checks explicit session binding, not destination-side fencing.
+func (e EpochRef) ValidateApply(opts ApplyOptions) error {
+	if err := e.Validate(); err != nil {
+		return err
+	}
+	if opts.Epoch == nil || *opts.Epoch != e {
+		return ErrFenced
+	}
+	return nil
+}
+
+type EpochKey struct {
+	StreamID          string
+	Generation, Epoch int64
+}
+
+func (e EpochRef) Key() EpochKey { return EpochKey{e.StreamID, e.Generation, e.Epoch} }
 
 // InboxClaimRef identifies an exact claim, never a sequence watermark.
 // The enclosing certificate supplies tenant scope. No inbox infrastructure is
@@ -59,4 +111,107 @@ func (c Coverage) Canonicalize(r CodecResolver) (Coverage, error) {
 	return c, nil
 }
 
-var ErrIncompleteCoverage = errors.New("stream: incomplete or mixed coverage")
+// StreamingSink extends an opened Sink with a native reusable epoch lifecycle.
+// CommitEpoch waits for negotiated durability. AbortEpoch discards only tentative
+// effects. CloseSession succeeds only when no later destination effects remain
+// possible; a timeout or mere client resource release must return an error.
+// Calls are serialized initially. No legacy Commit/Abort adaptation is implied.
+type StreamingSink interface {
+	BeginEpoch(context.Context, EpochRef) error
+	CommitEpoch(context.Context, EpochRef) ([]EpochReceipt, error)
+	AbortEpoch(context.Context, EpochRef) error
+	CloseSession(context.Context) error
+}
+
+// EpochReceipt contains stable aggregate evidence; it is not a dedup guarantee.
+// Evidence uses a destination-owned versioned encoding, immutable across retries.
+type EpochReceipt struct {
+	Resource    string
+	Rows, Bytes int64
+	WriteCRC    uint32
+	Evidence    Position
+}
+
+// EpochCertificate is immutable input to a future fenced store transaction.
+// Structural canonicalization does not seal coverage or authorize its commit.
+// PR 06 must bind this content to private source and completed barrier evidence.
+type EpochCertificate struct {
+	FormatVersion     int
+	Tenant            TenantID
+	Ref               EpochRef
+	PipelineVersionID string
+	Coverage          Coverage
+	Receipts          []EpochReceipt
+	Records, Bytes    int64
+}
+
+func (c EpochCertificate) Clone() EpochCertificate {
+	c.Coverage = c.Coverage.Clone()
+	c.Receipts = append([]EpochReceipt(nil), c.Receipts...)
+	for i := range c.Receipts {
+		c.Receipts[i].Evidence = c.Receipts[i].Evidence.Clone()
+	}
+	return c
+}
+
+// CanonicalBytes v1 sorts semantically unordered domains, claims and receipts;
+// preserves nil versus empty opaque payloads; excludes datastore timestamps.
+// Position canonicalization is codec-owned. Receipt evidence is already encoded
+// by the destination and is not interpreted as source progress.
+func (c EpochCertificate) CanonicalBytes(r CodecResolver) ([]byte, error) {
+	if c.FormatVersion != 1 || c.Tenant == "" || c.PipelineVersionID == "" || c.Records < 0 || c.Bytes < 0 || !utf8.ValidString(string(c.Tenant)) || !utf8.ValidString(c.PipelineVersionID) {
+		return nil, errors.New("epoch: invalid certificate")
+	}
+	if err := c.Ref.Validate(); err != nil {
+		return nil, err
+	}
+	c = c.Clone()
+	var err error
+	c.Coverage, err = c.Coverage.Canonicalize(r)
+	if err != nil {
+		return nil, err
+	}
+	if c.Receipts == nil {
+		c.Receipts = []EpochReceipt{}
+	}
+	for _, receipt := range c.Receipts {
+		if receipt.Resource == "" || receipt.Rows < 0 || receipt.Bytes < 0 || !utf8.ValidString(receipt.Resource) {
+			return nil, errors.New("epoch: invalid receipt")
+		}
+		if receipt.Evidence.Codec != "" {
+			if err := receipt.Evidence.Validate(); err != nil {
+				return nil, err
+			}
+		} else if receipt.Evidence.Version != 0 || receipt.Evidence.Payload != nil {
+			return nil, errors.New("epoch: unversioned receipt evidence")
+		}
+	}
+	sort.Slice(c.Receipts, func(i, j int) bool {
+		a, _ := json.Marshal(c.Receipts[i])
+		b, _ := json.Marshal(c.Receipts[j])
+		return bytes.Compare(a, b) < 0
+	})
+	return json.Marshal(c)
+}
+func (c EpochCertificate) Digest(r CodecResolver) ([32]byte, error) {
+	data, err := c.CanonicalBytes(r)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return sha256.Sum256(data), nil
+}
+
+type CommittedEpoch struct {
+	Certificate EpochCertificate
+	CommittedAt time.Time
+}
+
+var (
+	ErrFenced               = errors.New("stream: fenced")
+	ErrLeaseExpired         = errors.New("stream: lease expired")
+	ErrEpochConflict        = errors.New("stream: epoch conflict")
+	ErrPositionRegression   = errors.New("stream: position regression")
+	ErrPositionIncomparable = rowmodel.ErrPositionIncomparable
+	ErrIncompleteCoverage   = errors.New("stream: incomplete or mixed coverage")
+	ErrMembershipChanged    = errors.New("stream: membership changed")
+)

--- a/pipeline/inlet.go
+++ b/pipeline/inlet.go
@@ -41,6 +41,9 @@ func (in *inlet) Builder(resource string, part int, supplied rowmodel.Schema) (a
 	key := partKey{resource: resource, part: part}
 	p.registryMu.Lock()
 	defer p.registryMu.Unlock()
+	if err := rowmodel.ValidateReservedFields(supplied); err != nil {
+		return nil, fmt.Errorf("pipeline: %w", err)
+	}
 	schema := supplied.Clone()
 	if schema.Resource == "" {
 		schema.Resource = resource

--- a/rowmodel/audit.go
+++ b/rowmodel/audit.go
@@ -1,10 +1,5 @@
 package rowmodel
 
-import (
-	"fmt"
-	"strings"
-)
-
 // Filament reserves this namespace for row lineage materialized after source
 // fields. Audit fields remain nullable so existing destination tables can
 // evolve without rewriting historical rows.
@@ -20,10 +15,8 @@ const (
 // Filament's universal lineage fields and, for CDC, change-stream fields.
 func WithAuditFields(schema Schema, cdc bool) (Schema, error) {
 	out := schema.Clone()
-	for _, field := range out.Fields {
-		if strings.HasPrefix(strings.ToLower(field.Name), "_filament_") {
-			return Schema{}, fmt.Errorf("resource %q uses reserved Filament column %q", schema.Resource, field.Name)
-		}
+	if err := ValidateReservedFields(out); err != nil {
+		return Schema{}, err
 	}
 	out.Fields = append(out.Fields,
 		Field{Name: AuditRunIDField, Logical: LogicalString, Nullable: true},

--- a/rowmodel/control.go
+++ b/rowmodel/control.go
@@ -2,8 +2,10 @@ package rowmodel
 
 import "errors"
 
+// ControlKind identifies a standalone source boundary marker.
 type ControlKind uint8
 
+// Control kinds distinguish source transactions, progress, and membership boundaries.
 const (
 	ControlUnspecified ControlKind = iota
 	TxnBegin
@@ -23,7 +25,10 @@ type Control struct {
 	MembershipRevision int64
 }
 
+// Clone returns a control with independently owned position bytes.
 func (c Control) Clone() Control { c.Position = c.Position.Clone(); return c }
+
+// Validate checks the control kind and its required source-boundary fields.
 func (c Control) Validate() error {
 	if err := c.Domain.Validate(); err != nil {
 		return err

--- a/rowmodel/control.go
+++ b/rowmodel/control.go
@@ -1,0 +1,58 @@
+package rowmodel
+
+import "errors"
+
+type ControlKind uint8
+
+const (
+	ControlUnspecified ControlKind = iota
+	TxnBegin
+	TxnEnd
+	ProgressBoundary
+	MemberActivated
+)
+
+// Control is a standalone source boundary, including boundaries with no rows.
+// It supplies source evidence, not proof of pipeline completion or durability.
+type Control struct {
+	Kind               ControlKind
+	Domain             DomainKey
+	Position           Position
+	TxnID              string
+	Resource           string
+	MembershipRevision int64
+}
+
+func (c Control) Clone() Control { c.Position = c.Position.Clone(); return c }
+func (c Control) Validate() error {
+	if err := c.Domain.Validate(); err != nil {
+		return err
+	}
+	if err := c.Position.Validate(); err != nil {
+		return err
+	}
+	switch c.Kind {
+	case TxnBegin, TxnEnd:
+		if c.TxnID == "" || c.Resource != "" || c.MembershipRevision != 0 {
+			return errors.New("control: invalid transaction payload")
+		}
+	case ProgressBoundary:
+		if c.TxnID != "" || c.Resource != "" || c.MembershipRevision != 0 {
+			return errors.New("control: invalid progress payload")
+		}
+	case MemberActivated:
+		if c.TxnID != "" || c.Resource == "" || c.MembershipRevision <= 0 {
+			return errors.New("control: invalid membership payload")
+		}
+	default:
+		return errors.New("control: unknown kind")
+	}
+	return nil
+}
+
+// ResourceDomainRef describes a relationship, not an independently writable
+// per-resource checkpoint. Multiple resources may share the same log domain.
+type ResourceDomainRef struct {
+	Resource string
+	Domain   DomainKey
+}

--- a/rowmodel/envelope.go
+++ b/rowmodel/envelope.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// Reserved envelope column names identify row-aligned event metadata.
 const (
 	EventIDField        = "_filament_event_id"
 	EventIdentityField  = "_filament_event_identity"

--- a/rowmodel/envelope.go
+++ b/rowmodel/envelope.go
@@ -1,0 +1,67 @@
+package rowmodel
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	EventIDField        = "_filament_event_id"
+	EventIdentityField  = "_filament_event_identity"
+	EventTimestampField = "_filament_event_ts"
+	EventHeadersField   = "_filament_headers"
+	EventKeyField       = "_filament_key"
+	EventPayloadField   = "_filament_payload"
+)
+
+func envelopeFields() []Field {
+	return []Field{
+		{Name: EventIDField, Logical: LogicalString, Nullable: true},
+		{Name: EventIdentityField, Logical: LogicalBytes, Nullable: true},
+		// RFC3339Nano in UTC preserves sub-microsecond source precision, unlike the
+		// existing Arrow timestamp mapping (microseconds).
+		{Name: EventTimestampField, Logical: LogicalString, Nullable: true},
+		{Name: EventHeadersField, Logical: LogicalBytes, Nullable: true},
+		{Name: EventKeyField, Logical: LogicalBytes, Nullable: true},
+		{Name: EventPayloadField, Logical: LogicalBytes, Nullable: true},
+	}
+}
+
+// WithEnvelopeFields declares the SDK-owned suffix. It rejects user collisions
+// before adding columns; callers cannot mark arbitrary fields as SDK-generated.
+func WithEnvelopeFields(s Schema) (Schema, error) {
+	if s.envelope {
+		return Schema{}, fmt.Errorf("resource %q already has an envelope", s.Resource)
+	}
+	if err := ValidateReservedFields(s); err != nil {
+		return Schema{}, err
+	}
+	s = s.Clone()
+	s.Fields = append(s.Fields, envelopeFields()...)
+	s.envelope = true
+	return s, nil
+}
+
+// ValidateReservedFields permits only the exact SDK-declared suffix. The marker
+// is schema provenance, not a security boundary against malicious Go code.
+func ValidateReservedFields(s Schema) error {
+	start := len(s.Fields)
+	if s.envelope {
+		fields := envelopeFields()
+		start -= len(fields)
+		if start < 0 {
+			return fmt.Errorf("resource %q has incomplete envelope fields", s.Resource)
+		}
+		for i, f := range fields {
+			if s.Fields[start+i] != f {
+				return fmt.Errorf("resource %q has modified envelope field %q", s.Resource, f.Name)
+			}
+		}
+	}
+	for _, f := range s.Fields[:start] {
+		if strings.HasPrefix(strings.ToLower(f.Name), "_filament_") {
+			return fmt.Errorf("resource %q uses reserved Filament column %q", s.Resource, f.Name)
+		}
+	}
+	return nil
+}

--- a/rowmodel/model.go
+++ b/rowmodel/model.go
@@ -73,12 +73,10 @@ type Field struct {
 
 // Meta accompanies a row without becoming an Arrow column.
 type Meta struct {
-	Domain   DomainKey
-	Position Position
-	Ordinal  uint64
-	Op       Operation
-	Key      []string
-	Coarse   bool
-	LSN      string
-	Seq      uint64
+	Op     Operation
+	Key    []string
+	Coarse bool
+	LSN    string
+	Seq    uint64
+	Stream *StreamMeta
 }

--- a/rowmodel/model.go
+++ b/rowmodel/model.go
@@ -72,9 +72,12 @@ type Field struct {
 
 // Meta accompanies a row without becoming an Arrow column.
 type Meta struct {
-	Op     Operation
-	Key    []string
-	Coarse bool
-	LSN    string
-	Seq    uint64
+	Domain   DomainKey
+	Position Position
+	Ordinal  uint64
+	Op       Operation
+	Key      []string
+	Coarse   bool
+	LSN      string
+	Seq      uint64
 }

--- a/rowmodel/model.go
+++ b/rowmodel/model.go
@@ -40,6 +40,7 @@ const (
 
 // Schema is one resource's column layout.
 type Schema struct {
+	envelope   bool
 	Resource   string
 	Fields     []Field
 	PrimaryKey []string
@@ -48,7 +49,7 @@ type Schema struct {
 
 // Equal reports whether two supplied schemas describe the same resource model.
 func (s Schema) Equal(other Schema) bool {
-	return s.Resource == other.Resource && s.Engine == other.Engine &&
+	return s.envelope == other.envelope && s.Resource == other.Resource && s.Engine == other.Engine &&
 		slices.Equal(s.PrimaryKey, other.PrimaryKey) && slices.Equal(s.Fields, other.Fields)
 }
 

--- a/rowmodel/progress.go
+++ b/rowmodel/progress.go
@@ -23,10 +23,11 @@ func (d DomainKey) Validate() error {
 type Position struct {
 	Codec   string
 	Version int
-	Payload []byte
+	// Value is the codec-encoded source position, not message content.
+	Value []byte
 }
 
-func (p Position) Clone() Position { p.Payload = bytes.Clone(p.Payload); return p }
+func (p Position) Clone() Position { p.Value = bytes.Clone(p.Value); return p }
 func (p Position) Validate() error {
 	if p.Codec == "" || p.Version < 0 || !utf8.ValidString(p.Codec) {
 		return errors.New("progress: missing codec or negative version")

--- a/rowmodel/progress.go
+++ b/rowmodel/progress.go
@@ -13,6 +13,7 @@ import (
 // Consumer, run and attempt identities must not be used as incarnations.
 type DomainKey struct{ Incarnation, Domain string }
 
+// Validate requires nonempty UTF-8 incarnation and domain identifiers.
 func (d DomainKey) Validate() error {
 	if d.Incarnation == "" || d.Domain == "" || !utf8.ValidString(d.Incarnation) || !utf8.ValidString(d.Domain) {
 		return errors.New("progress: missing incarnation or domain")
@@ -20,6 +21,7 @@ func (d DomainKey) Validate() error {
 	return nil
 }
 
+// Position stores a codec-encoded source bookmark, independently of message content.
 type Position struct {
 	Codec   string
 	Version int
@@ -27,7 +29,10 @@ type Position struct {
 	Value []byte
 }
 
+// Clone returns a position with independently owned encoded bytes.
 func (p Position) Clone() Position { p.Value = bytes.Clone(p.Value); return p }
+
+// Validate checks codec identity and version; the codec validates Value.
 func (p Position) Validate() error {
 	if p.Codec == "" || p.Version < 0 || !utf8.ValidString(p.Codec) {
 		return errors.New("progress: missing codec or negative version")
@@ -35,9 +40,11 @@ func (p Position) Validate() error {
 	return nil
 }
 
-// Zero fails closed. Ordering is connector-specific, never byte ordering.
+// PositionOrder describes codec-defined progress ordering; zero fails closed.
+// Encoded byte ordering does not establish source progress.
 type PositionOrder uint8
 
+// Position comparison outcomes fail closed when ordering cannot be established.
 const (
 	PositionIncomparable PositionOrder = iota
 	PositionEqual
@@ -45,17 +52,23 @@ const (
 	PositionAfter
 )
 
+// ErrPositionIncomparable indicates that compatible progress ordering cannot be established.
 var ErrPositionIncomparable = errors.New("progress: positions incomparable")
 
+// PositionCodec validates, compares, and canonicalizes one source position format.
+// Implementations must be deterministic, pure, and safe for concurrent use.
 type PositionCodec interface {
 	Validate(Position) error
 	Compare(a, b Position) (PositionOrder, error)
 	Canonicalize(Position) (Position, error)
 }
+
+// CodecResolver locates a position codec by identifier and version.
 type CodecResolver interface {
 	Lookup(codec string, version int) (PositionCodec, error)
 }
 
+// CanonicalPosition validates and canonicalizes a position without retaining caller buffers.
 func CanonicalPosition(r CodecResolver, p Position) (Position, error) {
 	if err := p.Validate(); err != nil {
 		return Position{}, err
@@ -86,6 +99,7 @@ func CanonicalPosition(r CodecResolver, p Position) (Position, error) {
 	return out.Clone(), nil
 }
 
+// ComparePositions compares compatible domains and codecs, failing closed on incomparable progress.
 func ComparePositions(r CodecResolver, aDomain DomainKey, a Position, bDomain DomainKey, b Position) (PositionOrder, error) {
 	if aDomain.Validate() != nil || bDomain.Validate() != nil || aDomain != bDomain || a.Codec != b.Codec || a.Version != b.Version {
 		return PositionIncomparable, ErrPositionIncomparable
@@ -112,6 +126,7 @@ func ComparePositions(r CodecResolver, aDomain DomainKey, a Position, bDomain Do
 	return order, nil
 }
 
+// DomainPosition pairs a source domain with its bookmark for wire serialization.
 type DomainPosition struct {
 	Domain   DomainKey
 	Position Position
@@ -121,6 +136,7 @@ type DomainPosition struct {
 // Clone when handing ownership across a session/coordinator boundary.
 type DomainPositions map[DomainKey]Position
 
+// Clone returns an independently owned map and position values.
 func (p DomainPositions) Clone() DomainPositions {
 	if p == nil {
 		return nil
@@ -131,6 +147,8 @@ func (p DomainPositions) Clone() DomainPositions {
 	}
 	return out
 }
+
+// Entries validates and copies positions into deterministic incarnation/domain order.
 func (p DomainPositions) Entries() ([]DomainPosition, error) {
 	out := make([]DomainPosition, 0, len(p))
 	for k, v := range p {
@@ -151,6 +169,8 @@ func (p DomainPositions) Entries() ([]DomainPosition, error) {
 	})
 	return out, nil
 }
+
+// MarshalJSON encodes sorted entries instead of a map with struct keys.
 func (p DomainPositions) MarshalJSON() ([]byte, error) {
 	entries, err := p.Entries()
 	if err != nil {
@@ -158,6 +178,8 @@ func (p DomainPositions) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(entries)
 }
+
+// UnmarshalJSON validates entries and rejects duplicate domains before replacing the map.
 func (p *DomainPositions) UnmarshalJSON(data []byte) error {
 	var entries []DomainPosition
 	if err := json.Unmarshal(data, &entries); err != nil {

--- a/rowmodel/progress.go
+++ b/rowmodel/progress.go
@@ -1,0 +1,180 @@
+package rowmodel
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"unicode/utf8"
+)
+
+// DomainKey names a source ordering domain within a stable source incarnation.
+// Consumer, run and attempt identities must not be used as incarnations.
+type DomainKey struct{ Incarnation, Domain string }
+
+func (d DomainKey) Validate() error {
+	if d.Incarnation == "" || d.Domain == "" || !utf8.ValidString(d.Incarnation) || !utf8.ValidString(d.Domain) {
+		return errors.New("progress: missing incarnation or domain")
+	}
+	return nil
+}
+
+type Position struct {
+	Codec   string
+	Version int
+	Payload []byte
+}
+
+func (p Position) Clone() Position { p.Payload = bytes.Clone(p.Payload); return p }
+func (p Position) Validate() error {
+	if p.Codec == "" || p.Version < 0 || !utf8.ValidString(p.Codec) {
+		return errors.New("progress: missing codec or negative version")
+	}
+	return nil
+}
+
+// Zero fails closed. Ordering is connector-specific, never byte ordering.
+type PositionOrder uint8
+
+const (
+	PositionIncomparable PositionOrder = iota
+	PositionEqual
+	PositionBefore
+	PositionAfter
+)
+
+var ErrPositionIncomparable = errors.New("progress: positions incomparable")
+
+type PositionCodec interface {
+	Validate(Position) error
+	Compare(a, b Position) (PositionOrder, error)
+	Canonicalize(Position) (Position, error)
+}
+type CodecResolver interface {
+	Lookup(codec string, version int) (PositionCodec, error)
+}
+
+func CanonicalPosition(r CodecResolver, p Position) (Position, error) {
+	if err := p.Validate(); err != nil {
+		return Position{}, err
+	}
+	if r == nil {
+		return Position{}, errors.New("progress: codec resolver required")
+	}
+	codec, err := r.Lookup(p.Codec, p.Version)
+	if err != nil {
+		return Position{}, err
+	}
+	if codec == nil {
+		return Position{}, errors.New("progress: nil codec")
+	}
+	if err := codec.Validate(p.Clone()); err != nil {
+		return Position{}, err
+	}
+	out, err := codec.Canonicalize(p.Clone())
+	if err != nil {
+		return Position{}, err
+	}
+	if out.Codec != p.Codec || out.Version != p.Version {
+		return Position{}, errors.New("progress: canonicalization changed codec identity")
+	}
+	if err := codec.Validate(out.Clone()); err != nil {
+		return Position{}, err
+	}
+	return out.Clone(), nil
+}
+
+func ComparePositions(r CodecResolver, aDomain DomainKey, a Position, bDomain DomainKey, b Position) (PositionOrder, error) {
+	if aDomain.Validate() != nil || bDomain.Validate() != nil || aDomain != bDomain || a.Codec != b.Codec || a.Version != b.Version {
+		return PositionIncomparable, ErrPositionIncomparable
+	}
+	a, err := CanonicalPosition(r, a)
+	if err != nil {
+		return PositionIncomparable, err
+	}
+	b, err = CanonicalPosition(r, b)
+	if err != nil {
+		return PositionIncomparable, err
+	}
+	codec, err := r.Lookup(a.Codec, a.Version)
+	if err != nil {
+		return PositionIncomparable, err
+	}
+	order, err := codec.Compare(a, b)
+	if err != nil {
+		return PositionIncomparable, err
+	}
+	if order == PositionIncomparable || order > PositionAfter {
+		return PositionIncomparable, ErrPositionIncomparable
+	}
+	return order, nil
+}
+
+type DomainPosition struct {
+	Domain   DomainKey
+	Position Position
+}
+
+// DomainPositions uses sorted entries on the wire; duplicate domains are invalid.
+// Clone when handing ownership across a session/coordinator boundary.
+type DomainPositions map[DomainKey]Position
+
+func (p DomainPositions) Clone() DomainPositions {
+	if p == nil {
+		return nil
+	}
+	out := make(DomainPositions, len(p))
+	for k, v := range p {
+		out[k] = v.Clone()
+	}
+	return out
+}
+func (p DomainPositions) Entries() ([]DomainPosition, error) {
+	out := make([]DomainPosition, 0, len(p))
+	for k, v := range p {
+		if err := k.Validate(); err != nil {
+			return nil, err
+		}
+		if err := v.Validate(); err != nil {
+			return nil, err
+		}
+		out = append(out, DomainPosition{k, v.Clone()})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i].Domain, out[j].Domain
+		if a.Incarnation != b.Incarnation {
+			return a.Incarnation < b.Incarnation
+		}
+		return a.Domain < b.Domain
+	})
+	return out, nil
+}
+func (p DomainPositions) MarshalJSON() ([]byte, error) {
+	entries, err := p.Entries()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(entries)
+}
+func (p *DomainPositions) UnmarshalJSON(data []byte) error {
+	var entries []DomainPosition
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return err
+	}
+	out := make(DomainPositions, len(entries))
+	for _, e := range entries {
+		if err := e.Domain.Validate(); err != nil {
+			return err
+		}
+		if err := e.Position.Validate(); err != nil {
+			return err
+		}
+		if _, ok := out[e.Domain]; ok {
+			return fmt.Errorf("progress: duplicate domain %q", e.Domain.Domain)
+		}
+		out[e.Domain] = e.Position.Clone()
+	}
+	*p = out
+	return nil
+}

--- a/rowmodel/stream.go
+++ b/rowmodel/stream.go
@@ -8,6 +8,7 @@ type EventIdentity struct {
 	Ordinal  uint64
 }
 
+// Clone returns an event identity with independently owned position bytes.
 func (e EventIdentity) Clone() EventIdentity { e.Position = e.Position.Clone(); return e }
 
 // StreamMeta carries native event metadata. Its presence does not select
@@ -15,6 +16,7 @@ func (e EventIdentity) Clone() EventIdentity { e.Position = e.Position.Clone(); 
 // It cannot certify coverage or replace the row-aligned envelope columns.
 type StreamMeta struct{ Identity EventIdentity }
 
+// Clone copies stream metadata and its position bytes, preserving nil metadata.
 func (m *StreamMeta) Clone() *StreamMeta {
 	if m == nil {
 		return nil

--- a/rowmodel/stream.go
+++ b/rowmodel/stream.go
@@ -1,0 +1,23 @@
+package rowmodel
+
+// EventIdentity identifies one source event independently of its run, attempt,
+// generation or consumer. Ordinal distinguishes events sharing a position.
+type EventIdentity struct {
+	Domain   DomainKey
+	Position Position
+	Ordinal  uint64
+}
+
+func (e EventIdentity) Clone() EventIdentity { e.Position = e.Position.Clone(); return e }
+
+// StreamMeta carries native event metadata. Its presence does not select
+// continuous execution: bounded catch-up can also carry event identities.
+// It cannot certify coverage or replace the row-aligned envelope columns.
+type StreamMeta struct{ Identity EventIdentity }
+
+func (m *StreamMeta) Clone() *StreamMeta {
+	if m == nil {
+		return nil
+	}
+	return &StreamMeta{Identity: m.Identity.Clone()}
+}

--- a/run.go
+++ b/run.go
@@ -12,9 +12,11 @@ import (
 // RunSpec is the fully resolved execution plan for one run — what a Runtime
 // receives after the engine has bound refs, ingestion type, and options.
 type RunSpec struct {
-	Attempt *AttemptRef `json:",omitempty"`
-	Tenant  TenantID
-	Run     RunID
+	// StreamAttempt is authoritative for continuous execution. Existing dispatch
+	// fields, when populated, must agree with the admitted attempt.
+	StreamAttempt *AttemptRef `json:",omitempty"`
+	Tenant        TenantID
+	Run           RunID
 	// StartedAt is the logical run's first start time. A zero value is stamped by
 	// the runner; resumed executions retain the original value.
 	StartedAt time.Time

--- a/run.go
+++ b/run.go
@@ -12,8 +12,9 @@ import (
 // RunSpec is the fully resolved execution plan for one run — what a Runtime
 // receives after the engine has bound refs, ingestion type, and options.
 type RunSpec struct {
-	Tenant TenantID
-	Run    RunID
+	Attempt *AttemptRef `json:",omitempty"`
+	Tenant  TenantID
+	Run     RunID
 	// StartedAt is the logical run's first start time. A zero value is stamped by
 	// the runner; resumed executions retain the original value.
 	StartedAt time.Time
@@ -165,6 +166,8 @@ func (s RunSpec) ResourceCheckpointKey(resource string) (ResourceCheckpointKey, 
 // RunOptions tunes throughput knobs for a run; zero values defer to engine
 // defaults.
 type RunOptions struct {
+	Execution           ExecutionMode `json:",omitempty"`
+	EpochBoundary       *Boundary     `json:",omitempty"`
 	FetchSize           int
 	BatchMaxRows        int
 	BatchMaxBytes       int64

--- a/runner/continuous_disabled_test.go
+++ b/runner/continuous_disabled_test.go
@@ -1,0 +1,15 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"github.com/galaxy-io/filament"
+	"testing"
+)
+
+func TestContinuousExecutionDisabledBeforeSideEffects(t *testing.T) {
+	err := RunOne(context.Background(), Deps{}, filament.RunSpec{Options: filament.RunOptions{Execution: filament.ExecutionContinuous}})
+	if !errors.Is(err, filament.ErrContinuousDisabled) {
+		t.Fatalf("continuous execution: %v", err)
+	}
+}

--- a/runner/continuous_disabled_test.go
+++ b/runner/continuous_disabled_test.go
@@ -13,3 +13,20 @@ func TestContinuousExecutionDisabledBeforeSideEffects(t *testing.T) {
 		t.Fatalf("continuous execution: %v", err)
 	}
 }
+
+func TestExecutionAvailabilityAndSuppliedOwnership(t *testing.T) {
+	if err := filament.ExecutionContinuous.Validate(); err != nil {
+		t.Fatal("continuous is a valid mode", err)
+	}
+	valid := filament.RunSpec{Run: "r", ExecutionID: "e", Options: filament.RunOptions{Execution: filament.ExecutionContinuous}, StreamAttempt: &filament.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 1}}
+	if err := RunOne(context.Background(), Deps{}, valid); !errors.Is(err, filament.ErrContinuousDisabled) {
+		t.Fatal("valid continuous execution should remain disabled", err)
+	}
+	valid.ExecutionID = "conflict"
+	if err := RunOne(context.Background(), Deps{}, valid); err == nil || errors.Is(err, filament.ErrContinuousDisabled) {
+		t.Fatal("supplied ownership conflict not checked", err)
+	}
+	if err := RunOne(context.Background(), Deps{}, filament.RunSpec{Options: filament.RunOptions{Execution: "unknown"}}); err == nil || errors.Is(err, filament.ErrContinuousDisabled) {
+		t.Fatal("unknown mode not distinguished", err)
+	}
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -82,6 +82,9 @@ func ShouldRun(state filament.RunState) bool {
 //
 //nolint:funlen,gocyclo // the run lifecycle reads best as one sequence
 func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) error {
+	if err := spec.Options.Execution.ValidateExecution(); err != nil {
+		return err
+	}
 	deps.Log = scopedRunLogger(deps.Log, spec)
 	ctx, span, endSpan := startRunSpan(ctx, deps, spec)
 	defer endSpan()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -82,8 +82,17 @@ func ShouldRun(state filament.RunState) bool {
 //
 //nolint:funlen,gocyclo // the run lifecycle reads best as one sequence
 func RunOne(ctx context.Context, deps Deps, spec filament.RunSpec) error {
-	if err := spec.Options.Execution.ValidateExecution(); err != nil {
+	if err := spec.Options.Execution.Validate(); err != nil {
 		return err
+	}
+	// Reject conflicting supplied ownership before any execution side effects.
+	if spec.StreamAttempt != nil {
+		if err := spec.ValidateStreamAttempt(); err != nil {
+			return err
+		}
+	}
+	if spec.Options.Execution.Normalize() == filament.ExecutionContinuous {
+		return filament.ErrContinuousDisabled
 	}
 	deps.Log = scopedRunLogger(deps.Log, spec)
 	ctx, span, endSpan := startRunSpan(ctx, deps, spec)

--- a/sink.go
+++ b/sink.go
@@ -21,6 +21,9 @@ type Sink interface {
 
 // ApplyOptions carries the per-resource write policy governing one Apply.
 type ApplyOptions struct {
+	// Epoch is nil for bounded writes. Native sinks reject writes that do not
+	// match the currently open epoch; this is not destination fencing.
+	Epoch  *EpochRef
 	Policy WritePolicy
 }
 
@@ -65,6 +68,7 @@ type SinkSpec struct {
 // SinkCapabilities advertises the optional contracts and write modes a sink
 // supports, so the engine can match it to an ingestion type.
 type SinkCapabilities struct {
+	Stream        *StreamingSinkCapabilities
 	Transactional bool
 	Upsertable    bool
 	Schematized   bool

--- a/source.go
+++ b/source.go
@@ -245,6 +245,7 @@ type ConfigValidatable interface {
 // ConnectorSpec is a source's self-description: identity, supported modes and
 // policies, config schema, and resource capabilities. It powers the catalog.
 type ConnectorSpec struct {
+	Stream         *StreamCapabilities
 	Name           string
 	DisplayName    string
 	Description    string

--- a/stream.go
+++ b/stream.go
@@ -25,13 +25,11 @@ func (e ExecutionMode) Normalize() ExecutionMode {
 
 var ErrContinuousDisabled = errors.New("continuous execution is disabled")
 
-// ValidateExecution keeps the runtime default-off while public contracts land.
-func (e ExecutionMode) ValidateExecution() error {
+// Validate checks the mode, independently of runtime availability.
+func (e ExecutionMode) Validate() error {
 	switch e.Normalize() {
-	case ExecutionBounded:
+	case ExecutionBounded, ExecutionContinuous:
 		return nil
-	case ExecutionContinuous:
-		return ErrContinuousDisabled
 	default:
 		return fmt.Errorf("unknown execution mode %q", e)
 	}
@@ -63,6 +61,8 @@ type Boundary struct {
 	MaxBytes        int64
 	MaxWait, MaxAge time.Duration
 }
+type StreamMeta = rowmodel.StreamMeta
+type EventIdentity = rowmodel.EventIdentity
 type DomainKey = rowmodel.DomainKey
 type Position = rowmodel.Position
 type DomainPosition = rowmodel.DomainPosition
@@ -120,4 +120,28 @@ type StreamRecordSink interface {
 type StreamingSinkCapabilities struct {
 	OwnerFencing, IsolatedEpochs bool
 	InFlightBound                *time.Duration
+}
+
+// ValidateStreamAttempt checks admitted continuous ownership against duplicated
+// run/dispatch identities. It does not grant authority or check runtime support.
+// Bounded specifications do not interpret this optional continuous context.
+func (s RunSpec) ValidateStreamAttempt() error {
+	if err := s.Options.Execution.Validate(); err != nil {
+		return err
+	}
+	if s.Options.Execution.Normalize() != ExecutionContinuous {
+		return nil
+	}
+	if s.StreamAttempt == nil {
+		return errors.New("stream: admitted attempt required")
+	}
+	a := s.StreamAttempt
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if (s.Run != "" && s.Run != a.RunID) || (s.ExecutionID != "" && s.ExecutionID != a.ExecutionID) ||
+		(s.ReplicationStream != nil && (s.ReplicationStream.ID != a.StreamID || s.ReplicationStream.Generation != a.Generation)) {
+		return errors.New("stream: run identity conflicts with admitted attempt")
+	}
+	return nil
 }

--- a/stream.go
+++ b/stream.go
@@ -9,13 +9,16 @@ import (
 	"github.com/galaxy-io/filament/rowmodel"
 )
 
+// ExecutionMode selects bounded or continuous execution independently of input semantics.
 type ExecutionMode string
 
+// Execution modes retain bounded behavior as the default.
 const (
 	ExecutionBounded    ExecutionMode = "bounded"
 	ExecutionContinuous ExecutionMode = "continuous"
 )
 
+// Normalize maps the compatibility zero value to bounded execution.
 func (e ExecutionMode) Normalize() ExecutionMode {
 	if e == "" {
 		return ExecutionBounded
@@ -23,6 +26,7 @@ func (e ExecutionMode) Normalize() ExecutionMode {
 	return e
 }
 
+// ErrContinuousDisabled reports that the continuous runtime is unavailable.
 var ErrContinuousDisabled = errors.New("continuous execution is disabled")
 
 // Validate checks the mode, independently of runtime availability.
@@ -35,10 +39,16 @@ func (e ExecutionMode) Validate() error {
 	}
 }
 
-type InputSemantics string
-type Ordering string
-type DeliveryGuarantee string
+type (
+	// InputSemantics describes whether input consists of rows, changes, or messages.
+	InputSemantics string
+	// Ordering identifies a source guarantee or destination ordering requirement.
+	Ordering string
+	// DeliveryGuarantee describes input replay and loss semantics.
+	DeliveryGuarantee string
+)
 
+// Source input, ordering, and delivery capabilities are negotiated independently.
 const (
 	InputRows                     InputSemantics    = "rows"
 	InputChanges                  InputSemantics    = "changes"
@@ -51,29 +61,49 @@ const (
 	DeliveryBestEffort            DeliveryGuarantee = "best_effort"
 )
 
+// StreamCapabilities describes source input, ordering, and replay guarantees.
 type StreamCapabilities struct {
 	Input    InputSemantics
 	Ordering []Ordering
 	Delivery DeliveryGuarantee
 }
+
+// Boundary defines soft record, byte, idle, and age targets for one epoch.
+// Complete source transactions may exceed these targets.
 type Boundary struct {
 	MaxRecords      int
 	MaxBytes        int64
 	MaxWait, MaxAge time.Duration
 }
-type StreamMeta = rowmodel.StreamMeta
-type EventIdentity = rowmodel.EventIdentity
-type DomainKey = rowmodel.DomainKey
-type Position = rowmodel.Position
-type DomainPosition = rowmodel.DomainPosition
-type DomainPositions = rowmodel.DomainPositions
-type PositionOrder = rowmodel.PositionOrder
-type PositionCodec = rowmodel.PositionCodec
-type CodecResolver = rowmodel.CodecResolver
-type Control = rowmodel.Control
-type ControlKind = rowmodel.ControlKind
-type ResourceDomainRef = rowmodel.ResourceDomainRef
 
+type (
+	// StreamMeta carries optional native event metadata alongside a row.
+	StreamMeta = rowmodel.StreamMeta
+	// EventIdentity identifies a source event independently of ingestion attempts.
+	EventIdentity = rowmodel.EventIdentity
+	// DomainKey identifies an ordering domain within a source incarnation.
+	DomainKey = rowmodel.DomainKey
+	// Position stores codec-encoded source progress.
+	Position = rowmodel.Position
+	// DomainPosition pairs a domain with its position for serialization.
+	DomainPosition = rowmodel.DomainPosition
+	// DomainPositions maps source ordering domains to their bookmarks.
+	DomainPositions = rowmodel.DomainPositions
+	// PositionOrder reports codec-defined ordering between compatible positions.
+	PositionOrder = rowmodel.PositionOrder
+	// PositionCodec defines validation, comparison, and canonicalization for progress.
+	PositionCodec = rowmodel.PositionCodec
+	// CodecResolver finds a position codec by name and version.
+	CodecResolver = rowmodel.CodecResolver
+	// Control carries standalone source boundary evidence.
+	Control = rowmodel.Control
+	// ControlKind distinguishes transaction, progress, and membership markers.
+	ControlKind = rowmodel.ControlKind
+	// ResourceDomainRef relates a resource to a shared source ordering domain.
+	ResourceDomainRef = rowmodel.ResourceDomainRef
+)
+
+// Neutral comparison outcomes and control kinds retain their rowmodel meanings.
 const (
 	PositionIncomparable = rowmodel.PositionIncomparable
 	PositionEqual        = rowmodel.PositionEqual
@@ -86,9 +116,12 @@ const (
 	MemberActivated      = rowmodel.MemberActivated
 )
 
+// StreamSource is an optional native factory for reusable source sessions.
 type StreamSource interface {
 	OpenStream(context.Context, StreamOpenOpts) (StreamSession, error)
 }
+
+// StreamOpenOpts supplies selected resources, durable resume state, and admitted ownership.
 type StreamOpenOpts struct {
 	Resources          []string
 	CommittedPositions DomainPositions
@@ -107,6 +140,8 @@ type StreamSession interface {
 	Acknowledge(context.Context, Coverage) error
 	Close(context.Context) error
 }
+
+// StreamRecordSink extends row writing with owner-ordered source boundary controls.
 type StreamRecordSink interface {
 	RecordSink
 	Control(context.Context, Control) error

--- a/stream.go
+++ b/stream.go
@@ -1,7 +1,68 @@
 package filament
 
-import "github.com/galaxy-io/filament/rowmodel"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
 
+	"github.com/galaxy-io/filament/rowmodel"
+)
+
+type ExecutionMode string
+
+const (
+	ExecutionBounded    ExecutionMode = "bounded"
+	ExecutionContinuous ExecutionMode = "continuous"
+)
+
+func (e ExecutionMode) Normalize() ExecutionMode {
+	if e == "" {
+		return ExecutionBounded
+	}
+	return e
+}
+
+var ErrContinuousDisabled = errors.New("continuous execution is disabled")
+
+// ValidateExecution keeps the runtime default-off while public contracts land.
+func (e ExecutionMode) ValidateExecution() error {
+	switch e.Normalize() {
+	case ExecutionBounded:
+		return nil
+	case ExecutionContinuous:
+		return ErrContinuousDisabled
+	default:
+		return fmt.Errorf("unknown execution mode %q", e)
+	}
+}
+
+type InputSemantics string
+type Ordering string
+type DeliveryGuarantee string
+
+const (
+	InputRows                     InputSemantics    = "rows"
+	InputChanges                  InputSemantics    = "changes"
+	InputMessages                 InputSemantics    = "messages"
+	OrderingNone                  Ordering          = "none"
+	OrderingPartition             Ordering          = "partition"
+	OrderingTransaction           Ordering          = "transaction"
+	OrderingGlobalStrict          Ordering          = "global_strict"
+	DeliveryReplayableAtLeastOnce DeliveryGuarantee = "replayable_at_least_once"
+	DeliveryBestEffort            DeliveryGuarantee = "best_effort"
+)
+
+type StreamCapabilities struct {
+	Input    InputSemantics
+	Ordering []Ordering
+	Delivery DeliveryGuarantee
+}
+type Boundary struct {
+	MaxRecords      int
+	MaxBytes        int64
+	MaxWait, MaxAge time.Duration
+}
 type DomainKey = rowmodel.DomainKey
 type Position = rowmodel.Position
 type DomainPosition = rowmodel.DomainPosition
@@ -24,3 +85,39 @@ const (
 	ProgressBoundary     = rowmodel.ProgressBoundary
 	MemberActivated      = rowmodel.MemberActivated
 )
+
+type StreamSource interface {
+	OpenStream(context.Context, StreamOpenOpts) (StreamSession, error)
+}
+type StreamOpenOpts struct {
+	Resources          []string
+	CommittedPositions DomainPositions
+	Membership         map[string]ReplicationStreamResourceStatus
+	Attempt            AttemptRef
+}
+
+// StreamSession owns its connection and protocol liveness under backpressure.
+// Read and Acknowledge are serialized. Cancel and join an outstanding call before
+// Close; concurrent Close is not required. Cancellation is never a safe boundary.
+// Read returns candidate complete-source coverage; only the coordinator can
+// certify pipeline completion and durability. Acknowledge receives certified
+// coverage and must still check current provider authority.
+type StreamSession interface {
+	Read(context.Context, StreamRecordSink, Boundary) (Coverage, error)
+	Acknowledge(context.Context, Coverage) error
+	Close(context.Context) error
+}
+type StreamRecordSink interface {
+	RecordSink
+	Control(context.Context, Control) error
+}
+
+// StreamingSinkCapabilities are claims requiring connector-specific evidence.
+// OwnerFencing checks authority across generations atomically with effects.
+// IsolatedEpochs additionally requires independent contexts (a later contract).
+// InFlightBound is nil when unknown; when set it must be positive and enforced
+// server-side over all residual effects after a proven end to submissions.
+type StreamingSinkCapabilities struct {
+	OwnerFencing, IsolatedEpochs bool
+	InFlightBound                *time.Duration
+}

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,26 @@
+package filament
+
+import "github.com/galaxy-io/filament/rowmodel"
+
+type DomainKey = rowmodel.DomainKey
+type Position = rowmodel.Position
+type DomainPosition = rowmodel.DomainPosition
+type DomainPositions = rowmodel.DomainPositions
+type PositionOrder = rowmodel.PositionOrder
+type PositionCodec = rowmodel.PositionCodec
+type CodecResolver = rowmodel.CodecResolver
+type Control = rowmodel.Control
+type ControlKind = rowmodel.ControlKind
+type ResourceDomainRef = rowmodel.ResourceDomainRef
+
+const (
+	PositionIncomparable = rowmodel.PositionIncomparable
+	PositionEqual        = rowmodel.PositionEqual
+	PositionBefore       = rowmodel.PositionBefore
+	PositionAfter        = rowmodel.PositionAfter
+	ControlUnspecified   = rowmodel.ControlUnspecified
+	TxnBegin             = rowmodel.TxnBegin
+	TxnEnd               = rowmodel.TxnEnd
+	ProgressBoundary     = rowmodel.ProgressBoundary
+	MemberActivated      = rowmodel.MemberActivated
+)

--- a/stream_store.go
+++ b/stream_store.go
@@ -22,22 +22,30 @@ type StreamRuntimeStore interface {
 	CommitEpoch(context.Context, EpochCertificate) (CommittedEpoch, error)
 	GetEpoch(context.Context, EpochLookup) (CommittedEpoch, error)
 }
+
+// StreamDesiredState records intended execution independently of worker health.
 type StreamDesiredState string
 
+// Desired stream states guide whether a supervisor should admit further attempts.
 const (
 	StreamEnabled StreamDesiredState = "enabled"
 	StreamPaused  StreamDesiredState = "paused"
 	StreamStopped StreamDesiredState = "stopped"
 )
 
+// StreamStateRequest identifies a tenant-scoped stream generation.
 type StreamStateRequest struct {
 	Tenant TenantID
 	Stream StreamRef
 }
+
+// LeaseToken binds complete attempt ownership to its tenant.
 type LeaseToken struct {
 	Tenant  TenantID
 	Attempt AttemptRef
 }
+
+// StartAttemptRequest supplies immutable execution identity and expected state for admission.
 type StartAttemptRequest struct {
 	Tenant                                TenantID
 	Stream                                StreamRef
@@ -46,27 +54,34 @@ type StartAttemptRequest struct {
 	ExpectedRevision                      int64
 	TTL                                   time.Duration
 }
+
+// Attempt describes one admitted worker lifetime and its lease interval.
 type Attempt struct {
 	Lease                LeaseToken
 	StartedAt, ExpiresAt time.Time
 	EndedAt              *time.Time
 }
 
+// AttemptTermination describes how a worker ended.
 // Successful session closure, not inferred workload disappearance, is necessary
 // to record clean termination. Detailed takeover proofs land with their owner.
 type AttemptTermination string
 
+// Termination outcomes distinguish proven closure from inferred or unproven shutdown.
 const (
 	AttemptClean    AttemptTermination = "clean"
 	AttemptReaped   AttemptTermination = "reaped"
 	AttemptUnproven AttemptTermination = "unproven"
 )
 
+// EndAttemptRequest conditionally records termination under the owning lease.
 type EndAttemptRequest struct {
 	Lease       LeaseToken
 	Termination AttemptTermination
 	Reason      string
 }
+
+// StreamState provides authoritative intent and recovery state for a stream generation.
 type StreamState struct {
 	StreamStateRequest
 	Desired                  StreamDesiredState
@@ -79,20 +94,28 @@ type StreamState struct {
 	MembershipRevision       int64
 	Membership               map[string]ReplicationStreamResourceStatus
 }
+
+// ReconcileQuery selects a bounded page of tenant-scoped reconciliation candidates.
 type ReconcileQuery struct {
 	Tenant TenantID
 	After  string
 	Limit  int
 }
+
+// ReconcilePage returns stream states and an opaque continuation cursor.
 type ReconcilePage struct {
 	States []StreamState
 	Next   string
 }
+
+// DesiredStateChange requests an intent update guarded by the expected revision.
 type DesiredStateChange struct {
 	StreamStateRequest
 	ExpectedRevision int64
 	Desired          StreamDesiredState
 }
+
+// EpochLookup identifies a historical certificate within its tenant scope.
 type EpochLookup struct {
 	Tenant TenantID
 	Key    EpochKey

--- a/stream_store.go
+++ b/stream_store.go
@@ -1,0 +1,99 @@
+package filament
+
+import (
+	"context"
+	"time"
+)
+
+// StreamRuntimeStore is an optional engine extension, not part of DataStore or
+// connector lifecycles. Definitions only: no backend implements it yet.
+// All operations are tenant-scoped. StartAttempt, renewal and certification must
+// serialize authority. Tokens increase across generations. Identical certificate
+// retries return historical success without granting current ack authority.
+// CommitEpoch must verify sealed source/barrier evidence in addition to these
+// public value types; the transaction and evidence contract lands in PRs 04–06.
+type StreamRuntimeStore interface {
+	StartAttempt(context.Context, StartAttemptRequest) (Attempt, error)
+	RenewLease(context.Context, LeaseToken, time.Duration) error
+	EndAttempt(context.Context, EndAttemptRequest) error
+	LoadStreamState(context.Context, StreamStateRequest) (StreamState, error)
+	ListReconcileCandidates(context.Context, ReconcileQuery) (ReconcilePage, error)
+	SetDesiredState(context.Context, DesiredStateChange) error
+	CommitEpoch(context.Context, EpochCertificate) (CommittedEpoch, error)
+	GetEpoch(context.Context, EpochLookup) (CommittedEpoch, error)
+}
+type StreamDesiredState string
+
+const (
+	StreamEnabled StreamDesiredState = "enabled"
+	StreamPaused  StreamDesiredState = "paused"
+	StreamStopped StreamDesiredState = "stopped"
+)
+
+type StreamStateRequest struct {
+	Tenant TenantID
+	Stream StreamRef
+}
+type LeaseToken struct {
+	Tenant  TenantID
+	Attempt AttemptRef
+}
+type StartAttemptRequest struct {
+	Tenant                                TenantID
+	Stream                                StreamRef
+	Run                                   RunID
+	ExecutionID, PipelineVersionID, Route string
+	ExpectedRevision                      int64
+	TTL                                   time.Duration
+}
+type Attempt struct {
+	Lease                LeaseToken
+	StartedAt, ExpiresAt time.Time
+	EndedAt              *time.Time
+}
+
+// Successful session closure, not inferred workload disappearance, is necessary
+// to record clean termination. Detailed takeover proofs land with their owner.
+type AttemptTermination string
+
+const (
+	AttemptClean    AttemptTermination = "clean"
+	AttemptReaped   AttemptTermination = "reaped"
+	AttemptUnproven AttemptTermination = "unproven"
+)
+
+type EndAttemptRequest struct {
+	Lease       LeaseToken
+	Termination AttemptTermination
+	Reason      string
+}
+type StreamState struct {
+	StreamStateRequest
+	Desired                  StreamDesiredState
+	Revision                 int64
+	PipelineVersionID, Route string
+	Run                      RunID
+	Attempt                  *Attempt
+	CommittedPositions       DomainPositions
+	LastEpoch                *EpochKey
+	MembershipRevision       int64
+	Membership               map[string]ReplicationStreamResourceStatus
+}
+type ReconcileQuery struct {
+	Tenant TenantID
+	After  string
+	Limit  int
+}
+type ReconcilePage struct {
+	States []StreamState
+	Next   string
+}
+type DesiredStateChange struct {
+	StreamStateRequest
+	ExpectedRevision int64
+	Desired          StreamDesiredState
+}
+type EpochLookup struct {
+	Tenant TenantID
+	Key    EpochKey
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,129 @@
+package filament_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	f "github.com/galaxy-io/filament"
+	"github.com/galaxy-io/filament/rowmodel"
+)
+
+// This contract test deliberately has no streamkit dependency: PR 02 stands alone.
+type testCodec struct{}
+
+func (testCodec) Lookup(string, int) (rowmodel.PositionCodec, error) { return testCodec{}, nil }
+func (testCodec) Validate(p f.Position) error                        { return p.Validate() }
+func (testCodec) Canonicalize(p f.Position) (f.Position, error) {
+	p.Payload = bytes.ToLower(p.Payload)
+	return p, nil
+}
+func (testCodec) Compare(a, b f.Position) (f.PositionOrder, error) {
+	if bytes.Equal(a.Payload, b.Payload) {
+		return f.PositionEqual, nil
+	}
+	return f.PositionIncomparable, nil
+}
+func TestStreamDefaultsAndApplyBinding(t *testing.T) {
+	var opts f.RunOptions
+	if err := json.Unmarshal([]byte(`{"BatchMaxRows":10}`), &opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.Execution.Normalize() != f.ExecutionBounded || opts.Execution.ValidateExecution() != nil {
+		t.Fatal("legacy options changed")
+	}
+	if !errors.Is(f.ExecutionContinuous.ValidateExecution(), f.ErrContinuousDisabled) || f.ExecutionMode("future").ValidateExecution() == nil {
+		t.Fatal("execution must fail closed")
+	}
+	e := f.EpochRef{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 2}, Epoch: 1, MembershipRevision: 1}
+	if err := e.ValidateApply(f.ApplyOptions{Epoch: &e}); err != nil {
+		t.Fatal(err)
+	}
+	for _, changed := range []f.EpochRef{
+		{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 2, Token: 2}, Epoch: 1, MembershipRevision: 1},
+		{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 1}, Epoch: 1, MembershipRevision: 1},
+	} {
+		if !errors.Is(e.ValidateApply(f.ApplyOptions{Epoch: &changed}), f.ErrFenced) {
+			t.Fatal("stale epoch accepted")
+		}
+	}
+	if !errors.Is(e.ValidateApply(f.ApplyOptions{}), f.ErrFenced) {
+		t.Fatal("unbound write accepted")
+	}
+}
+func TestCanonicalCertificateAndCoverageOwnership(t *testing.T) {
+	a, b := f.DomainKey{Incarnation: "i", Domain: "a"}, f.DomainKey{Incarnation: "i", Domain: "b"}
+	cert := f.EpochCertificate{FormatVersion: 1, Tenant: "t", PipelineVersionID: "p", Ref: f.EpochRef{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 1}, Epoch: 1, MembershipRevision: 1}, Coverage: f.Coverage{Positions: f.DomainPositions{b: {Codec: "c", Version: 1, Payload: []byte("B")}, a: {Codec: "c", Version: 1, Payload: []byte("A")}}}, Receipts: []f.EpochReceipt{{Resource: "b"}, {Resource: "a"}}}
+	copy := cert.Clone()
+	copy.Coverage.Positions[a].Payload[0] = 'a'
+	copy.Coverage.Positions[b].Payload[0] = 'b'
+	copy.Receipts[0], copy.Receipts[1] = copy.Receipts[1], copy.Receipts[0]
+	x, err := cert.Digest(testCodec{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	y, err := copy.Digest(testCodec{})
+	if err != nil || x != y {
+		t.Fatalf("canonical mismatch: %v", err)
+	}
+	if string(cert.Coverage.Positions[a].Payload) != "A" {
+		t.Fatal("clone mutated original")
+	}
+	copy.Ref.Token++
+	z, _ := copy.Digest(testCodec{})
+	if x == z {
+		t.Fatal("authority omitted from digest")
+	}
+	wire, err := json.Marshal(cert.Coverage.Positions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var positions f.DomainPositions
+	if err := json.Unmarshal(wire, &positions); err != nil {
+		t.Fatal(err)
+	}
+	if len(positions) != 2 {
+		t.Fatal("position wire roundtrip")
+	}
+	if err := json.Unmarshal([]byte(`[{"Domain":{"Incarnation":"i","Domain":"a"},"Position":{"Codec":"c"}},{"Domain":{"Incarnation":"i","Domain":"a"},"Position":{"Codec":"c"}}]`), &positions); err == nil {
+		t.Fatal("duplicate domain accepted")
+	}
+	for _, coverage := range []f.Coverage{{}, {Positions: cert.Coverage.Positions, Claims: []f.InboxClaimRef{{RowID: "1", Owner: "o", Token: 1}}}, {Claims: []f.InboxClaimRef{{RowID: "1", Owner: "o", Token: 1}, {RowID: "1", Owner: "o", Token: 2}}}} {
+		if coverage.Validate() == nil {
+			t.Fatal("invalid coverage accepted")
+		}
+	}
+	claims := f.Coverage{Claims: []f.InboxClaimRef{{RowID: "2", Owner: "o", Token: 1}, {RowID: "1", Owner: "o", Token: 2}}}
+	sealed, err := claims.Canonicalize(nil)
+	if err != nil || sealed.Claims[0].RowID != "1" || claims.Claims[0].RowID != "2" {
+		t.Fatal("claim canonicalization ownership")
+	}
+	_, err = rowmodel.ComparePositions(testCodec{}, a, cert.Coverage.Positions[a], f.DomainKey{Incarnation: "other", Domain: "a"}, cert.Coverage.Positions[a])
+	if !errors.Is(err, f.ErrPositionIncomparable) {
+		t.Fatal("incarnation ordering inferred")
+	}
+}
+func TestControlValidationAndOwnership(t *testing.T) {
+	c := f.Control{Kind: f.ProgressBoundary, Domain: f.DomainKey{Incarnation: "i", Domain: "d"}, Position: f.Position{Codec: "c", Payload: []byte("p")}}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	copy := c.Clone()
+	copy.Position.Payload[0] = 'x'
+	if string(c.Position.Payload) != "p" {
+		t.Fatal("control aliases bytes")
+	}
+	for _, kind := range []f.ControlKind{f.ControlUnspecified, f.TxnBegin, f.TxnEnd, f.MemberActivated, 99} {
+		c.Kind = kind
+		if c.Validate() == nil {
+			t.Fatalf("invalid control %d", kind)
+		}
+	}
+	c.Kind = f.MemberActivated
+	c.Resource = "r"
+	c.MembershipRevision = 1
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,11 +16,11 @@ type testCodec struct{}
 func (testCodec) Lookup(string, int) (rowmodel.PositionCodec, error) { return testCodec{}, nil }
 func (testCodec) Validate(p f.Position) error                        { return p.Validate() }
 func (testCodec) Canonicalize(p f.Position) (f.Position, error) {
-	p.Payload = bytes.ToLower(p.Payload)
+	p.Value = bytes.ToLower(p.Value)
 	return p, nil
 }
 func (testCodec) Compare(a, b f.Position) (f.PositionOrder, error) {
-	if bytes.Equal(a.Payload, b.Payload) {
+	if bytes.Equal(a.Value, b.Value) {
 		return f.PositionEqual, nil
 	}
 	return f.PositionIncomparable, nil
@@ -30,34 +30,34 @@ func TestStreamDefaultsAndApplyBinding(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{"BatchMaxRows":10}`), &opts); err != nil {
 		t.Fatal(err)
 	}
-	if opts.Execution.Normalize() != f.ExecutionBounded || opts.Execution.ValidateExecution() != nil {
+	if opts.Execution.Normalize() != f.ExecutionBounded || opts.Execution.Validate() != nil {
 		t.Fatal("legacy options changed")
 	}
-	if !errors.Is(f.ExecutionContinuous.ValidateExecution(), f.ErrContinuousDisabled) || f.ExecutionMode("future").ValidateExecution() == nil {
+	if f.ExecutionContinuous.Validate() != nil || f.ExecutionMode("future").Validate() == nil {
 		t.Fatal("execution must fail closed")
 	}
-	e := f.EpochRef{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 2}, Epoch: 1, MembershipRevision: 1}
+	e := f.EpochRef{Attempt: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 2}, Epoch: 1, MembershipRevision: 1}
 	if err := e.ValidateApply(f.ApplyOptions{Epoch: &e}); err != nil {
 		t.Fatal(err)
 	}
 	for _, changed := range []f.EpochRef{
-		{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 2, Token: 2}, Epoch: 1, MembershipRevision: 1},
-		{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 1}, Epoch: 1, MembershipRevision: 1},
+		{Attempt: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 2, Token: 2}, Epoch: 1, MembershipRevision: 1},
+		{Attempt: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 1}, Epoch: 1, MembershipRevision: 1},
 	} {
-		if !errors.Is(e.ValidateApply(f.ApplyOptions{Epoch: &changed}), f.ErrFenced) {
+		if !errors.Is(e.ValidateApply(f.ApplyOptions{Epoch: &changed}), f.ErrEpochMismatch) {
 			t.Fatal("stale epoch accepted")
 		}
 	}
-	if !errors.Is(e.ValidateApply(f.ApplyOptions{}), f.ErrFenced) {
+	if !errors.Is(e.ValidateApply(f.ApplyOptions{}), f.ErrEpochMismatch) {
 		t.Fatal("unbound write accepted")
 	}
 }
 func TestCanonicalCertificateAndCoverageOwnership(t *testing.T) {
 	a, b := f.DomainKey{Incarnation: "i", Domain: "a"}, f.DomainKey{Incarnation: "i", Domain: "b"}
-	cert := f.EpochCertificate{FormatVersion: 1, Tenant: "t", PipelineVersionID: "p", Ref: f.EpochRef{AttemptRef: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 1}, Epoch: 1, MembershipRevision: 1}, Coverage: f.Coverage{Positions: f.DomainPositions{b: {Codec: "c", Version: 1, Payload: []byte("B")}, a: {Codec: "c", Version: 1, Payload: []byte("A")}}}, Receipts: []f.EpochReceipt{{Resource: "b"}, {Resource: "a"}}}
+	cert := f.EpochCertificate{FormatVersion: f.EpochCertificateFormatVersion, Tenant: "t", PipelineVersionID: "p", Ref: f.EpochRef{Attempt: f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 1}, Epoch: 1, MembershipRevision: 1}, Coverage: f.Coverage{Positions: f.DomainPositions{b: {Codec: "c", Version: 1, Value: []byte("B")}, a: {Codec: "c", Version: 1, Value: []byte("A")}}}, Receipts: []f.EpochReceipt{{Resource: "b"}, {Resource: "a"}}}
 	copy := cert.Clone()
-	copy.Coverage.Positions[a].Payload[0] = 'a'
-	copy.Coverage.Positions[b].Payload[0] = 'b'
+	copy.Coverage.Positions[a].Value[0] = 'a'
+	copy.Coverage.Positions[b].Value[0] = 'b'
 	copy.Receipts[0], copy.Receipts[1] = copy.Receipts[1], copy.Receipts[0]
 	x, err := cert.Digest(testCodec{})
 	if err != nil {
@@ -67,10 +67,10 @@ func TestCanonicalCertificateAndCoverageOwnership(t *testing.T) {
 	if err != nil || x != y {
 		t.Fatalf("canonical mismatch: %v", err)
 	}
-	if string(cert.Coverage.Positions[a].Payload) != "A" {
+	if string(cert.Coverage.Positions[a].Value) != "A" {
 		t.Fatal("clone mutated original")
 	}
-	copy.Ref.Token++
+	copy.Ref.Attempt.Token++
 	z, _ := copy.Digest(testCodec{})
 	if x == z {
 		t.Fatal("authority omitted from digest")
@@ -90,7 +90,7 @@ func TestCanonicalCertificateAndCoverageOwnership(t *testing.T) {
 		t.Fatal("duplicate domain accepted")
 	}
 	for _, coverage := range []f.Coverage{{}, {Positions: cert.Coverage.Positions, Claims: []f.InboxClaimRef{{RowID: "1", Owner: "o", Token: 1}}}, {Claims: []f.InboxClaimRef{{RowID: "1", Owner: "o", Token: 1}, {RowID: "1", Owner: "o", Token: 2}}}} {
-		if coverage.Validate() == nil {
+		if coverage.ValidateRepresentation() == nil {
 			t.Fatal("invalid coverage accepted")
 		}
 	}
@@ -105,13 +105,13 @@ func TestCanonicalCertificateAndCoverageOwnership(t *testing.T) {
 	}
 }
 func TestControlValidationAndOwnership(t *testing.T) {
-	c := f.Control{Kind: f.ProgressBoundary, Domain: f.DomainKey{Incarnation: "i", Domain: "d"}, Position: f.Position{Codec: "c", Payload: []byte("p")}}
+	c := f.Control{Kind: f.ProgressBoundary, Domain: f.DomainKey{Incarnation: "i", Domain: "d"}, Position: f.Position{Codec: "c", Value: []byte("p")}}
 	if err := c.Validate(); err != nil {
 		t.Fatal(err)
 	}
 	copy := c.Clone()
-	copy.Position.Payload[0] = 'x'
-	if string(c.Position.Payload) != "p" {
+	copy.Position.Value[0] = 'x'
+	if string(c.Position.Value) != "p" {
 		t.Fatal("control aliases bytes")
 	}
 	for _, kind := range []f.ControlKind{f.ControlUnspecified, f.TxnBegin, f.TxnEnd, f.MemberActivated, 99} {
@@ -125,5 +125,90 @@ func TestControlValidationAndOwnership(t *testing.T) {
 	c.MembershipRevision = 1
 	if err := c.Validate(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCoverageConstructorsOwnInputs(t *testing.T) {
+	domain := f.DomainKey{Incarnation: "i", Domain: "d"}
+	positions := f.DomainPositions{domain: {Codec: "c", Value: []byte("p")}}
+	coverage, err := f.NewPositionCoverage(positions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	positions[domain].Value[0] = 'x'
+	delete(positions, domain)
+	if string(coverage.Positions[domain].Value) != "p" {
+		t.Fatal("position coverage borrows input")
+	}
+	claims := []f.InboxClaimRef{{RowID: "1", Owner: "o", Token: 1}}
+	claimed, err := f.NewClaimCoverage(claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims[0].Token = 2
+	if claimed.Claims[0].Token != 1 {
+		t.Fatal("claim coverage borrows input")
+	}
+	if _, err := f.NewPositionCoverage(nil); err == nil {
+		t.Fatal("empty position coverage")
+	}
+	if _, err := f.NewClaimCoverage(nil); err == nil {
+		t.Fatal("empty claim coverage")
+	}
+	coverage.Claims = claimed.Claims
+	if coverage.ValidateRepresentation() == nil {
+		t.Fatal("mutated mixed coverage accepted")
+	}
+}
+
+func TestRunStreamAttemptIdentity(t *testing.T) {
+	a := f.AttemptRef{RunID: "r", ExecutionID: "e", StreamID: "s", Generation: 1, Token: 2}
+	spec := f.RunSpec{StreamAttempt: &a, Run: "r", ExecutionID: "e", ReplicationStream: &f.StreamRef{ID: "s", Generation: 1}, Options: f.RunOptions{Execution: f.ExecutionContinuous}}
+	if err := spec.ValidateStreamAttempt(); err != nil {
+		t.Fatal(err)
+	}
+	for _, change := range []func(*f.RunSpec){
+		func(s *f.RunSpec) { s.Run = "wrong" },
+		func(s *f.RunSpec) { s.ExecutionID = "wrong" },
+		func(s *f.RunSpec) { s.ReplicationStream = &f.StreamRef{ID: "wrong", Generation: 1} },
+		func(s *f.RunSpec) { s.ReplicationStream = &f.StreamRef{ID: "s", Generation: 2} },
+		func(s *f.RunSpec) { s.StreamAttempt = nil },
+	} {
+		copy := spec
+		change(&copy)
+		if copy.ValidateStreamAttempt() == nil {
+			t.Fatal("conflicting or absent attempt accepted")
+		}
+	}
+	spec.Run = ""
+	spec.ExecutionID = ""
+	spec.ReplicationStream = nil
+	if err := spec.ValidateStreamAttempt(); err != nil {
+		t.Fatal("attempt must be authoritative when optional mirrors are absent", err)
+	}
+	spec.Options.Execution = f.ExecutionBounded
+	spec.Run = "unrelated"
+	if err := spec.ValidateStreamAttempt(); err != nil {
+		t.Fatal("bounded dispatch changed", err)
+	}
+}
+
+func TestReceiptEvidenceOwnershipAndPresence(t *testing.T) {
+	cert := f.EpochCertificate{Receipts: []f.EpochReceipt{{Resource: "r", Evidence: &f.ReceiptEvidence{Format: "receipt", Version: 0, Payload: []byte{1}}}, {Resource: "absent"}}}
+	clone := cert.Clone()
+	clone.Receipts[0].Evidence.Payload[0] = 2
+	clone.Receipts[0].Evidence.Format = "changed"
+	if cert.Receipts[0].Evidence.Payload[0] != 1 || cert.Receipts[0].Evidence.Format != "receipt" || clone.Receipts[1].Evidence != nil {
+		t.Fatal("receipt evidence ownership/presence lost")
+	}
+	for _, e := range []*f.ReceiptEvidence{{}, {Format: "receipt", Version: -1}} {
+		if e.Validate() == nil {
+			t.Fatal("invalid present evidence")
+		}
+	}
+	nilPayload := (&f.ReceiptEvidence{Format: "receipt"}).Clone()
+	emptyPayload := (&f.ReceiptEvidence{Format: "receipt", Payload: []byte{}}).Clone()
+	if nilPayload.Payload != nil || emptyPayload.Payload == nil {
+		t.Fatal("nil/empty evidence payload lost")
 	}
 }

--- a/streamkit/codec.go
+++ b/streamkit/codec.go
@@ -1,0 +1,126 @@
+// Package streamkit provides optional public helpers for native stream connectors.
+// It supplies encoding mechanics, never runtime admission or delivery guarantees.
+package streamkit
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/galaxy-io/filament/rowmodel"
+)
+
+var ErrUnknownCodec = errors.New("streamkit: unknown codec")
+
+type codecKey struct {
+	name    string
+	version int
+}
+
+// Registry is safe for concurrent lookup/registration. Codecs must be pure,
+// deterministic and concurrency-safe. Registrations cannot replace live codecs.
+type Registry struct {
+	mu     sync.RWMutex
+	codecs map[codecKey]rowmodel.PositionCodec
+}
+
+func (r *Registry) Register(name string, version int, c rowmodel.PositionCodec) error {
+	if name == "" || version < 0 || c == nil {
+		return errors.New("streamkit: invalid codec registration")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := codecKey{name, version}
+	if _, ok := r.codecs[key]; ok {
+		return errors.New("streamkit: duplicate codec")
+	}
+	if r.codecs == nil {
+		r.codecs = make(map[codecKey]rowmodel.PositionCodec)
+	}
+	r.codecs[key] = c
+	return nil
+}
+func (r *Registry) Lookup(name string, version int) (rowmodel.PositionCodec, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.codecs[codecKey{name, version}]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s v%d", ErrUnknownCodec, name, version)
+	}
+	return c, nil
+}
+
+// OpaqueCodec permits equality only; differing opaque cursors are incomparable.
+// Nil and empty payloads remain distinct. It does not interpret native cursors.
+type OpaqueCodec struct{}
+
+func (OpaqueCodec) Validate(p rowmodel.Position) error { return p.Validate() }
+func (c OpaqueCodec) Canonicalize(p rowmodel.Position) (rowmodel.Position, error) {
+	return p.Clone(), c.Validate(p)
+}
+func (c OpaqueCodec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, error) {
+	if a.Codec != b.Codec || a.Version != b.Version {
+		return rowmodel.PositionIncomparable, nil
+	}
+	if err := c.Validate(a); err != nil {
+		return rowmodel.PositionIncomparable, err
+	}
+	if err := c.Validate(b); err != nil {
+		return rowmodel.PositionIncomparable, err
+	}
+	if (a.Payload == nil) == (b.Payload == nil) && bytes.Equal(a.Payload, b.Payload) {
+		return rowmodel.PositionEqual, nil
+	}
+	return rowmodel.PositionIncomparable, nil
+}
+
+// Uint64Codec encodes a connector-declared unsigned counter as decimal ASCII.
+// Leading zeros normalize away. It must not be used for LSNs, GTID sets or opaque
+// cursors merely because a sample happens to contain digits.
+type Uint64Codec struct{}
+
+func (Uint64Codec) Validate(p rowmodel.Position) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if len(p.Payload) == 0 {
+		return errors.New("streamkit: empty counter")
+	}
+	for _, b := range p.Payload {
+		if b < '0' || b > '9' {
+			return errors.New("streamkit: non-decimal counter")
+		}
+	}
+	_, err := strconv.ParseUint(string(p.Payload), 10, 64)
+	return err
+}
+func (c Uint64Codec) Canonicalize(p rowmodel.Position) (rowmodel.Position, error) {
+	if err := c.Validate(p); err != nil {
+		return rowmodel.Position{}, err
+	}
+	n, _ := strconv.ParseUint(string(p.Payload), 10, 64)
+	p.Payload = []byte(strconv.FormatUint(n, 10))
+	return p, nil
+}
+func (c Uint64Codec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, error) {
+	if a.Codec != b.Codec || a.Version != b.Version {
+		return rowmodel.PositionIncomparable, nil
+	}
+	if err := c.Validate(a); err != nil {
+		return rowmodel.PositionIncomparable, err
+	}
+	if err := c.Validate(b); err != nil {
+		return rowmodel.PositionIncomparable, err
+	}
+	x, _ := strconv.ParseUint(string(a.Payload), 10, 64)
+	y, _ := strconv.ParseUint(string(b.Payload), 10, 64)
+	if x < y {
+		return rowmodel.PositionBefore, nil
+	}
+	if x > y {
+		return rowmodel.PositionAfter, nil
+	}
+	return rowmodel.PositionEqual, nil
+}

--- a/streamkit/codec.go
+++ b/streamkit/codec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/galaxy-io/filament/rowmodel"
 )
 
+// ErrUnknownCodec reports an unregistered codec identifier or version.
 var ErrUnknownCodec = errors.New("streamkit: unknown codec")
 
 type codecKey struct {
@@ -26,6 +27,7 @@ type Registry struct {
 	codecs map[codecKey]rowmodel.PositionCodec
 }
 
+// Register adds a codec without allowing replacement of an existing registration.
 func (r *Registry) Register(name string, version int, c rowmodel.PositionCodec) error {
 	if name == "" || version < 0 || c == nil {
 		return errors.New("streamkit: invalid codec registration")
@@ -42,6 +44,8 @@ func (r *Registry) Register(name string, version int, c rowmodel.PositionCodec) 
 	r.codecs[key] = c
 	return nil
 }
+
+// Lookup resolves a registered codec or returns ErrUnknownCodec.
 func (r *Registry) Lookup(name string, version int) (rowmodel.PositionCodec, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -56,10 +60,15 @@ func (r *Registry) Lookup(name string, version int) (rowmodel.PositionCodec, err
 // Nil and empty payloads remain distinct. It does not interpret native cursors.
 type OpaqueCodec struct{}
 
+// Validate checks the position format identity without interpreting opaque bytes.
 func (OpaqueCodec) Validate(p rowmodel.Position) error { return p.Validate() }
+
+// Canonicalize validates and copies the value, preserving nil versus empty bytes.
 func (c OpaqueCodec) Canonicalize(p rowmodel.Position) (rowmodel.Position, error) {
 	return p.Clone(), c.Validate(p)
 }
+
+// Compare permits exact equality only; different opaque values remain incomparable.
 func (c OpaqueCodec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, error) {
 	if a.Codec != b.Codec || a.Version != b.Version {
 		return rowmodel.PositionIncomparable, nil
@@ -81,6 +90,7 @@ func (c OpaqueCodec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, er
 // cursors merely because a sample happens to contain digits.
 type Uint64Codec struct{}
 
+// Validate requires decimal digits representing a value within the uint64 range.
 func (Uint64Codec) Validate(p rowmodel.Position) error {
 	if err := p.Validate(); err != nil {
 		return err
@@ -96,6 +106,8 @@ func (Uint64Codec) Validate(p rowmodel.Position) error {
 	_, err := strconv.ParseUint(string(p.Value), 10, 64)
 	return err
 }
+
+// Canonicalize returns independently owned decimal bytes without leading zeros.
 func (c Uint64Codec) Canonicalize(p rowmodel.Position) (rowmodel.Position, error) {
 	if err := c.Validate(p); err != nil {
 		return rowmodel.Position{}, err
@@ -104,6 +116,8 @@ func (c Uint64Codec) Canonicalize(p rowmodel.Position) (rowmodel.Position, error
 	p.Value = []byte(strconv.FormatUint(n, 10))
 	return p, nil
 }
+
+// Compare orders validated unsigned counters with matching codec identities.
 func (c Uint64Codec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, error) {
 	if a.Codec != b.Codec || a.Version != b.Version {
 		return rowmodel.PositionIncomparable, nil

--- a/streamkit/codec.go
+++ b/streamkit/codec.go
@@ -70,7 +70,7 @@ func (c OpaqueCodec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, er
 	if err := c.Validate(b); err != nil {
 		return rowmodel.PositionIncomparable, err
 	}
-	if (a.Payload == nil) == (b.Payload == nil) && bytes.Equal(a.Payload, b.Payload) {
+	if (a.Value == nil) == (b.Value == nil) && bytes.Equal(a.Value, b.Value) {
 		return rowmodel.PositionEqual, nil
 	}
 	return rowmodel.PositionIncomparable, nil
@@ -85,23 +85,23 @@ func (Uint64Codec) Validate(p rowmodel.Position) error {
 	if err := p.Validate(); err != nil {
 		return err
 	}
-	if len(p.Payload) == 0 {
+	if len(p.Value) == 0 {
 		return errors.New("streamkit: empty counter")
 	}
-	for _, b := range p.Payload {
+	for _, b := range p.Value {
 		if b < '0' || b > '9' {
 			return errors.New("streamkit: non-decimal counter")
 		}
 	}
-	_, err := strconv.ParseUint(string(p.Payload), 10, 64)
+	_, err := strconv.ParseUint(string(p.Value), 10, 64)
 	return err
 }
 func (c Uint64Codec) Canonicalize(p rowmodel.Position) (rowmodel.Position, error) {
 	if err := c.Validate(p); err != nil {
 		return rowmodel.Position{}, err
 	}
-	n, _ := strconv.ParseUint(string(p.Payload), 10, 64)
-	p.Payload = []byte(strconv.FormatUint(n, 10))
+	n, _ := strconv.ParseUint(string(p.Value), 10, 64)
+	p.Value = []byte(strconv.FormatUint(n, 10))
 	return p, nil
 }
 func (c Uint64Codec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, error) {
@@ -114,8 +114,8 @@ func (c Uint64Codec) Compare(a, b rowmodel.Position) (rowmodel.PositionOrder, er
 	if err := c.Validate(b); err != nil {
 		return rowmodel.PositionIncomparable, err
 	}
-	x, _ := strconv.ParseUint(string(a.Payload), 10, 64)
-	y, _ := strconv.ParseUint(string(b.Payload), 10, 64)
+	x, _ := strconv.ParseUint(string(a.Value), 10, 64)
+	y, _ := strconv.ParseUint(string(b.Value), 10, 64)
 	if x < y {
 		return rowmodel.PositionBefore, nil
 	}

--- a/streamkit/envelope.go
+++ b/streamkit/envelope.go
@@ -57,6 +57,7 @@ func DecodeIdentity(data []byte, r rowmodel.CodecResolver) (EventIdentity, error
 	return identity, nil
 }
 
+// EventID returns the SHA-256 hex digest of the canonical source event identity.
 func EventID(e EventIdentity, r rowmodel.CodecResolver) (string, error) {
 	data, err := CanonicalIdentity(e, r)
 	if err != nil {
@@ -66,6 +67,7 @@ func EventID(e EventIdentity, r rowmodel.CodecResolver) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
+// Envelope combines source identity with message content and lossless delivery metadata.
 type Envelope struct {
 	Identity    EventIdentity
 	Timestamp   *time.Time
@@ -85,12 +87,18 @@ type Projector struct {
 	codecs rowmodel.CodecResolver
 }
 
+// NewProjector binds an envelope writer to its position codecs.
+// The writer must have been opened with WithEnvelopeFields.
 func NewProjector(w arrowbatch.RowWriter, r rowmodel.CodecResolver) *Projector {
 	return &Projector{w, r}
 }
+
+// WithEnvelopeFields appends the SDK schema suffix after rejecting reserved-name collisions.
 func WithEnvelopeFields(s rowmodel.Schema) (rowmodel.Schema, error) {
 	return rowmodel.WithEnvelopeFields(s)
 }
+
+// EndEvent projects envelope columns and derives stream metadata before completing the row.
 func (w *Projector) EndEvent(e Envelope, meta rowmodel.Meta) error {
 	// Validate before appending any SDK column. On error the source must abandon
 	// the pending row/writer; RowWriter does not provide rollback of source fields.

--- a/streamkit/envelope.go
+++ b/streamkit/envelope.go
@@ -6,27 +6,21 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"time"
-	"unicode/utf8"
 
 	"github.com/galaxy-io/filament/arrowbatch"
 	"github.com/galaxy-io/filament/rowmodel"
 )
 
-// EventIdentity is independent of runs, generations, attempts and consumer names.
-// Ordinal distinguishes changes sharing a transaction position without overflow
-// at uint32. Sources must supply stable event positions, including on replay.
-type EventIdentity struct {
-	Domain   rowmodel.DomainKey
-	Position rowmodel.Position
-	Ordinal  uint64
-}
+// IdentityEncodingVersion identifies the canonical event identity encoding.
+const IdentityEncodingVersion = 1
 
-func (e EventIdentity) CanonicalBytes(r rowmodel.CodecResolver) ([]byte, error) {
+// EventIdentity shares the neutral value type; encoding belongs to this SDK.
+type EventIdentity = rowmodel.EventIdentity
+
+// CanonicalIdentity encodes an identity with its codec-canonical position.
+func CanonicalIdentity(e EventIdentity, r rowmodel.CodecResolver) ([]byte, error) {
 	if err := e.Domain.Validate(); err != nil {
 		return nil, err
-	}
-	if !utf8.ValidString(e.Domain.Incarnation) || !utf8.ValidString(e.Domain.Domain) || !utf8.ValidString(e.Position.Codec) {
-		return nil, ErrInvalidEnvelope
 	}
 	p, err := rowmodel.CanonicalPosition(r, e.Position)
 	if err != nil {
@@ -36,7 +30,7 @@ func (e EventIdentity) CanonicalBytes(r rowmodel.CodecResolver) ([]byte, error) 
 	return json.Marshal(struct {
 		Version  int
 		Identity EventIdentity
-	}{1, e})
+	}{IdentityEncodingVersion, e})
 }
 
 // DecodeIdentity accepts only the canonical versioned SDK representation. It
@@ -49,26 +43,27 @@ func DecodeIdentity(data []byte, r rowmodel.CodecResolver) (EventIdentity, error
 	if err := json.Unmarshal(data, &wire); err != nil {
 		return EventIdentity{}, err
 	}
-	if wire.Version != 1 {
+	if wire.Version != IdentityEncodingVersion {
 		return EventIdentity{}, ErrInvalidEnvelope
 	}
-	canonical, err := wire.Identity.CanonicalBytes(r)
+	identity := wire.Identity
+	canonical, err := CanonicalIdentity(identity, r)
 	if err != nil {
 		return EventIdentity{}, err
 	}
 	if !bytes.Equal(data, canonical) {
 		return EventIdentity{}, ErrInvalidEnvelope
 	}
-	return wire.Identity, nil
+	return identity, nil
 }
 
-func (e EventIdentity) ID(r rowmodel.CodecResolver) (string, error) {
-	data, err := e.CanonicalBytes(r)
+func EventID(e EventIdentity, r rowmodel.CodecResolver) (string, error) {
+	data, err := CanonicalIdentity(e, r)
 	if err != nil {
 		return "", err
 	}
 	sum := sha256.Sum256(data)
-	return "v1:" + hex.EncodeToString(sum[:]), nil
+	return hex.EncodeToString(sum[:]), nil
 }
 
 type Envelope struct {
@@ -82,11 +77,11 @@ type Envelope struct {
 }
 
 // Projector wraps a schema-ordered writer opened with WithEnvelopeFields. Source
-// fields are appended first; EndRow projects every envelope before batching and
+// fields are appended first; EndEvent projects every envelope before batching and
 // before any outer audit writer appends legacy lineage. No last-row Meta is used
 // to reconstruct earlier envelopes. A projector is owned by one producer loop.
 type Projector struct {
-	arrowbatch.RowWriter
+	writer arrowbatch.RowWriter
 	codecs rowmodel.CodecResolver
 }
 
@@ -96,13 +91,13 @@ func NewProjector(w arrowbatch.RowWriter, r rowmodel.CodecResolver) *Projector {
 func WithEnvelopeFields(s rowmodel.Schema) (rowmodel.Schema, error) {
 	return rowmodel.WithEnvelopeFields(s)
 }
-func (w *Projector) EndRow(e Envelope, meta rowmodel.Meta) error {
+func (w *Projector) EndEvent(e Envelope, meta rowmodel.Meta) error {
 	// Validate before appending any SDK column. On error the source must abandon
 	// the pending row/writer; RowWriter does not provide rollback of source fields.
 	if (e.KeyNull && len(e.Key) > 0) || (e.PayloadNull && len(e.Payload) > 0) {
 		return ErrInvalidEnvelope
 	}
-	identity, err := e.Identity.CanonicalBytes(w.codecs)
+	identity, err := CanonicalIdentity(e.Identity, w.codecs)
 	if err != nil {
 		return err
 	}
@@ -118,26 +113,24 @@ func (w *Projector) EndRow(e Envelope, meta rowmodel.Meta) error {
 		timestamp = e.Timestamp.UTC().Format(time.RFC3339Nano)
 	}
 	sum := sha256.Sum256(identity)
-	w.String("v1:" + hex.EncodeToString(sum[:]))
-	w.Bytes(identity)
+	w.writer.String(hex.EncodeToString(sum[:]))
+	w.writer.Bytes(identity)
 	if e.Timestamp == nil {
-		w.Null()
+		w.writer.Null()
 	} else {
-		w.String(timestamp)
+		w.writer.String(timestamp)
 	}
-	w.Bytes(headers)
+	w.writer.Bytes(headers)
 	if e.KeyNull {
-		w.Null()
+		w.writer.Null()
 	} else {
-		w.Bytes(e.Key)
+		w.writer.Bytes(e.Key)
 	}
 	if e.PayloadNull {
-		w.Null()
+		w.writer.Null()
 	} else {
-		w.Bytes(e.Payload)
+		w.writer.Bytes(e.Payload)
 	}
-	meta.Domain = e.Identity.Domain
-	meta.Position = e.Identity.Position.Clone()
-	meta.Ordinal = e.Identity.Ordinal
-	return w.RowWriter.EndRow(meta)
+	meta.Stream = &rowmodel.StreamMeta{Identity: e.Identity.Clone()}
+	return w.writer.EndRow(meta)
 }

--- a/streamkit/envelope.go
+++ b/streamkit/envelope.go
@@ -1,0 +1,143 @@
+package streamkit
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+	"unicode/utf8"
+
+	"github.com/galaxy-io/filament/arrowbatch"
+	"github.com/galaxy-io/filament/rowmodel"
+)
+
+// EventIdentity is independent of runs, generations, attempts and consumer names.
+// Ordinal distinguishes changes sharing a transaction position without overflow
+// at uint32. Sources must supply stable event positions, including on replay.
+type EventIdentity struct {
+	Domain   rowmodel.DomainKey
+	Position rowmodel.Position
+	Ordinal  uint64
+}
+
+func (e EventIdentity) CanonicalBytes(r rowmodel.CodecResolver) ([]byte, error) {
+	if err := e.Domain.Validate(); err != nil {
+		return nil, err
+	}
+	if !utf8.ValidString(e.Domain.Incarnation) || !utf8.ValidString(e.Domain.Domain) || !utf8.ValidString(e.Position.Codec) {
+		return nil, ErrInvalidEnvelope
+	}
+	p, err := rowmodel.CanonicalPosition(r, e.Position)
+	if err != nil {
+		return nil, err
+	}
+	e.Position = p
+	return json.Marshal(struct {
+		Version  int
+		Identity EventIdentity
+	}{1, e})
+}
+
+// DecodeIdentity accepts only the canonical versioned SDK representation. It
+// rejects unknown versions, duplicate/unknown fields and ambiguous spellings.
+func DecodeIdentity(data []byte, r rowmodel.CodecResolver) (EventIdentity, error) {
+	var wire struct {
+		Version  int
+		Identity EventIdentity
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return EventIdentity{}, err
+	}
+	if wire.Version != 1 {
+		return EventIdentity{}, ErrInvalidEnvelope
+	}
+	canonical, err := wire.Identity.CanonicalBytes(r)
+	if err != nil {
+		return EventIdentity{}, err
+	}
+	if !bytes.Equal(data, canonical) {
+		return EventIdentity{}, ErrInvalidEnvelope
+	}
+	return wire.Identity, nil
+}
+
+func (e EventIdentity) ID(r rowmodel.CodecResolver) (string, error) {
+	data, err := e.CanonicalBytes(r)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "v1:" + hex.EncodeToString(sum[:]), nil
+}
+
+type Envelope struct {
+	Identity    EventIdentity
+	Timestamp   *time.Time
+	Headers     []Header
+	Key         []byte
+	KeyNull     bool
+	Payload     []byte
+	PayloadNull bool
+}
+
+// Projector wraps a schema-ordered writer opened with WithEnvelopeFields. Source
+// fields are appended first; EndRow projects every envelope before batching and
+// before any outer audit writer appends legacy lineage. No last-row Meta is used
+// to reconstruct earlier envelopes. A projector is owned by one producer loop.
+type Projector struct {
+	arrowbatch.RowWriter
+	codecs rowmodel.CodecResolver
+}
+
+func NewProjector(w arrowbatch.RowWriter, r rowmodel.CodecResolver) *Projector {
+	return &Projector{w, r}
+}
+func WithEnvelopeFields(s rowmodel.Schema) (rowmodel.Schema, error) {
+	return rowmodel.WithEnvelopeFields(s)
+}
+func (w *Projector) EndRow(e Envelope, meta rowmodel.Meta) error {
+	// Validate before appending any SDK column. On error the source must abandon
+	// the pending row/writer; RowWriter does not provide rollback of source fields.
+	if (e.KeyNull && len(e.Key) > 0) || (e.PayloadNull && len(e.Payload) > 0) {
+		return ErrInvalidEnvelope
+	}
+	identity, err := e.Identity.CanonicalBytes(w.codecs)
+	if err != nil {
+		return err
+	}
+	headers, err := EncodeHeaders(e.Headers)
+	if err != nil {
+		return err
+	}
+	var timestamp string
+	if e.Timestamp != nil {
+		if e.Timestamp.UTC().Year() < 0 || e.Timestamp.UTC().Year() > 9999 {
+			return ErrInvalidEnvelope
+		}
+		timestamp = e.Timestamp.UTC().Format(time.RFC3339Nano)
+	}
+	sum := sha256.Sum256(identity)
+	w.String("v1:" + hex.EncodeToString(sum[:]))
+	w.Bytes(identity)
+	if e.Timestamp == nil {
+		w.Null()
+	} else {
+		w.String(timestamp)
+	}
+	w.Bytes(headers)
+	if e.KeyNull {
+		w.Null()
+	} else {
+		w.Bytes(e.Key)
+	}
+	if e.PayloadNull {
+		w.Null()
+	} else {
+		w.Bytes(e.Payload)
+	}
+	meta.Domain = e.Identity.Domain
+	meta.Position = e.Identity.Position.Clone()
+	meta.Ordinal = e.Identity.Ordinal
+	return w.RowWriter.EndRow(meta)
+}

--- a/streamkit/headers.go
+++ b/streamkit/headers.go
@@ -9,6 +9,9 @@ import (
 
 var ErrInvalidEnvelope = errors.New("streamkit: invalid envelope")
 
+// HeaderEncodingVersion identifies the ordered binary header encoding.
+const HeaderEncodingVersion byte = 1
+
 // Header preserves provider order, duplicate names and arbitrary binary values.
 // Null is authoritative; a null header with nonempty bytes is invalid.
 type Header struct {
@@ -21,7 +24,7 @@ type Header struct {
 // u32-length key, null byte, u32-length value. Integers are big endian. Nil and
 // empty lists differ; null values differ from non-null empty bytes.
 func EncodeHeaders(headers []Header) ([]byte, error) {
-	out := []byte{1, 0}
+	out := []byte{HeaderEncodingVersion, 0}
 	if headers == nil {
 		return out, nil
 	}
@@ -50,7 +53,7 @@ func EncodeHeaders(headers []Header) ([]byte, error) {
 	return out, nil
 }
 func DecodeHeaders(data []byte) ([]Header, error) {
-	if len(data) < 2 || data[0] != 1 || data[1] > 1 {
+	if len(data) < 2 || data[0] != HeaderEncodingVersion || data[1] > 1 {
 		return nil, ErrInvalidEnvelope
 	}
 	if data[1] == 0 {

--- a/streamkit/headers.go
+++ b/streamkit/headers.go
@@ -5,8 +5,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 )
 
+// ErrInvalidEnvelope reports malformed or contradictory envelope data.
 var ErrInvalidEnvelope = errors.New("streamkit: invalid envelope")
 
 // HeaderEncodingVersion identifies the ordered binary header encoding.
@@ -29,29 +31,37 @@ func EncodeHeaders(headers []Header) ([]byte, error) {
 		return out, nil
 	}
 	out[1] = 1
-	if uint64(len(headers)) > uint64(^uint32(0)) {
+	count, err := headerLength(len(headers))
+	if err != nil {
 		return nil, ErrInvalidEnvelope
 	}
-	out = binary.BigEndian.AppendUint32(out, uint32(len(headers)))
+	out = binary.BigEndian.AppendUint32(out, count)
 	for _, h := range headers {
 		if h.Null && len(h.Value) > 0 {
 			return nil, ErrInvalidEnvelope
 		}
-		if uint64(len(h.Key)) > uint64(^uint32(0)) || uint64(len(h.Value)) > uint64(^uint32(0)) {
+		keySize, err := headerLength(len(h.Key))
+		if err != nil {
+			return nil, err
+		}
+		valueSize, err := headerLength(len(h.Value))
+		if err != nil {
 			return nil, ErrInvalidEnvelope
 		}
-		out = binary.BigEndian.AppendUint32(out, uint32(len(h.Key)))
+		out = binary.BigEndian.AppendUint32(out, keySize)
 		out = append(out, h.Key...)
 		flag := byte(0)
 		if h.Null {
 			flag = 1
 		}
 		out = append(out, flag)
-		out = binary.BigEndian.AppendUint32(out, uint32(len(h.Value)))
+		out = binary.BigEndian.AppendUint32(out, valueSize)
 		out = append(out, h.Value...)
 	}
 	return out, nil
 }
+
+// DecodeHeaders validates and decodes headers into independently owned values.
 func DecodeHeaders(data []byte) ([]Header, error) {
 	if len(data) < 2 || data[0] != HeaderEncodingVersion || data[1] > 1 {
 		return nil, ErrInvalidEnvelope
@@ -64,12 +74,12 @@ func DecodeHeaders(data []byte) ([]Header, error) {
 	}
 	r := bytes.NewReader(data[2:])
 	var count uint32
-	if binary.Read(r, binary.BigEndian, &count) != nil || uint64(count) > uint64(r.Len()/9) {
+	if binary.Read(r, binary.BigEndian, &count) != nil || int64(count) > int64(r.Len()/9) {
 		return nil, ErrInvalidEnvelope
 	}
 	readBytes := func() ([]byte, error) {
 		var n uint32
-		if binary.Read(r, binary.BigEndian, &n) != nil || uint64(n) > uint64(r.Len()) {
+		if binary.Read(r, binary.BigEndian, &n) != nil || int64(n) > int64(r.Len()) {
 			return nil, ErrInvalidEnvelope
 		}
 		b := make([]byte, int(n))
@@ -99,4 +109,13 @@ func DecodeHeaders(data []byte) ([]Header, error) {
 		return nil, ErrInvalidEnvelope
 	}
 	return out, nil
+}
+
+// headerLength checks the wire limit before narrowing a platform-sized length.
+func headerLength(n int) (uint32, error) {
+	size := int64(n)
+	if size < 0 || size > math.MaxUint32 {
+		return 0, ErrInvalidEnvelope
+	}
+	return uint32(size), nil
 }

--- a/streamkit/headers.go
+++ b/streamkit/headers.go
@@ -1,0 +1,99 @@
+package streamkit
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+var ErrInvalidEnvelope = errors.New("streamkit: invalid envelope")
+
+// Header preserves provider order, duplicate names and arbitrary binary values.
+// Null is authoritative; a null header with nonempty bytes is invalid.
+type Header struct {
+	Key   string
+	Value []byte
+	Null  bool
+}
+
+// EncodeHeaders v1: version byte, presence byte, u32 count; each entry is a
+// u32-length key, null byte, u32-length value. Integers are big endian. Nil and
+// empty lists differ; null values differ from non-null empty bytes.
+func EncodeHeaders(headers []Header) ([]byte, error) {
+	out := []byte{1, 0}
+	if headers == nil {
+		return out, nil
+	}
+	out[1] = 1
+	if uint64(len(headers)) > uint64(^uint32(0)) {
+		return nil, ErrInvalidEnvelope
+	}
+	out = binary.BigEndian.AppendUint32(out, uint32(len(headers)))
+	for _, h := range headers {
+		if h.Null && len(h.Value) > 0 {
+			return nil, ErrInvalidEnvelope
+		}
+		if uint64(len(h.Key)) > uint64(^uint32(0)) || uint64(len(h.Value)) > uint64(^uint32(0)) {
+			return nil, ErrInvalidEnvelope
+		}
+		out = binary.BigEndian.AppendUint32(out, uint32(len(h.Key)))
+		out = append(out, h.Key...)
+		flag := byte(0)
+		if h.Null {
+			flag = 1
+		}
+		out = append(out, flag)
+		out = binary.BigEndian.AppendUint32(out, uint32(len(h.Value)))
+		out = append(out, h.Value...)
+	}
+	return out, nil
+}
+func DecodeHeaders(data []byte) ([]Header, error) {
+	if len(data) < 2 || data[0] != 1 || data[1] > 1 {
+		return nil, ErrInvalidEnvelope
+	}
+	if data[1] == 0 {
+		if len(data) != 2 {
+			return nil, ErrInvalidEnvelope
+		}
+		return nil, nil
+	}
+	r := bytes.NewReader(data[2:])
+	var count uint32
+	if binary.Read(r, binary.BigEndian, &count) != nil || uint64(count) > uint64(r.Len()/9) {
+		return nil, ErrInvalidEnvelope
+	}
+	readBytes := func() ([]byte, error) {
+		var n uint32
+		if binary.Read(r, binary.BigEndian, &n) != nil || uint64(n) > uint64(r.Len()) {
+			return nil, ErrInvalidEnvelope
+		}
+		b := make([]byte, int(n))
+		_, err := io.ReadFull(r, b)
+		return b, err
+	}
+	out := make([]Header, 0, int(count))
+	for range count {
+		key, err := readBytes()
+		if err != nil {
+			return nil, ErrInvalidEnvelope
+		}
+		flag, err := r.ReadByte()
+		if err != nil || flag > 1 {
+			return nil, ErrInvalidEnvelope
+		}
+		value, err := readBytes()
+		if err != nil || (flag == 1 && len(value) > 0) {
+			return nil, ErrInvalidEnvelope
+		}
+		if flag == 1 {
+			value = nil
+		}
+		out = append(out, Header{string(key), value, flag == 1})
+	}
+	if r.Len() != 0 {
+		return nil, ErrInvalidEnvelope
+	}
+	return out, nil
+}


### PR DESCRIPTION
Adds foundational stream contracts and a public envelope SDK while preserving bounded execution. Continuous execution remains unwired/no-op

  - Defines source sessions, sink epoch lifecycles, attempt ownership, capabilities, and optional runtime-store contracts.
  - Separates stream metadata from bounded row metadata through StreamMeta and shared event identity.
  - Adds domain positions, controls, exclusive position/claim coverage, canonicalization, and explicit epoch binding.
  - Projects event identity, timestamps, ordered repeated headers, keys, and payloads into reserved columns before batching, preserving null-versus-empty values.
  
  
NATs Example: 

Source Event

```
Account:          demo-account
  Stream:           ORDERS
  Stream created:   2026-09-01T00:00:00Z
  Subject:          orders.created
  Stream sequence:  1042
  Consumer:         filament-orders
  Consumer sequence: 87
  Delivery count:   1
  Timestamp:        2026-09-11T15:30:00.123456789Z

  Headers:
    Content-Type: application/json
    X-Tag: checkout
    X-Tag: priority

  Payload:
    {"order_id":"ord-42","amount":12900,"currency":"USD"}
```

Would create the following equivalent in engine using these types

```go
// Connector defined codec registered in streamkit
const (
      sequenceCodec        = "example.jetstream-sequence"
      sequenceCodecVersion = 1
  )

domain := rowmodel.DomainKey{
    Incarnation: "demo-account/ORDERS/2026-09-01T00:00:00Z",
    Domain:      "stream",
}

position := rowmodel.Position{
    Codec:   sequenceCodec,
    Version: sequenceCodecVersion,
    Value: []byte("1042"),
}

identity := rowmodel.EventIdentity{
    Domain:   domain,
    Position: position,
    Ordinal:  0, // This message produces one event row.
}

codecs := &streamkit.Registry{}
err := codecs.Register(
    sequenceCodec,
    sequenceCodecVersion,
    streamkit.Uint64Codec{},
)

timestamp := time.Date(
    2026, time.September, 11,
    15, 30, 0, 123456789,
    time.UTC,
)

envelope := streamkit.Envelope{
    Identity:  identity,
    Timestamp: &timestamp,

    Headers: []streamkit.Header{
        {Key: "Content-Type", Value: []byte("application/json")},
        {Key: "X-Tag", Value: []byte("checkout")},
        {Key: "X-Tag", Value: []byte("priority")},
    },

    Key:     nil,
    KeyNull: true,

    Payload: []byte(
        `{"order_id":"ord-42","amount":12900,"currency":"USD"}`,
    ),
    PayloadNull: false,
  }
  ```


